### PR TITLE
docs: use safe plugin placeholder targets

### DIFF
--- a/plugins/dns_enum/metadata.json
+++ b/plugins/dns_enum/metadata.json
@@ -27,7 +27,7 @@
       "label": "Domain",
       "type": "string",
       "required": true,
-      "placeholder": "secuscan.in",
+      "placeholder": "example.com",
       "help": "Target domain for DNS enumeration."
     },
     {
@@ -88,5 +88,5 @@
     ]
   },
   "docker_image": "darkoperator/dnsrecon:latest",
-  "checksum": "bee6dad0b06890b0a9df92a679abcc9bf7032e3651b504f4f96b13ec9114331f"
+  "checksum": "1bb635fe9948ff4e3c2d8582c9060a4b0cd50a8f3a46083a2a7b4417f73cf71e"
 }

--- a/plugins/http_inspector/metadata.json
+++ b/plugins/http_inspector/metadata.json
@@ -29,7 +29,7 @@
       "label": "Target URL",
       "type": "string",
       "required": true,
-      "placeholder": "https://secuscan.in",
+      "placeholder": "https://example.com",
       "validation": {
         "pattern": "^https?://",
         "message": "Must be a valid HTTP(S) URL"
@@ -92,5 +92,5 @@
     "system_packages": []
   },
   "docker_image": "curlimages/curl",
-  "checksum": "2a6bbe035dc8aedfdc62fab2ca7ee7d229041aef8d0600f1bcf794cc46936a82"
+  "checksum": "fa4ca833b6ee0106d47c450415fb103f1e0dde661d2e434ca4b2356a1acfc8d6"
 }

--- a/plugins/subfinder/metadata.json
+++ b/plugins/subfinder/metadata.json
@@ -27,7 +27,7 @@
       "label": "Root Domain",
       "type": "string",
       "required": true,
-      "placeholder": "secuscan.in"
+      "placeholder": "example.com"
     }
   ],
   "presets": {
@@ -52,5 +52,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "5a6dbd714db89c65ef888a93580e19db4798ca1013435eba2e1a781b8f276f6c"
+  "checksum": "fb52ad0e71440069d87bdce652d0d686997ebb31c3bb9c0c6ff51b0a08db2001"
 }

--- a/plugins/tls_inspector/metadata.json
+++ b/plugins/tls_inspector/metadata.json
@@ -26,7 +26,7 @@
       "label": "Target Host",
       "type": "string",
       "required": true,
-      "placeholder": "secuscan.in",
+      "placeholder": "example.com",
       "validation": {
         "pattern": "^[a-zA-Z0-9.-]+$",
         "message": "Must be valid hostname or IP"
@@ -47,7 +47,7 @@
       "label": "SNI Hostname",
       "type": "string",
       "required": false,
-      "placeholder": "secuscan.in",
+      "placeholder": "example.com",
       "help": "Server Name Indication for virtual hosting (usually same as host)"
     },
     {
@@ -137,5 +137,5 @@
     "system_packages": []
   },
   "docker_image": "alpine:latest",
-  "checksum": "8b2991841f02a5fb5f8531336d6f02ab4a0a712f2e114a5b0ce6b403b7123aa6"
+  "checksum": "6e82c01aec4fd69e8f2d4bc8e339bfab408abacc50d2e83db0d6977a6f9bd00a"
 }

--- a/plugins/whois_lookup/metadata.json
+++ b/plugins/whois_lookup/metadata.json
@@ -26,7 +26,7 @@
       "label": "Domain/IP",
       "type": "string",
       "required": true,
-      "placeholder": "secuscan.in",
+      "placeholder": "example.com",
       "help": "Target domain name or IP address."
     }
   ],
@@ -58,5 +58,5 @@
     "system_packages": []
   },
   "docker_image": "alpine:latest",
-  "checksum": "b4df81e9bd8d3aa423a73d5f412a6845d8076a57fc37b97c584d9c523dd371dc"
+  "checksum": "173fdb4a9f941fbbf0bda3d2511a31036a614aabc901990bc2f16bc7e7b8b0fc"
 }


### PR DESCRIPTION
## Summary
- replace live-looking plugin placeholder targets with reserved example domains
- update the affected plugin metadata checksums after the placeholder changes

Fixes #11

## Verification
- `git diff --check`
- validated the five edited metadata files with PowerShell `ConvertFrom-Json`
- verified the five edited plugin metadata checksums with a local Python checksum script

Note: `python -m pytest testing/backend/unit/test_plugin_integrity.py -q` was not run because `pytest` is not installed in this local Python environment.

## Summary by Sourcery

Update plugin metadata placeholders to use reserved example domains and refresh associated checksums.

Enhancements:
- Replace live-looking plugin target placeholders with reserved example domains across affected plugin metadata files.
- Recalculate and update checksums for the modified plugin metadata files to maintain integrity validations.