### PR TITLE
fix: refresh plugin metadata checksums

### DIFF
--- a/plugins/dns_enum/metadata.json
+++ b/plugins/dns_enum/metadata.json
@@ -88,5 +88,5 @@
     ]
   },
   "docker_image": "darkoperator/dnsrecon:latest",
-  "checksum": "1bb635fe9948ff4e3c2d8582c9060a4b0cd50a8f3a46083a2a7b4417f73cf71e"
+  "checksum": "50b01be30942c2896ad4a26b45ad3676d523f3ef46e02891a9d66b2aeb593666"
 }

--- a/plugins/dns_enum/metadata.json
+++ b/plugins/dns_enum/metadata.json
@@ -27,7 +27,7 @@
       "label": "Domain",
       "type": "string",
       "required": true,
-      "placeholder": "secuscan.in",
+      "placeholder": "example.com",
       "help": "Target domain for DNS enumeration."
     },
     {
@@ -88,5 +88,5 @@
     ]
   },
   "docker_image": "darkoperator/dnsrecon:latest",
-  "checksum": "bee6dad0b06890b0a9df92a679abcc9bf7032e3651b504f4f96b13ec9114331f"
+  "checksum": "1bb635fe9948ff4e3c2d8582c9060a4b0cd50a8f3a46083a2a7b4417f73cf71e"
 }

--- a/plugins/http_inspector/metadata.json
+++ b/plugins/http_inspector/metadata.json
@@ -92,5 +92,5 @@
     "system_packages": []
   },
   "docker_image": "curlimages/curl",
-  "checksum": "fa4ca833b6ee0106d47c450415fb103f1e0dde661d2e434ca4b2356a1acfc8d6"
+  "checksum": "435436b8dbde27b30f545c3f5701089db880794a8a3f3a47e08cf2e6dbffa447"
 }

--- a/plugins/http_inspector/metadata.json
+++ b/plugins/http_inspector/metadata.json
@@ -29,7 +29,7 @@
       "label": "Target URL",
       "type": "string",
       "required": true,
-      "placeholder": "https://secuscan.in",
+      "placeholder": "https://example.com",
       "validation": {
         "pattern": "^https?://",
         "message": "Must be a valid HTTP(S) URL"
@@ -92,5 +92,5 @@
     "system_packages": []
   },
   "docker_image": "curlimages/curl",
-  "checksum": "2a6bbe035dc8aedfdc62fab2ca7ee7d229041aef8d0600f1bcf794cc46936a82"
+  "checksum": "fa4ca833b6ee0106d47c450415fb103f1e0dde661d2e434ca4b2356a1acfc8d6"
 }

--- a/plugins/subfinder/metadata.json
+++ b/plugins/subfinder/metadata.json
@@ -52,5 +52,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "fb52ad0e71440069d87bdce652d0d686997ebb31c3bb9c0c6ff51b0a08db2001"
+  "checksum": "a1cb24265eea66c6059544857e22a5a5cd6c4fc0c1049b329f1b1f970d516312"
 }

--- a/plugins/subfinder/metadata.json
+++ b/plugins/subfinder/metadata.json
@@ -27,7 +27,7 @@
       "label": "Root Domain",
       "type": "string",
       "required": true,
-      "placeholder": "secuscan.in"
+      "placeholder": "example.com"
     }
   ],
   "presets": {
@@ -52,5 +52,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "5a6dbd714db89c65ef888a93580e19db4798ca1013435eba2e1a781b8f276f6c"
+  "checksum": "fb52ad0e71440069d87bdce652d0d686997ebb31c3bb9c0c6ff51b0a08db2001"
 }

--- a/plugins/tls_inspector/metadata.json
+++ b/plugins/tls_inspector/metadata.json
@@ -137,5 +137,5 @@
     "system_packages": []
   },
   "docker_image": "alpine:latest",
-  "checksum": "6e82c01aec4fd69e8f2d4bc8e339bfab408abacc50d2e83db0d6977a6f9bd00a"
+  "checksum": "fac3b48892e86d2727495b46df5cf0b6ff6bcc72f1c40f1d218ef9afc79e1615"
 }

--- a/plugins/tls_inspector/metadata.json
+++ b/plugins/tls_inspector/metadata.json
@@ -26,7 +26,7 @@
       "label": "Target Host",
       "type": "string",
       "required": true,
-      "placeholder": "secuscan.in",
+      "placeholder": "example.com",
       "validation": {
         "pattern": "^[a-zA-Z0-9.-]+$",
         "message": "Must be valid hostname or IP"
@@ -47,7 +47,7 @@
       "label": "SNI Hostname",
       "type": "string",
       "required": false,
-      "placeholder": "secuscan.in",
+      "placeholder": "example.com",
       "help": "Server Name Indication for virtual hosting (usually same as host)"
     },
     {
@@ -137,5 +137,5 @@
     "system_packages": []
   },
   "docker_image": "alpine:latest",
-  "checksum": "8b2991841f02a5fb5f8531336d6f02ab4a0a712f2e114a5b0ce6b403b7123aa6"
+  "checksum": "6e82c01aec4fd69e8f2d4bc8e339bfab408abacc50d2e83db0d6977a6f9bd00a"
 }

--- a/plugins/whois_lookup/metadata.json
+++ b/plugins/whois_lookup/metadata.json
@@ -58,5 +58,5 @@
     "system_packages": []
   },
   "docker_image": "alpine:latest",
-  "checksum": "173fdb4a9f941fbbf0bda3d2511a31036a614aabc901990bc2f16bc7e7b8b0fc"
+  "checksum": "ecda30e7a979e1a0200d6f58c6c01fe6bae7dbe985cc0f47c5047165c46f3a53"
 }

--- a/plugins/whois_lookup/metadata.json
+++ b/plugins/whois_lookup/metadata.json
@@ -26,7 +26,7 @@
       "label": "Domain/IP",
       "type": "string",
       "required": true,
-      "placeholder": "secuscan.in",
+      "placeholder": "example.com",
       "help": "Target domain name or IP address."
     }
   ],
@@ -58,5 +58,5 @@
     "system_packages": []
   },
   "docker_image": "alpine:latest",
-  "checksum": "b4df81e9bd8d3aa423a73d5f412a6845d8076a57fc37b97c584d9c523dd371dc"
+  "checksum": "173fdb4a9f941fbbf0bda3d2511a31036a614aabc901990bc2f16bc7e7b8b0fc"
 }


### PR DESCRIPTION
## Summary

- Updates the five safe placeholder plugin metadata files from #12 with CI-compatible plugin checksums.
- Checksums were recomputed against Git-normalized parser bytes so they match the repository plugin digest logic used on Linux CI.

## Verification

```bash
# Custom checksum verification using backend.secuscan.plugins.PluginManager-compatible logic
# and parser bytes from git blobs:
# dns_enum ok
# http_inspector ok
# subfinder ok
# tls_inspector ok
# whois_lookup ok

git diff --check
# passed; Windows only reported local LF/CRLF conversion warnings
```

Follow-up to #12 after maintainer feedback about checksum mismatches.