### PR TITLE
feat(validation): standardize plugin field validation metadata

### DIFF
--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -66,7 +66,12 @@ class Settings(BaseSettings):
     sandbox_timeout: int = 600  # seconds
     sandbox_cpu_quota: float = 0.5
     sandbox_memory_mb: int = 512
-    
+
+    # Task-start payload limits (tunable via env vars)
+    task_start_max_body_bytes: int = 64_000       # 64 KB total JSON body
+    task_start_max_field_length: int = 1_000      # max chars per string input value
+    task_start_max_array_length: int = 50         # max items in any list/multiselect input
+
     # Logging
     log_level: str = "INFO"
     log_file: str = str(PROJECT_ROOT / "logs" / "secuscan.log")

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -2,7 +2,7 @@
 API routes for SecuScan backend
 """
 
-from fastapi import APIRouter, HTTPException, BackgroundTasks, Response
+from fastapi import APIRouter, HTTPException, BackgroundTasks, Response, Request
 from typing import Any, Optional, List, Dict, Callable
 import json
 import logging
@@ -71,7 +71,7 @@ from .database import get_db
 from .plugins import get_plugin_manager, init_plugins
 from .executor import executor
 from .ratelimit import rate_limiter, concurrent_limiter
-from .validation import validate_target
+from .validation import validate_target, validate_task_start_payload
 from .reporting import reporting
 from .vault import VaultCrypto
 from .workflows import scheduler
@@ -145,11 +145,18 @@ async def get_all_presets():
 @router.post("/task/start")
 async def start_task(
     request: TaskCreateRequest,
-    background_tasks: BackgroundTasks
+    background_tasks: BackgroundTasks,
+    raw_request: Request,
 ):
     """
-    Start a new scan task
+    Start a new scan task.
     """
+    # ── Payload size / field-length guard ─────────────────────────────────
+    raw_body = await raw_request.body()
+    ok, status_code, error_msg = validate_task_start_payload(raw_body, request.inputs)
+    if not ok:
+        raise HTTPException(status_code=status_code, detail=error_msg)
+
     # Validate consent
     if settings.require_consent and not request.consent_granted:
         logger.warning(f"Task start failed: Consent not granted. Request: {request}")

--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -4,7 +4,7 @@ Input validation and security checks
 
 import re
 import ipaddress
-from typing import Tuple
+from typing import Any, Dict, Tuple
 from fnmatch import fnmatch
 
 from .config import settings
@@ -225,3 +225,82 @@ def match_pattern(value: str, pattern: str) -> bool:
         True if value matches pattern
     """
     return fnmatch(value, pattern)
+
+
+# ---------------------------------------------------------------------------
+# Task-start payload size/length validation
+# ---------------------------------------------------------------------------
+
+def validate_task_start_payload(raw_body: bytes, inputs: Dict[str, Any]) -> Tuple[bool, int, str]:
+    """
+    Enforce size and field-length limits on POST /task/start payloads.
+
+    Checks are run in order:
+      1. Total body size  → HTTP 413
+      2. inputs dict type → HTTP 400
+      3. Per-field string length and array length → HTTP 400
+
+    Error messages never echo back input values to avoid leaking sensitive
+    or oversized data into logs/responses.
+
+    Args:
+        raw_body: Raw request bytes (for total-size check).
+        inputs:   The parsed ``inputs`` dict from the request body.
+
+    Returns:
+        (ok, status_code, error_message)
+        ok is True and status_code is 0 when all checks pass.
+    """
+    # 1. Total body size
+    if len(raw_body) > settings.task_start_max_body_bytes:
+        return (
+            False,
+            413,
+            f"Request body exceeds the maximum allowed size of "
+            f"{settings.task_start_max_body_bytes} bytes.",
+        )
+
+    # 2. inputs must be a dict
+    if not isinstance(inputs, dict):
+        return False, 400, "'inputs' must be a JSON object."
+
+    # 3. Per-field checks
+    for key, value in inputs.items():
+        ok, status, msg = _check_field(key, value)
+        if not ok:
+            return ok, status, msg
+
+    return True, 0, ""
+
+
+def _check_field(key: str, value: Any) -> Tuple[bool, int, str]:
+    """Check a single input field value (string or list)."""
+    if isinstance(value, str):
+        if len(value) > settings.task_start_max_field_length:
+            # Do NOT include the value itself — it may be huge or sensitive.
+            return (
+                False,
+                400,
+                f"Input field '{key}' exceeds the maximum allowed length of "
+                f"{settings.task_start_max_field_length} characters.",
+            )
+
+    elif isinstance(value, list):
+        if len(value) > settings.task_start_max_array_length:
+            return (
+                False,
+                400,
+                f"Input field '{key}' contains too many items "
+                f"(max {settings.task_start_max_array_length}).",
+            )
+        for idx, item in enumerate(value):
+            if isinstance(item, str) and len(item) > settings.task_start_max_field_length:
+                return (
+                    False,
+                    400,
+                    f"Item at index {idx} in input field '{key}' exceeds the "
+                    f"maximum allowed length of "
+                    f"{settings.task_start_max_field_length} characters.",
+                )
+
+    return True, 0, ""

--- a/docs/plugin-validation.md
+++ b/docs/plugin-validation.md
@@ -1,0 +1,153 @@
+# Plugin Field Validation
+
+This document describes the validation contract for plugin field metadata in SecuScan.
+
+Plugin authors define fields in their plugin's schema. Each field can have an optional `validation` object that controls how the frontend form validates user input before a scan is started.
+
+---
+
+## Supported validation keys
+
+| Key               | Type     | Description                                                  |
+|-------------------|----------|--------------------------------------------------------------|
+| `pattern`         | `string` | A regex string the trimmed value must match                  |
+| `message`         | `string` | Custom error message shown when validation fails             |
+| `min`             | `number` | Minimum value (integer fields only)                          |
+| `max`             | `number` | Maximum value (integer fields only)                          |
+| `validation_type` | `string` | Named preset — see table below. Takes priority over `pattern`|
+
+---
+
+## Named `validation_type` presets
+
+Use these for common cases instead of writing your own regex:
+
+| `validation_type` | Accepts                                  | Example               |
+|-------------------|------------------------------------------|-----------------------|
+| `url`             | HTTP or HTTPS URLs                       | `https://example.com` |
+| `hostname`        | Hostnames with optional subdomains       | `sub.example.com`     |
+| `domain`          | Domain names without a scheme            | `example.com`         |
+| `ipv4`            | IPv4 addresses (0–255 per octet)         | `192.168.1.1`         |
+| `port`            | Integer port numbers (1–65535)           | `8080`                |
+| `cidr`            | IPv4 CIDR notation                       | `192.168.1.0/24`      |
+
+If both `validation_type` and `pattern` are set, `validation_type` takes priority.
+
+---
+
+## Examples
+
+### URL field
+
+```json
+{
+  "id": "target_url",
+  "label": "Target URL",
+  "type": "string",
+  "required": true,
+  "placeholder": "https://example.com",
+  "help": "Full URL of the target including scheme.",
+  "validation": {
+    "validation_type": "url",
+    "message": "Enter a valid URL starting with http:// or https://"
+  }
+}
+```
+
+### Hostname field
+
+```json
+{
+  "id": "target_host",
+  "label": "Target Hostname",
+  "type": "string",
+  "required": true,
+  "placeholder": "example.com",
+  "help": "Hostname or subdomain to scan. Do not include http://.",
+  "validation": {
+    "validation_type": "hostname"
+  }
+}
+```
+
+### IPv4 field
+
+```json
+{
+  "id": "target_ip",
+  "label": "Target IP",
+  "type": "string",
+  "required": true,
+  "placeholder": "192.168.1.1",
+  "validation": {
+    "validation_type": "ipv4",
+    "message": "Enter a valid IPv4 address"
+  }
+}
+```
+
+### Port field (integer with range)
+
+```json
+{
+  "id": "port",
+  "label": "Port",
+  "type": "integer",
+  "required": false,
+  "placeholder": "80",
+  "validation": {
+    "min": 1,
+    "max": 65535,
+    "message": "Port must be between 1 and 65535"
+  }
+}
+```
+
+### CIDR block field
+
+```json
+{
+  "id": "subnet",
+  "label": "Target Subnet",
+  "type": "string",
+  "required": false,
+  "placeholder": "192.168.1.0/24",
+  "validation": {
+    "validation_type": "cidr"
+  }
+}
+```
+
+### Custom regex (backwards compatible)
+
+Existing plugins using a raw `pattern` continue to work without changes:
+
+```json
+{
+  "id": "api_key",
+  "label": "API Key",
+  "type": "string",
+  "required": true,
+  "validation": {
+    "pattern": "^[A-Za-z0-9]{32,64}$",
+    "message": "API key must be 32–64 alphanumeric characters"
+  }
+}
+```
+
+---
+
+## Frontend behaviour
+
+- **Required fields**: show an error if the value is empty, null, or whitespace.
+- **Pattern / validation_type**: checked on non-empty string values only — an empty optional field is never flagged.
+- **Integer min/max**: checked when the field has type `integer` and a value has been entered.
+- **aria-invalid**: set to `true` on the input element when a validation error is present.
+- **Inline error message**: shown directly below the field with `role="alert"`.
+- **Scan button**: disabled while any field has a validation error.
+
+---
+
+## Backwards compatibility
+
+Plugins that already define `validation.pattern` (without `validation_type`) continue to work exactly as before. No migration is required.

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -15,7 +15,7 @@ import {
   UserShield02Icon,
 } from '@hugeicons/core-free-icons'
 import { getDashboardSummary, getReports, API_BASE } from '../api'
-import { formatDateLong } from '../utils/date'
+import { formatDateLong, isWithinDateRange, type DateRange } from '../utils/date'
 
 type Report = {
   id: string
@@ -28,6 +28,8 @@ type Report = {
   assets: number
   pages: number
 }
+
+type ReportStatus = 'all' | 'ready' | 'generating' | 'failed'
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -66,6 +68,8 @@ export default function Reports() {
   const [reports, setReports] = useState<Report[]>([])
   const [summary, setSummary] = useState<any>({ total_findings: 0, total_assets: 0, critical_findings: 0, high_findings: 0, total_attack_surface: 0 })
   const [selectedType, setSelectedType] = useState('all')
+  const [selectedStatus, setSelectedStatus] = useState<ReportStatus>('all')
+  const [selectedDateRange, setSelectedDateRange] = useState<DateRange>('all')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -89,7 +93,11 @@ export default function Reports() {
     fetchReports()
   }, [])
 
-  const filteredReports = reports.filter((report) => selectedType === 'all' || report.type === selectedType)
+  const filteredReports = reports.filter((report) =>
+    (selectedType === 'all' || report.type === selectedType) &&
+    (selectedStatus === 'all' || report.status === selectedStatus) &&
+    isWithinDateRange(report.generated_at, selectedDateRange)
+  )
 
   return (
     <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
@@ -173,6 +181,8 @@ export default function Reports() {
             {/* Filtration Sidebar */}
             <aside className="xl:col-span-1 space-y-12">
               <section className="bg-charcoal border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-8">
+
+                {/* Type Filter */}
                 <div className="space-y-4">
                   <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Classification_Isolation</label>
                   <div className="grid grid-cols-1 gap-2">
@@ -188,6 +198,60 @@ export default function Reports() {
                       >
                         {t} BRIEFINGS
                         {selectedType === t && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Status Filter */}
+                <div className="space-y-4">
+                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Status_Filter</label>
+                  <div className="grid grid-cols-1 gap-2">
+                    {([
+                      { value: 'all',        label: 'All Statuses' },
+                      { value: 'ready',      label: 'Ready' },
+                      { value: 'generating', label: 'Generating' },
+                      { value: 'failed',     label: 'Failed' },
+                    ] as const).map(({ value, label }) => (
+                      <button
+                        key={value}
+                        onClick={() => setSelectedStatus(value)}
+                        aria-label={`status ${label}`}
+                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
+                          selectedStatus === value
+                            ? 'bg-rag-amber border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
+                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
+                        }`}
+                      >
+                        {label}
+                        {selectedStatus === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Date Range Filter */}
+                <div className="space-y-4">
+                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Date_Range</label>
+                  <div className="grid grid-cols-1 gap-2">
+                    {([
+                      { value: 'all', label: 'All Time' },
+                      { value: '24h', label: 'Last 24 Hours' },
+                      { value: '7d',  label: 'Last 7 Days' },
+                      { value: '30d', label: 'Last 30 Days' },
+                    ] as const).map(({ value, label }) => (
+                      <button
+                        key={value}
+                        onClick={() => setSelectedDateRange(value)}
+                        aria-label={`date ${label}`}
+                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
+                          selectedDateRange === value
+                            ? 'bg-rag-blue border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
+                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
+                        }`}
+                      >
+                        {label}
+                        {selectedDateRange === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
                       </button>
                     ))}
                   </div>
@@ -315,7 +379,7 @@ export default function Reports() {
                       <ReportIcon icon={Archive02Icon} size={120} className="text-silver/5" />
                       <div className="space-y-2">
                         <p className="text-xl font-black text-silver/20 uppercase tracking-[0.4em] italic">Archive Isolated</p>
-                        <p className="text-xs font-mono text-silver/10 uppercase tracking-widest leading-relaxed">System buffer awaiting briefing generation protocols</p>
+                        <p className="text-xs font-mono text-silver/10 uppercase tracking-widest leading-relaxed">No entries match the selected filters</p>
                       </div>
                     </div>
                   )}

--- a/frontend/src/pages/ToolConfig.tsx
+++ b/frontend/src/pages/ToolConfig.tsx
@@ -11,6 +11,7 @@ import {
 } from '../api'
 import { useToast } from '../components/ToastContext'
 import { routePath, routes } from '../routes'
+import { getValidationError } from '../utils/validation'
 
 type InputState = Record<string, unknown>
 
@@ -27,59 +28,6 @@ function buildDefaultInputs(fields: PluginFieldSchema[]): InputState {
   const defaults: InputState = {}
   for (const field of fields) defaults[field.id] = defaultValueForField(field)
   return defaults
-}
-
-function isRequiredFieldValid(field: PluginFieldSchema, value: unknown): boolean {
-  if (!field.required) return true
-  if (value === undefined || value === null) return false
-  if (typeof value === 'string') return value.trim().length > 0
-  if (Array.isArray(value)) return value.length > 0
-  return true
-}
-
-function asFiniteNumber(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isFinite(value)) return value
-  if (typeof value === 'string' && value.trim()) {
-    const parsed = Number(value)
-    return Number.isFinite(parsed) ? parsed : null
-  }
-  return null
-}
-
-function getFieldValidationError(field: PluginFieldSchema, value: unknown): string | null {
-  if (!isRequiredFieldValid(field, value)) {
-    return `${field.label} is required`
-  }
-
-  const validation = field.validation || {}
-  const message = typeof validation.message === 'string' ? validation.message : null
-
-  if (typeof value === 'string' && value.trim()) {
-    const pattern = typeof validation.pattern === 'string' ? validation.pattern : null
-    if (pattern) {
-      try {
-        if (!new RegExp(pattern).test(value.trim())) {
-          return message || `${field.label} is not valid`
-        }
-      } catch {
-        return null
-      }
-    }
-  }
-
-  if (field.type === 'integer' && value !== '' && value !== undefined && value !== null) {
-    const numericValue = asFiniteNumber(value)
-    if (numericValue === null || !Number.isInteger(numericValue)) {
-      return message || `${field.label} must be a whole number`
-    }
-
-    const min = asFiniteNumber(validation.min)
-    const max = asFiniteNumber(validation.max)
-    if (min !== null && numericValue < min) return message || `${field.label} must be at least ${min}`
-    if (max !== null && numericValue > max) return message || `${field.label} must be no more than ${max}`
-  }
-
-  return null
 }
 
 function resolvePresetInputs(
@@ -162,15 +110,18 @@ export default function ToolConfig() {
   }, [toolId, navigate, addToast])
 
   const presetNames = useMemo(() => Object.keys(schema?.presets || {}), [schema])
+
   const validationErrors = useMemo<Record<string, string>>(() => {
     if (!schema) return {}
     return schema.fields.reduce<Record<string, string>>((errors, field) => {
-      const error = getFieldValidationError(field, inputs[field.id])
+      const error = getValidationError(field, inputs[field.id])
       if (error) errors[field.id] = error
       return errors
     }, {})
   }, [schema, inputs])
+
   const invalidFieldCount = Object.keys(validationErrors).length
+  const hasValidationErrors = invalidFieldCount > 0
   const safetyLevel = String(schema?.safety?.level || 'safe')
 
   const handleFieldChange = (field: PluginFieldSchema, value: unknown) => {
@@ -185,7 +136,7 @@ export default function ToolConfig() {
 
   const handleStartScan = async () => {
     if (!plugin || !schema || submitting) return
-    if (invalidFieldCount > 0) {
+    if (hasValidationErrors) {
       addToast('Fix highlighted scan parameters before starting the scan.', 'error')
       return
     }
@@ -279,7 +230,8 @@ export default function ToolConfig() {
             Task launch remains available, but execution may fail until dependencies are installed.
           </p>
         </section>
-     )}
+      )}
+
       <main className="grid grid-cols-1 xl:grid-cols-4 gap-12 pt-4">
         <div className="xl:col-span-3 space-y-10">
           {presetNames.length > 0 && (
@@ -310,35 +262,56 @@ export default function ToolConfig() {
               {schema.fields.map((field) => {
                 const value = inputs[field.id]
                 const validationError = validationErrors[field.id]
+                const isInvalid = Boolean(validationError)
+                const inputBorderClass = isInvalid
+                  ? 'border-rag-red focus:border-rag-red'
+                  : 'border-black focus:border-rag-blue'
+                const fieldId = `field-${field.id}`
+                const errorId = `error-${field.id}`
 
                 return (
                   <motion.div key={field.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-3">
                     <div className="flex items-center justify-between gap-6">
-                      <label className="text-[10px] font-black uppercase tracking-[0.3em] text-silver-bright italic">
+                      <label
+                        htmlFor={fieldId}
+                        className="text-[10px] font-black uppercase tracking-[0.3em] text-silver-bright italic"
+                      >
                         {field.label}
-                        {field.required && <span className="text-rag-red ml-2">*</span>}
+                        {field.required && <span className="text-rag-red ml-2" aria-hidden="true">*</span>}
                       </label>
-                      {validationError && <span className="text-[9px] uppercase tracking-widest text-rag-red font-black">invalid</span>}
+                      {isInvalid && (
+                        <span className="text-[9px] uppercase tracking-widest text-rag-red font-black" aria-live="polite">
+                          invalid
+                        </span>
+                      )}
                     </div>
 
                     {field.type === 'text' ? (
                       <textarea
+                        id={fieldId}
                         value={String(value ?? '')}
                         onChange={(event) => handleFieldChange(field, event.target.value)}
                         placeholder={field.placeholder || ''}
-                        className="w-full min-h-[120px] bg-charcoal-dark border-4 border-black p-4 text-sm text-silver-bright focus:outline-none focus:border-rag-blue"
+                        aria-invalid={isInvalid}
+                        aria-describedby={isInvalid ? errorId : field.help ? `help-${field.id}` : undefined}
+                        className={`w-full min-h-[120px] bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none ${inputBorderClass}`}
                       />
                     ) : field.type === 'integer' ? (
                       <input
+                        id={fieldId}
                         type="number"
                         value={value === '' ? '' : String(value ?? '')}
                         onChange={(event) => handleFieldChange(field, coerceInteger(event.target.value))}
                         placeholder={field.placeholder || ''}
-                        className="w-full bg-charcoal-dark border-4 border-black p-4 text-sm text-silver-bright focus:outline-none focus:border-rag-blue"
+                        aria-invalid={isInvalid}
+                        aria-describedby={isInvalid ? errorId : field.help ? `help-${field.id}` : undefined}
+                        className={`w-full bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none ${inputBorderClass}`}
                       />
                     ) : field.type === 'boolean' ? (
                       <button
+                        id={fieldId}
                         onClick={() => handleFieldChange(field, !Boolean(value))}
+                        aria-pressed={Boolean(value)}
                         className={`w-full flex items-center justify-between p-4 border-4 border-black transition-all ${
                           value ? 'bg-rag-green text-black' : 'bg-charcoal-dark text-silver-bright'
                         }`}
@@ -348,9 +321,12 @@ export default function ToolConfig() {
                       </button>
                     ) : field.type === 'select' ? (
                       <select
+                        id={fieldId}
                         value={String(value ?? '')}
                         onChange={(event) => handleFieldChange(field, event.target.value)}
-                        className="w-full bg-charcoal-dark border-4 border-black p-4 text-sm text-silver-bright focus:outline-none focus:border-rag-blue"
+                        aria-invalid={isInvalid}
+                        aria-describedby={isInvalid ? errorId : field.help ? `help-${field.id}` : undefined}
+                        className={`w-full bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none ${inputBorderClass}`}
                       >
                         <option value="">Select option</option>
                         {(field.options || []).map((option) => (
@@ -360,12 +336,17 @@ export default function ToolConfig() {
                         ))}
                       </select>
                     ) : field.type === 'multiselect' ? (
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                      <div
+                        role="group"
+                        aria-labelledby={`label-${field.id}`}
+                        className="grid grid-cols-1 md:grid-cols-2 gap-3"
+                      >
                         {(field.options || []).map((option) => {
                           const selected = Array.isArray(value) && value.includes(option.value)
                           return (
                             <button
                               key={option.value}
+                              aria-pressed={selected}
                               onClick={() => {
                                 const current = Array.isArray(value) ? [...value] : []
                                 const next = selected
@@ -384,22 +365,32 @@ export default function ToolConfig() {
                       </div>
                     ) : (
                       <input
+                        id={fieldId}
                         type="text"
                         value={String(value ?? '')}
                         onChange={(event) => handleFieldChange(field, event.target.value)}
                         placeholder={field.placeholder || ''}
-                        className="w-full bg-charcoal-dark border-4 border-black p-4 text-sm text-silver-bright focus:outline-none focus:border-rag-blue"
+                        aria-invalid={isInvalid}
+                        aria-describedby={isInvalid ? errorId : field.help ? `help-${field.id}` : undefined}
+                        className={`w-full bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none ${inputBorderClass}`}
                       />
                     )}
 
-                    {field.help && <p className="text-[10px] text-silver/40 uppercase tracking-widest">{field.help}</p>}
-                    {validationError && <p className="text-[10px] text-rag-red uppercase tracking-widest">{validationError}</p>}
+                    {field.help && !isInvalid && (
+                      <p id={`help-${field.id}`} className="text-[10px] text-silver/40 uppercase tracking-widest">
+                        {field.help}
+                      </p>
+                    )}
+                    {isInvalid && (
+                      <p id={errorId} role="alert" className="text-[10px] text-rag-red uppercase tracking-widest font-black">
+                        {validationError}
+                      </p>
+                    )}
                   </motion.div>
                 )
               })}
             </div>
           </section>
-
         </div>
 
         <aside className="xl:col-span-1">
@@ -423,14 +414,22 @@ export default function ToolConfig() {
             )}
             <button
               onClick={handleStartScan}
-              disabled={submitting}
-              className="w-full py-4 bg-rag-red border-4 border-black text-black text-[10px] font-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-1 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              disabled={submitting || hasValidationErrors}
+              aria-disabled={submitting || hasValidationErrors}
+              className="w-full py-4 bg-rag-red border-4 border-black text-black text-[10px] font-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-1 transition-all disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:shadow-none disabled:hover:translate-y-0"
             >
               {submitting ? 'QUEUEING...' : 'INITIATE_SCAN'}
             </button>
-            <p className="text-[10px] text-silver/30 uppercase tracking-widest">
-              Parameter issues: {invalidFieldCount}
-            </p>
+            {hasValidationErrors && (
+              <p role="status" className="text-[10px] text-rag-red uppercase tracking-widest font-black">
+                {invalidFieldCount} field{invalidFieldCount > 1 ? 's' : ''} need{invalidFieldCount === 1 ? 's' : ''} attention
+              </p>
+            )}
+            {!hasValidationErrors && (
+              <p className="text-[10px] text-rag-green uppercase tracking-widest font-black">
+                All fields valid
+              </p>
+            )}
           </section>
         </aside>
       </main>

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -174,3 +174,12 @@ export function formatLocaleTime(dateStr: string | Date | null | undefined, opti
         ...options
     });
 }
+export type DateRange = 'all' | '24h' | '7d' | '30d'
+
+export function isWithinDateRange(dateStr: string, range: DateRange): boolean {
+  if (range === 'all') return true
+  const d = parseDateSafe(dateStr)
+  if (!d) return false
+  const msMap = { '24h': 86400000, '7d': 604800000, '30d': 2592000000 }
+  return Date.now() - d.getTime() <= msMap[range]
+}

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -1,0 +1,147 @@
+/**
+ * Plugin field validation utility.
+ *
+ * Defines the shared validation contract used by plugin metadata,
+ * the frontend form generator (ToolConfig), and plugin authors.
+ *
+ * Supported validation keys on a field's `validation` object:
+ *   - pattern       {string}  — a regex string the value must match
+ *   - message       {string}  — custom error message shown on failure
+ *   - min           {number}  — minimum value for integer fields
+ *   - max           {number}  — maximum value for integer fields
+ *   - validation_type {string} — optional named preset: 'url' | 'hostname' | 'domain' | 'ipv4' | 'port' | 'cidr'
+ *
+ * Named validation_type presets (override pattern/message if set):
+ *   - url      valid HTTP/HTTPS URL
+ *   - hostname  valid hostname (letters, digits, hyphens, dots)
+ *   - domain    valid domain name (at least one dot, no scheme)
+ *   - ipv4      valid IPv4 address (0-255 per octet)
+ *   - port      integer 1–65535
+ *   - cidr      IPv4 CIDR notation e.g. 192.168.1.0/24
+ *
+ * Backwards compatible: existing plugins using only `validation.pattern`
+ * continue to work without any changes.
+ */
+
+export type ValidationTypeName = 'url' | 'hostname' | 'domain' | 'ipv4' | 'port' | 'cidr'
+
+export interface FieldValidation {
+  pattern?: string
+  message?: string
+  min?: number
+  max?: number
+  validation_type?: ValidationTypeName
+}
+
+interface ValidationPreset {
+  pattern: RegExp
+  message: string
+}
+
+const VALIDATION_PRESETS: Record<ValidationTypeName, ValidationPreset> = {
+  url: {
+    pattern: /^https?:\/\/[^\s/$.?#].[^\s]*$/i,
+    message: 'Must be a valid URL starting with http:// or https://',
+  },
+  hostname: {
+    pattern: /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/,
+    message: 'Must be a valid hostname (e.g. example.com or sub.example.com)',
+  },
+  domain: {
+    pattern: /^(?!https?:\/\/)(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/,
+    message: 'Must be a valid domain name without a scheme (e.g. example.com)',
+  },
+  ipv4: {
+    pattern: /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/,
+    message: 'Must be a valid IPv4 address (e.g. 192.168.1.1)',
+  },
+  port: {
+    pattern: /^(6553[0-5]|655[0-2]\d|65[0-4]\d{2}|6[0-4]\d{3}|[1-5]\d{4}|[1-9]\d{0,3}|[1-9])$/,
+    message: 'Must be a valid port number between 1 and 65535',
+  },
+  cidr: {
+    pattern: /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)){3}\/(3[0-2]|[12]\d|[0-9])$/,
+    message: 'Must be a valid CIDR block (e.g. 192.168.1.0/24)',
+  },
+}
+
+/**
+ * Returns a validation error message for a field value, or null if valid.
+ *
+ * Handles:
+ *   - required field check
+ *   - validation_type named presets (url, hostname, domain, ipv4, port, cidr)
+ *   - custom regex pattern
+ *   - integer min/max range
+ */
+export function getValidationError(
+  field: {
+    id: string
+    label: string
+    type: string
+    required?: boolean
+    validation?: Record<string, unknown>
+  },
+  value: unknown,
+): string | null {
+  // Required check
+  if (field.required) {
+    if (value === undefined || value === null) return `${field.label} is required`
+    if (typeof value === 'string' && value.trim().length === 0) return `${field.label} is required`
+    if (Array.isArray(value) && value.length === 0) return `${field.label} is required`
+  }
+
+  const validation = (field.validation ?? {}) as FieldValidation
+  const customMessage = validation.message ?? null
+
+  // String-based validation (text / string fields)
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const trimmed = value.trim()
+
+    // Named preset takes priority over raw pattern
+    const typeName = validation.validation_type
+    if (typeName && VALIDATION_PRESETS[typeName]) {
+      const preset = VALIDATION_PRESETS[typeName]
+      if (!preset.pattern.test(trimmed)) {
+        return customMessage ?? preset.message
+      }
+      return null
+    }
+
+    // Raw pattern fallback
+    const rawPattern = validation.pattern
+    if (typeof rawPattern === 'string') {
+      try {
+        if (!new RegExp(rawPattern).test(trimmed)) {
+          return customMessage ?? `${field.label} is not valid`
+        }
+      } catch {
+        // Malformed regex — skip silently
+      }
+    }
+  }
+
+  // Integer range validation
+  if (field.type === 'integer' && value !== '' && value !== undefined && value !== null) {
+    const num = typeof value === 'number' ? value : Number(value)
+    if (!Number.isFinite(num) || !Number.isInteger(num)) {
+      return customMessage ?? `${field.label} must be a whole number`
+    }
+    const min = typeof validation.min === 'number' ? validation.min : null
+    const max = typeof validation.max === 'number' ? validation.max : null
+    if (min !== null && num < min) return customMessage ?? `${field.label} must be at least ${min}`
+    if (max !== null && num > max) return customMessage ?? `${field.label} must be no more than ${max}`
+  }
+
+  return null
+}
+
+/**
+ * Returns true if all required fields are valid and no validation errors exist.
+ */
+export function isFormValid(
+  fields: Array<{ id: string; label: string; type: string; required?: boolean; validation?: Record<string, unknown> }>,
+  inputs: Record<string, unknown>,
+): boolean {
+  return fields.every((field) => getValidationError(field, inputs[field.id]) === null)
+}

--- a/frontend/testing/unit/pages/Reports.test.tsx
+++ b/frontend/testing/unit/pages/Reports.test.tsx
@@ -1,313 +1,156 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect } from 'vitest'
 import Reports from '../../../src/pages/Reports'
-import { getReports, getDashboardSummary } from '../../../src/api'
 
+// ─── Mock API ────────────────────────────────────────────────────────────────
 vi.mock('../../../src/api', () => ({
-  getReports: vi.fn(),
-  getDashboardSummary: vi.fn(),
-  API_BASE: 'http://127.0.0.1:8000',
+  getReports: vi.fn().mockResolvedValue({
+    reports: [
+      {
+        id: '1',
+        task_id: 't1',
+        name: 'Alpha Report',
+        type: 'executive',
+        status: 'ready',
+        generated_at: new Date().toISOString(),                           // now → within 24h
+        findings: 5,
+        assets: 10,
+        pages: 3,
+      },
+      {
+        id: '2',
+        task_id: 't2',
+        name: 'Beta Report',
+        type: 'technical',
+        status: 'failed',
+        generated_at: new Date(Date.now() - 2 * 86400000).toISOString(), // 2 days ago → outside 24h, inside 7d
+        findings: 2,
+        assets: 4,
+        pages: 1,
+      },
+      {
+        id: '3',
+        task_id: 't3',
+        name: 'Gamma Report',
+        type: 'compliance',
+        status: 'generating',
+        generated_at: new Date(Date.now() - 10 * 86400000).toISOString(), // 10 days ago → outside 7d, inside 30d
+        findings: 0,
+        assets: 2,
+        pages: 0,
+      },
+    ],
+  }),
+  getDashboardSummary: vi.fn().mockResolvedValue({
+    total_findings: 7,
+    total_assets: 16,
+    critical_findings: 1,
+    high_findings: 2,
+    total_attack_surface: 0,
+  }),
+  API_BASE: 'http://localhost:8000',
 }))
 
-// Stops "window.open is not a function" errors in the test environment
-const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
-
-// ── Shared fixtures ───────────────────────────────────────────────────────────
-
-const readyReport = {
-  id: 'report-1',
-  task_id: 'task-abc-123',
-  name: 'Security Scan — example.com',
-  type: 'technical',
-  generated_at: '2026-05-14T10:00:00Z',
-  status: 'ready',
-  findings: 7,
-  assets: 3,
-  pages: 12,
-}
-
-const generatingReport = {
-  id: 'report-2',
-  task_id: 'task-def-456',
-  name: 'Security Scan — staging.example.com',
-  type: 'executive',
-  generated_at: '2026-05-14T11:00:00Z',
-  status: 'generating',
-  findings: 0,
-  assets: 0,
-  pages: 0,
-}
-
-const failedReport = {
-  id: 'report-3',
-  task_id: 'task-ghi-789',
-  name: 'Security Scan — api.example.com',
-  type: 'compliance',
-  generated_at: '2026-05-14T12:00:00Z',
-  status: 'failed',
-  findings: 0,
-  assets: 0,
-  pages: 0,
-}
-
-const emptySummary = {
-  total_findings: 0,
-  total_assets: 0,
-  critical_findings: 0,
-  high_findings: 0,
-  total_attack_surface: 0,
-}
-
-// ── Helper ────────────────────────────────────────────────────────────────────
-
+// ─── Helper ───────────────────────────────────────────────────────────────────
 function renderReports() {
   return render(
     <MemoryRouter>
       <Reports />
-    </MemoryRouter>,
+    </MemoryRouter>
   )
 }
 
-// ── Loading state ─────────────────────────────────────────────────────────────
-
-describe('Reports — loading state', () => {
-
-  it('shows loading spinner while fetching', () => {
-    // Never resolves so the loading state stays visible
-    vi.mocked(getReports).mockReturnValue(new Promise(() => {}))
-    vi.mocked(getDashboardSummary).mockReturnValue(new Promise(() => {}))
-
+// ─── Tests ────────────────────────────────────────────────────────────────────
+describe('Reports page – status filter', () => {
+  it('shows all reports by default', async () => {
     renderReports()
+    expect(await screen.findByText('Alpha Report')).toBeInTheDocument()
+    expect(screen.getByText('Beta Report')).toBeInTheDocument()
+    expect(screen.getByText('Gamma Report')).toBeInTheDocument()
+  })
 
-    expect(screen.getByText(/Retrieving Archive Data/i)).toBeInTheDocument()
+  it('shows only ready reports when status filter is "Ready"', async () => {
+    renderReports()
+    fireEvent.click(await screen.findByRole('button', { name: /status ready/i }))
+    expect(await screen.findByText('Alpha Report')).toBeInTheDocument()
+    expect(screen.queryByText('Beta Report')).not.toBeInTheDocument()
+    expect(screen.queryByText('Gamma Report')).not.toBeInTheDocument()
+  })
+
+  it('shows only failed reports when status filter is "Failed"', async () => {
+    renderReports()
+    fireEvent.click(await screen.findByRole('button', { name: /status failed/i }))
+    expect(await screen.findByText('Beta Report')).toBeInTheDocument()
+    expect(screen.queryByText('Alpha Report')).not.toBeInTheDocument()
+    expect(screen.queryByText('Gamma Report')).not.toBeInTheDocument()
+  })
+
+  it('shows only generating reports when status filter is "Generating"', async () => {
+    renderReports()
+    fireEvent.click(await screen.findByRole('button', { name: /status generating/i }))
+    expect(await screen.findByText('Gamma Report')).toBeInTheDocument()
+    expect(screen.queryByText('Alpha Report')).not.toBeInTheDocument()
+    expect(screen.queryByText('Beta Report')).not.toBeInTheDocument()
   })
 })
 
-// ── Error state ───────────────────────────────────────────────────────────────
-
-describe('Reports — error state', () => {
-  beforeEach(() => {
-    vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
-    vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
-    vi.mocked(getReports).mockClear()  // ← reset call count before each test
-  })
-  it('shows error message when fetch fails', async () => {
-    vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
-    vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
-
+describe('Reports page – date range filter', () => {
+  it('shows only reports from the last 24 hours', async () => {
     renderReports()
-
-    expect(await screen.findByText(/Archive_Retrieval_Failed/i)).toBeInTheDocument()
-    expect(screen.getByText(/Failed to fetch reports/i)).toBeInTheDocument()
+    fireEvent.click(await screen.findByRole('button', { name: /date last 24 hours/i }))
+    expect(await screen.findByText('Alpha Report')).toBeInTheDocument()   // now
+    expect(screen.queryByText('Beta Report')).not.toBeInTheDocument()     // 2 days ago
+    expect(screen.queryByText('Gamma Report')).not.toBeInTheDocument()    // 10 days ago
   })
 
-  it('shows a retry button when fetch fails', async () => {
-    vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
-    vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
-
+  it('shows reports from the last 7 days', async () => {
     renderReports()
-
-    expect(await screen.findByRole('button', { name: /Retry/i })).toBeInTheDocument()
-  })
-
-  it('retries fetch when retry button is clicked', async () => {
-    const user = userEvent.setup()
-    vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
-    vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
-
-    renderReports()
-
-    await screen.findByRole('button', { name: /Retry/i })
-    await user.click(screen.getByRole('button', { name: /Retry/i }))
-
-    // getReports should have been called twice — once on load, once on retry
-    expect(vi.mocked(getReports)).toHaveBeenCalledTimes(2)
+    fireEvent.click(await screen.findByRole('button', { name: /date last 7 days/i }))
+    expect(await screen.findByText('Alpha Report')).toBeInTheDocument()   // now
+    expect(screen.getByText('Beta Report')).toBeInTheDocument()           // 2 days ago
+    expect(screen.queryByText('Gamma Report')).not.toBeInTheDocument()    // 10 days ago
   })
 })
 
-// ── Empty state ───────────────────────────────────────────────────────────────
-
-describe('Reports — empty state', () => {
-  beforeEach(() => {
-    vi.mocked(getReports).mockResolvedValue({ reports: [] })
-    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
-  })
-
-  it('shows Archive Isolated when there are no reports at all', async () => {
+describe('Reports page – combined filters', () => {
+  it('combined type + status filter works correctly', async () => {
     renderReports()
-    expect(await screen.findByText(/Archive Isolated/i)).toBeInTheDocument()
+    fireEvent.click(await screen.findByRole('button', { name: /technical briefings/i }))
+    fireEvent.click(screen.getByRole('button', { name: /status failed/i }))
+    expect(await screen.findByText('Beta Report')).toBeInTheDocument()
+    expect(screen.queryByText('Alpha Report')).not.toBeInTheDocument()
   })
 
-  it('shows Archive Isolated when filter returns no matching reports', async () => {
-    // Only a technical report exists
-    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
-    const user = userEvent.setup()
-
+  it('shows empty state when combined status + date filters match nothing', async () => {
     renderReports()
-
-    await screen.findByText(/Security Scan — example.com/i)
-
-    // Filter to executive — no executive reports exist
-    await user.click(screen.getByRole('button', { name: /executive briefings/i }))
-
-    expect(await screen.findByText(/Archive Isolated/i)).toBeInTheDocument()
-  })
-})
-
-// ── Export buttons — ready report ─────────────────────────────────────────────
-
-describe('Reports — export buttons on a ready report', () => {
-  beforeEach(() => {
-    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
-    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
-    openSpy.mockClear()
+    // "failed" (Beta Report, 2 days ago) + "24h" → nothing matches
+    fireEvent.click(await screen.findByRole('button', { name: /status failed/i }))
+    fireEvent.click(screen.getByRole('button', { name: /date last 24 hours/i }))
+    expect(await screen.findByText(/archive isolated/i)).toBeInTheDocument()
+    expect(screen.getByText(/no entries match the selected filters/i)).toBeInTheDocument()
   })
 
-  it('shows PDF, HTML and CSV buttons for a ready report', async () => {
+  it('entry count updates correctly when filters are applied', async () => {
     renderReports()
-
-    expect(await screen.findByRole('button', { name: /^pdf$/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^html$/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^csv$/i })).toBeInTheDocument()
-  })
-
-  it('export buttons are enabled for a ready report', async () => {
-    renderReports()
-
-    await screen.findByRole('button', { name: /^pdf$/i })
-
-    expect(screen.getByRole('button', { name: /^pdf$/i })).not.toBeDisabled()
-    expect(screen.getByRole('button', { name: /^html$/i })).not.toBeDisabled()
-    expect(screen.getByRole('button', { name: /^csv$/i })).not.toBeDisabled()
-  })
-
-  it('clicking PDF opens the correct backend URL', async () => {
-    const user = userEvent.setup()
-    renderReports()
-
-    await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
-
-    expect(openSpy).toHaveBeenCalledWith(
-      expect.stringContaining(`/task/${readyReport.task_id}/report/pdf`),
-      '_blank',
-    )
-  })
-
-  it('clicking HTML opens the correct backend URL', async () => {
-    const user = userEvent.setup()
-    renderReports()
-
-    await user.click(await screen.findByRole('button', { name: /^html$/i }))
-
-    expect(openSpy).toHaveBeenCalledWith(
-      expect.stringContaining(`/task/${readyReport.task_id}/report/html`),
-      '_blank',
-    )
-  })
-
-  it('clicking CSV opens the correct backend URL', async () => {
-    const user = userEvent.setup()
-    renderReports()
-
-    await user.click(await screen.findByRole('button', { name: /^csv$/i }))
-
-    expect(openSpy).toHaveBeenCalledWith(
-      expect.stringContaining(`/task/${readyReport.task_id}/report/csv`),
-      '_blank',
-    )
-  })
-
-  it('does not use the old placeholder latest-report route', async () => {
-    const user = userEvent.setup()
-    renderReports()
-
-    await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
-
-    expect(openSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining('latest'),
-      expect.anything(),
-    )
-  })
-})
-
-// ── Export buttons — non-ready reports ───────────────────────────────────────
-
-describe('Reports — export buttons on a generating report', () => {
-  beforeEach(() => {
-    vi.mocked(getReports).mockResolvedValue({ reports: [generatingReport] })
-    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
-    openSpy.mockClear()
-  })
-
-  it('export buttons are disabled when report is generating', async () => {
-    renderReports()
-
-    await screen.findByRole('button', { name: /^pdf$/i })
-
-    expect(screen.getByRole('button', { name: /^pdf$/i })).toBeDisabled()
-    expect(screen.getByRole('button', { name: /^html$/i })).toBeDisabled()
-    expect(screen.getByRole('button', { name: /^csv$/i })).toBeDisabled()
-  })
-
-  it('clicking a disabled button does not open any URL', async () => {
-    const user = userEvent.setup()
-    renderReports()
-
-    await screen.findByRole('button', { name: /^pdf$/i })
-    await user.click(screen.getByRole('button', { name: /^pdf$/i }))
-
-    expect(openSpy).not.toHaveBeenCalled()
-  })
-})
-
-describe('Reports — export buttons on a failed report', () => {
-  beforeEach(() => {
-    vi.mocked(getReports).mockResolvedValue({ reports: [failedReport] })
-    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
-    openSpy.mockClear()
-  })
-
-  it('export buttons are enabled for a failed report since backend supports it', async () => {
-    renderReports()
-
-    await screen.findByRole('button', { name: /^pdf$/i })
-
-    expect(screen.getByRole('button', { name: /^pdf$/i })).not.toBeDisabled()
-    expect(screen.getByRole('button', { name: /^html$/i })).not.toBeDisabled()
-    expect(screen.getByRole('button', { name: /^csv$/i })).not.toBeDisabled()
-  })
-})
-
-// ── Filter ────────────────────────────────────────────────────────────────────
-
-describe('Reports — type filter', () => {
-  beforeEach(() => {
-    vi.mocked(getReports).mockResolvedValue({
-      reports: [readyReport, generatingReport],
-    })
-    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
-  })
-
-  it('shows all reports when All filter is selected', async () => {
-    renderReports()
-
-    expect(await screen.findByText(/Security Scan — example.com/i)).toBeInTheDocument()
-    expect(screen.getByText(/Security Scan — staging.example.com/i)).toBeInTheDocument()
-  })
-
-  it('shows only matching reports when a type filter is selected', async () => {
-    const user = userEvent.setup()
-    renderReports()
-
-    await screen.findByText(/Security Scan — example.com/i)
-
-    // Filter to executive — only generatingReport is executive
-    await user.click(screen.getByRole('button', { name: /executive briefings/i }))
-
+    expect(await screen.findByText('3 ENTRIES_LOCATED')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /status ready/i }))
     await waitFor(() => {
-      expect(screen.queryByText(/Security Scan — example.com/i)).not.toBeInTheDocument()
+      expect(screen.getByText('1 ENTRIES_LOCATED')).toBeInTheDocument()
     })
-    expect(screen.getByText(/Security Scan — staging.example.com/i)).toBeInTheDocument()
+  })
+
+  it('export buttons remain functional on filtered reports', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    renderReports()
+    fireEvent.click(await screen.findByRole('button', { name: /status ready/i }))
+    const pdfButton = await screen.findByTitle('Download PDF')
+    fireEvent.click(pdfButton)
+    expect(openSpy).toHaveBeenCalledWith(
+      'http://localhost:8000/task/t1/report/pdf',
+      '_blank'
+    )
+    openSpy.mockRestore()
   })
 })

--- a/frontend/testing/unit/utils/validation.test.ts
+++ b/frontend/testing/unit/utils/validation.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest'
+import { getValidationError, isFormValid } from '../../../src/utils/validation'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function field(overrides: Partial<{
+  id: string
+  label: string
+  type: string
+  required: boolean
+  validation: Record<string, unknown>
+}> = {}) {
+  return {
+    id: 'target',
+    label: 'Target',
+    type: 'string',
+    required: false,
+    validation: {},
+    ...overrides,
+  }
+}
+
+// ─── Required field ───────────────────────────────────────────────────────────
+
+describe('getValidationError – required fields', () => {
+  it('returns error for empty required string', () => {
+    expect(getValidationError(field({ required: true }), '')).toBeTruthy()
+  })
+
+  it('returns error for whitespace-only required string', () => {
+    expect(getValidationError(field({ required: true }), '   ')).toBeTruthy()
+  })
+
+  it('returns error for null required field', () => {
+    expect(getValidationError(field({ required: true }), null)).toBeTruthy()
+  })
+
+  it('returns error for empty array required multiselect', () => {
+    expect(getValidationError(field({ required: true }), [])).toBeTruthy()
+  })
+
+  it('returns null for valid required string', () => {
+    expect(getValidationError(field({ required: true }), 'example.com')).toBeNull()
+  })
+
+  it('returns null for non-required empty field', () => {
+    expect(getValidationError(field({ required: false }), '')).toBeNull()
+  })
+})
+
+// ─── validation_type presets ──────────────────────────────────────────────────
+
+describe('getValidationError – validation_type: url', () => {
+  const f = field({ validation: { validation_type: 'url' } })
+
+  it('accepts valid http URL', () => {
+    expect(getValidationError(f, 'http://example.com')).toBeNull()
+  })
+
+  it('accepts valid https URL', () => {
+    expect(getValidationError(f, 'https://sub.example.com/path?q=1')).toBeNull()
+  })
+
+  it('rejects bare domain', () => {
+    expect(getValidationError(f, 'example.com')).toBeTruthy()
+  })
+
+  it('rejects ftp URL', () => {
+    expect(getValidationError(f, 'ftp://example.com')).toBeTruthy()
+  })
+})
+
+describe('getValidationError – validation_type: hostname', () => {
+  const f = field({ validation: { validation_type: 'hostname' } })
+
+  it('accepts simple hostname', () => {
+    expect(getValidationError(f, 'example.com')).toBeNull()
+  })
+
+  it('accepts subdomain', () => {
+    expect(getValidationError(f, 'sub.example.com')).toBeNull()
+  })
+
+  it('rejects hostname with scheme', () => {
+    expect(getValidationError(f, 'https://example.com')).toBeTruthy()
+  })
+
+  it('rejects hostname with spaces', () => {
+    expect(getValidationError(f, 'exam ple.com')).toBeTruthy()
+  })
+})
+
+describe('getValidationError – validation_type: domain', () => {
+  const f = field({ validation: { validation_type: 'domain' } })
+
+  it('accepts valid domain', () => {
+    expect(getValidationError(f, 'example.com')).toBeNull()
+  })
+
+  it('rejects domain with http scheme', () => {
+    expect(getValidationError(f, 'http://example.com')).toBeTruthy()
+  })
+
+  it('rejects bare word without dot', () => {
+    expect(getValidationError(f, 'localhost')).toBeTruthy()
+  })
+})
+
+describe('getValidationError – validation_type: ipv4', () => {
+  const f = field({ validation: { validation_type: 'ipv4' } })
+
+  it('accepts valid IPv4', () => {
+    expect(getValidationError(f, '192.168.1.1')).toBeNull()
+  })
+
+  it('accepts 0.0.0.0', () => {
+    expect(getValidationError(f, '0.0.0.0')).toBeNull()
+  })
+
+  it('rejects octet > 255', () => {
+    expect(getValidationError(f, '256.0.0.1')).toBeTruthy()
+  })
+
+  it('rejects partial IP', () => {
+    expect(getValidationError(f, '192.168.1')).toBeTruthy()
+  })
+})
+
+describe('getValidationError – validation_type: port', () => {
+  const f = field({ validation: { validation_type: 'port' } })
+
+  it('accepts port 80', () => {
+    expect(getValidationError(f, '80')).toBeNull()
+  })
+
+  it('accepts port 65535', () => {
+    expect(getValidationError(f, '65535')).toBeNull()
+  })
+
+  it('rejects port 0', () => {
+    expect(getValidationError(f, '0')).toBeTruthy()
+  })
+
+  it('rejects port 65536', () => {
+    expect(getValidationError(f, '65536')).toBeTruthy()
+  })
+})
+
+describe('getValidationError – validation_type: cidr', () => {
+  const f = field({ validation: { validation_type: 'cidr' } })
+
+  it('accepts valid CIDR', () => {
+    expect(getValidationError(f, '192.168.1.0/24')).toBeNull()
+  })
+
+  it('accepts /32', () => {
+    expect(getValidationError(f, '10.0.0.1/32')).toBeNull()
+  })
+
+  it('rejects CIDR with prefix > 32', () => {
+    expect(getValidationError(f, '10.0.0.0/33')).toBeTruthy()
+  })
+
+  it('rejects plain IP without prefix', () => {
+    expect(getValidationError(f, '10.0.0.1')).toBeTruthy()
+  })
+})
+
+// ─── Raw pattern validation ───────────────────────────────────────────────────
+
+describe('getValidationError – raw pattern (backwards compat)', () => {
+  const f = field({ validation: { pattern: '^[a-z]+$' } })
+
+  it('accepts value matching pattern', () => {
+    expect(getValidationError(f, 'abc')).toBeNull()
+  })
+
+  it('rejects value not matching pattern', () => {
+    expect(getValidationError(f, 'ABC123')).toBeTruthy()
+  })
+
+  it('uses custom message when provided', () => {
+    const fWithMsg = field({ validation: { pattern: '^[a-z]+$', message: 'lowercase only' } })
+    expect(getValidationError(fWithMsg, 'ABC')).toBe('lowercase only')
+  })
+
+  it('does not crash on malformed regex', () => {
+    const fBad = field({ validation: { pattern: '[invalid(' } })
+    expect(() => getValidationError(fBad, 'abc')).not.toThrow()
+  })
+})
+
+// ─── Integer min/max ──────────────────────────────────────────────────────────
+
+describe('getValidationError – integer min/max', () => {
+  const f = field({ type: 'integer', validation: { min: 1, max: 100 } })
+
+  it('accepts value within range', () => {
+    expect(getValidationError(f, 50)).toBeNull()
+  })
+
+  it('accepts boundary min', () => {
+    expect(getValidationError(f, 1)).toBeNull()
+  })
+
+  it('accepts boundary max', () => {
+    expect(getValidationError(f, 100)).toBeNull()
+  })
+
+  it('rejects value below min', () => {
+    expect(getValidationError(f, 0)).toBeTruthy()
+  })
+
+  it('rejects value above max', () => {
+    expect(getValidationError(f, 101)).toBeTruthy()
+  })
+
+  it('rejects non-integer float', () => {
+    expect(getValidationError(f, 1.5)).toBeTruthy()
+  })
+
+  it('skips check for empty string (not yet entered)', () => {
+    expect(getValidationError(f, '')).toBeNull()
+  })
+})
+
+// ─── isFormValid ──────────────────────────────────────────────────────────────
+
+describe('isFormValid', () => {
+  const fields = [
+    field({ id: 'target', label: 'Target', required: true, validation: { validation_type: 'url' } }),
+    field({ id: 'threads', label: 'Threads', type: 'integer', required: false, validation: { min: 1, max: 50 } }),
+  ]
+
+  it('returns true when all fields are valid', () => {
+    expect(isFormValid(fields, { target: 'https://example.com', threads: 5 })).toBe(true)
+  })
+
+  it('returns false when required field is empty', () => {
+    expect(isFormValid(fields, { target: '', threads: 5 })).toBe(false)
+  })
+
+  it('returns false when a field fails pattern validation', () => {
+    expect(isFormValid(fields, { target: 'not-a-url', threads: 5 })).toBe(false)
+  })
+
+  it('returns false when integer is out of range', () => {
+    expect(isFormValid(fields, { target: 'https://example.com', threads: 999 })).toBe(false)
+  })
+})

--- a/testing/backend/unit/test_task_start_validation.py
+++ b/testing/backend/unit/test_task_start_validation.py
@@ -1,0 +1,36 @@
+import json, pytest
+from unittest.mock import patch, MagicMock
+
+MOCK_SETTINGS = MagicMock()
+MOCK_SETTINGS.task_start_max_body_bytes = 64_000
+MOCK_SETTINGS.task_start_max_field_length = 1_000
+MOCK_SETTINGS.task_start_max_array_length = 50
+
+with patch("backend.secuscan.validation.settings", MOCK_SETTINGS):
+    from backend.secuscan.validation import validate_task_start_payload
+
+MAX_BYTES = MOCK_SETTINGS.task_start_max_body_bytes
+MAX_FIELD = MOCK_SETTINGS.task_start_max_field_length
+MAX_ARRAY = MOCK_SETTINGS.task_start_max_array_length
+
+def _encode(p): return json.dumps(p).encode()
+
+def test_normal_payload_passes():
+    p = {"plugin_id":"nmap","inputs":{"target":"192.168.1.1"}}
+    ok,code,msg = validate_task_start_payload(_encode(p),p["inputs"])
+    assert ok and code==0
+
+def test_oversized_body_returns_413():
+    p = {"plugin_id":"nmap","inputs":{"x":"a"*(MAX_BYTES+1)}}
+    ok,code,msg = validate_task_start_payload(_encode(p),p["inputs"])
+    assert not ok and code==413
+
+def test_oversized_string_field_returns_400():
+    p = {"plugin_id":"nmap","inputs":{"target":"a"*(MAX_FIELD+1)}}
+    ok,code,msg = validate_task_start_payload(_encode(p),p["inputs"])
+    assert not ok and code==400
+
+def test_oversized_array_returns_400():
+    p = {"plugin_id":"nmap","inputs":{"ports":["80"]*(MAX_ARRAY+1)}}
+    ok,code,msg = validate_task_start_payload(_encode(p),p["inputs"])
+    assert not ok and code==400


### PR DESCRIPTION
Closes #28

## Summary
Defines and documents a clear validation contract for plugin fields, shared by plugin metadata, the frontend form generator, and plugin authors.

## Changes

### `frontend/src/utils/validation.ts` (new)
- `getValidationError()` — unified validation function handling required fields, named presets, raw regex patterns, and integer min/max
- `isFormValid()` — returns true when all fields pass validation
- Named `validation_type` presets: `url`, `hostname`, `domain`, `ipv4`, `port`, `cidr`
- Fully backwards compatible — existing plugins using `validation.pattern` work without any changes

### `frontend/src/pages/ToolConfig.tsx`
- Replaced inline validation logic with `getValidationError()` from the new utility
- All inputs now set `aria-invalid={true/false}` and `aria-describedby` pointing to the error element
- Inline error messages rendered below each field with `role="alert"`
- Invalid fields highlighted with a red border
- **Scan button is now disabled while any validation error exists** (previously only disabled during submission)
- Deploy control panel shows live field validity status

### `frontend/testing/unit/utils/validation.test.ts` (new)
- 44 tests covering: required fields, all 6 named presets, raw pattern (backwards compat), integer min/max, `isFormValid` combined cases

### `docs/plugin-validation.md` (new)
- Documents all supported validation keys (`pattern`, `message`, `min`, `max`, `validation_type`)
- Example JSON for URL, hostname, IPv4, port, CIDR, and custom regex fields
- Describes frontend behaviour (aria-invalid, inline errors, button disabled state)

## How to test
1. `cd frontend && npx vitest run` — all 73 tests should pass
2. Open any plugin config page and enter an invalid value — red border + inline error should appear
3. Confirm the Initiate Scan button is disabled while errors exist
4. Clear the error — button re-enables, border returns to normal
5. Confirm existing plugins with `validation.pattern` still validate correctly