### PR TITLE
feat: add frontend dockerfile and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+
+-   repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+    -   id: black
+        language_version: python3

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Related Issue

None

## Description

This pull request improves the production readiness and code-quality enforcement of the SecuScan repository. 

Specifically, it:
1. Adds a multi-stage `Dockerfile` to the `frontend/` directory to properly build the Vite application and serve the static assets using Nginx (improving upon the dev-server setup currently defined in `docker-compose.yml`).
2. Introduces a `.pre-commit-config.yaml` file to automate code formatting (`black`) and standard Git hook checks (like trailing whitespace and large file checks) for backend contributors.

## Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [x] Other (specify): DevOps & DX Infrastructure

## Screenshots / Videos (if applicable)

*N/A — Infrastructure and DevOps configuration changes.*

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have followed the code style guidelines of this project.
- [x] I have checked for any existing open issues that my pull request may address.
- [x] I have ensured that my changes do not break any existing functionality.
- [x] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [x] I have read the resources for guidance listed below.
- [x] I have followed security best practices in my code changes.

## Additional Context

By creating a dedicated `Dockerfile` for the frontend, we pave the way for a true production deployment where the API and static frontend are properly decoupled. Adding `pre-commit` ensures all Python code pushed by future open-source contributors adheres to standard `black` formatting rules without requiring manual review.
