### PR TITLE
Fix IPv6 hostname parsing in validate_target

### DIFF
--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -74,8 +74,13 @@ def validate_target(target: str, safe_mode: bool = True) -> Tuple[bool, str]:
     # Handle URLs
     hostname_to_validate = target
     if target.startswith(("http://", "https://")):
-        # Extract host:port or host
-        hostname_to_validate = target.split("://", 1)[1].split("/", 1)[0].split(":", 1)[0]
+        # Extract host:port or host (handle IPv6 literals in brackets)
+        host_part = target.split("://", 1)[1].split("/", 1)[0]
+        if host_part.startswith("["):
+            # IPv6 literal like [::1]:8080 or [::1] for ipv6
+            hostname_to_validate = host_part.split("]")[0][1:]
+        else:
+            hostname_to_validate = host_part.split(":", 1)[0]
 
     # Validate hostname format (RFC 1123)
     if not re.match(r'^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$', hostname_to_validate):


### PR DESCRIPTION
## Description

Fixed IPv6 hostname parsing issue in `validate_target()`.

## Problem

The existing hostname extraction logic incorrectly split IPv6 URLs on the first `:` character, causing valid IPv6 bracket-notation URLs like:

* `http://[::1]/`
* `http://[::1]:8080/path`

to fail validation.

## Changes Made

* Added IPv6 bracket-notation handling
* Correctly extracted IPv6 host values
* Preserved existing hostname parsing behavior

## Testing

* Verified IPv6 URL parsing locally
* Existing test suite passes except for one unrelated repository test failure in `test_plugins.py`

## Issue

Closes #57
