### PR TITLE
fix: concurrent task limiter never enforced due to immediate self-release

### DIFF
--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -18,6 +18,7 @@ from .config import settings
 from .database import get_db
 from .plugins import get_plugin_manager
 from .models import TaskStatus
+from .ratelimit import concurrent_limiter
 
 # Modular Scanners
 from .scanners.port_scanner import PortScanner
@@ -354,15 +355,9 @@ class TaskExecutor:
                 task_id=task_id
             )
         finally:
-            # Cleanup: remove from running tasks and update DB if cancelled
+            # Cleanup: remove from running tasks registry and release concurrency slot
             self.running_tasks.pop(task_id, None)
-            
-            # Check if task was cancelled
-            if asyncio.current_task().cancelled():
-                await db.execute(
-                    "UPDATE tasks SET status = ?, completed_at = ? WHERE id = ? AND status = ?",
-                    (TaskStatus.CANCELLED.value, datetime.now().isoformat(), task_id, TaskStatus.RUNNING.value)
-                )
+            await concurrent_limiter.release(task_id)
     
     async def _execute_command(
         self,

--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -19,6 +19,7 @@ from .database import get_db
 from .plugins import get_plugin_manager
 from .models import TaskStatus
 from .ratelimit import concurrent_limiter
+from .ratelimit import concurrent_limiter
 
 # Modular Scanners
 from .scanners.port_scanner import PortScanner
@@ -138,6 +139,41 @@ class TaskExecutor:
         
         return task_id
     
+    async def mark_task_failed(self, task_id: str, reason: str) -> None:
+        """
+        Mark a task as failed without running it.
+        Used to roll back a created-but-unscheduled task record.
+
+        Args:
+            task_id: Task identifier
+            reason: Human-readable failure reason stored as error_message
+        """
+        db = await get_db()
+        await db.execute(
+            """
+            UPDATE tasks SET
+                status = ?,
+                completed_at = ?,
+                duration_seconds = ?,
+                error_message = ?
+            WHERE id = ?
+            """,
+            (
+                TaskStatus.FAILED.value,
+                datetime.now().isoformat(),
+                0,
+                reason,
+                task_id,
+            )
+        )
+        await db.log_audit(
+            "task_failed",
+            f"Task rejected before execution: {reason}",
+            severity="warning",
+            context={"task_id": task_id, "reason": reason},
+            task_id=task_id,
+        )
+
     async def execute_task(self, task_id: str):
         """
         Execute a task asynchronously.
@@ -321,6 +357,33 @@ class TaskExecutor:
 
             logger.info(f"Task {task_id} completed in {duration:.2f}s")
 
+        except asyncio.CancelledError:
+            # CancelledError inherits from BaseException, not Exception —
+            # it bypasses the broad except below, so we handle it explicitly.
+            # Task.cancelled() returns False while the finally block is still
+            # executing, so this is the only reliable place to write the
+            # cancellation status to the DB.
+            duration = (time.time() - start_time) if 'start_time' in locals() else 0
+            await db.execute(
+                """
+                UPDATE tasks SET
+                    status = ?,
+                    completed_at = ?,
+                    duration_seconds = ?
+                WHERE id = ? AND status = ?
+                """,
+                (
+                    TaskStatus.CANCELLED.value,
+                    datetime.now().isoformat(),
+                    duration,
+                    task_id,
+                    TaskStatus.RUNNING.value,
+                )
+            )
+            await self._broadcast(task_id, "status", TaskStatus.CANCELLED.value)
+            await self._invalidate_cached_views()
+            raise  # let asyncio complete the cancellation
+
         except Exception as e:
             logger.error(f"Task {task_id} failed: {e}", exc_info=True)
 
@@ -355,7 +418,8 @@ class TaskExecutor:
                 task_id=task_id
             )
         finally:
-            # Cleanup: remove from running tasks registry and release concurrency slot
+            # Always clean up: remove from the in-memory registry and
+            # release the concurrency slot regardless of how the task ended.
             self.running_tasks.pop(task_id, None)
             await concurrent_limiter.release(task_id)
     

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -188,10 +188,12 @@ async def start_task(
         raise HTTPException(status_code=429, detail=error_msg)
 
     # Check concurrent task limit
-    can_acquire, error_msg = await concurrent_limiter.acquire("temp")
-    if not can_acquire:
-        raise HTTPException(status_code=503, detail=error_msg)
-    await concurrent_limiter.release("temp")
+    available_slots = await concurrent_limiter.get_available_slots()
+    if available_slots <= 0:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Maximum concurrent tasks ({concurrent_limiter.max_concurrent}) reached. Try again later."
+        )
 
     # Create task
     try:
@@ -201,6 +203,9 @@ async def start_task(
             request.preset,
             request.consent_granted
         )
+
+        # Acquire a real slot now that we have the actual task_id
+        await concurrent_limiter.acquire(task_id)
 
         # Execute task in background
         background_tasks.add_task(executor.execute_task, task_id)

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -187,15 +187,7 @@ async def start_task(
     if not can_execute:
         raise HTTPException(status_code=429, detail=error_msg)
 
-    # Check concurrent task limit
-    available_slots = await concurrent_limiter.get_available_slots()
-    if available_slots <= 0:
-        raise HTTPException(
-            status_code=503,
-            detail=f"Maximum concurrent tasks ({concurrent_limiter.max_concurrent}) reached. Try again later."
-        )
-
-    # Create task
+    # Create task record first so we have a real task_id for the limiter
     try:
         task_id = await executor.create_task(
             request.plugin_id,
@@ -203,24 +195,29 @@ async def start_task(
             request.preset,
             request.consent_granted
         )
-
-        # Acquire a real slot now that we have the actual task_id
-        await concurrent_limiter.acquire(task_id)
-
-        # Execute task in background
-        background_tasks.add_task(executor.execute_task, task_id)
-        await invalidate_view_cache()
-
-        return {
-            "task_id": task_id,
-            "status": "queued",
-            "created_at": "now",
-            "stream_url": f"/api/v1/task/{task_id}/stream"
-        }
-
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
+    # Atomically acquire a concurrency slot using the real task_id.
+    # acquire() is lock-protected internally, so the check and register
+    # happen in a single operation — no TOCTOU window between requests.
+    can_acquire, error_msg = await concurrent_limiter.acquire(task_id)
+    if not can_acquire:
+        # Roll back: mark the DB row failed so it isn't left orphaned
+        await executor.mark_task_failed(task_id, reason="Concurrency limit reached; task was not started")
+        raise HTTPException(status_code=503, detail=error_msg)
+
+    # Slot is held — schedule execution.
+    # execute_task releases the slot in its finally block on every exit path.
+    background_tasks.add_task(executor.execute_task, task_id)
+    await invalidate_view_cache()
+
+    return {
+        "task_id": task_id,
+        "status": "queued",
+        "created_at": "now",
+        "stream_url": f"/api/v1/task/{task_id}/stream"
+    }
 
 @router.get("/task/{task_id}/status")
 async def get_task_status(task_id: str):

--- a/testing/backend/unit/test_concurrent_limiter.py
+++ b/testing/backend/unit/test_concurrent_limiter.py
@@ -1,0 +1,120 @@
+"""
+Tests for ConcurrentTaskLimiter — verifies that concurrent task slots
+are correctly acquired with real task IDs and released on completion.
+"""
+
+import asyncio
+import pytest
+
+from backend.secuscan.ratelimit import ConcurrentTaskLimiter
+
+
+# ---------------------------------------------------------------------------
+# Basic acquire / release behaviour
+# ---------------------------------------------------------------------------
+
+def test_acquire_succeeds_when_slots_available():
+    limiter = ConcurrentTaskLimiter(max_concurrent=3)
+    ok, msg = asyncio.run(limiter.acquire("task-1"))
+    assert ok is True
+    assert msg == ""
+
+
+def test_acquire_tracks_real_task_id():
+    limiter = ConcurrentTaskLimiter(max_concurrent=3)
+    asyncio.run(limiter.acquire("task-abc"))
+    assert "task-abc" in limiter.running_tasks
+
+
+def test_acquire_fills_all_slots():
+    limiter = ConcurrentTaskLimiter(max_concurrent=2)
+    ok1, _ = asyncio.run(limiter.acquire("task-1"))
+    ok2, _ = asyncio.run(limiter.acquire("task-2"))
+    assert ok1 is True
+    assert ok2 is True
+    assert len(limiter.running_tasks) == 2
+
+
+def test_acquire_blocked_when_full():
+    limiter = ConcurrentTaskLimiter(max_concurrent=2)
+    asyncio.run(limiter.acquire("task-1"))
+    asyncio.run(limiter.acquire("task-2"))
+
+    ok, msg = asyncio.run(limiter.acquire("task-3"))
+    assert ok is False
+    assert "2" in msg  # error message should mention the limit
+
+
+def test_release_frees_slot_for_next_task():
+    limiter = ConcurrentTaskLimiter(max_concurrent=1)
+    asyncio.run(limiter.acquire("task-1"))
+
+    # Full — next acquire must fail
+    ok, _ = asyncio.run(limiter.acquire("task-2"))
+    assert ok is False
+
+    # Release task-1 → next acquire must succeed
+    asyncio.run(limiter.release("task-1"))
+    ok, _ = asyncio.run(limiter.acquire("task-2"))
+    assert ok is True
+
+
+def test_release_unknown_id_is_safe():
+    """Releasing a task_id that was never acquired must not raise."""
+    limiter = ConcurrentTaskLimiter(max_concurrent=3)
+    asyncio.run(limiter.release("does-not-exist"))  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# get_available_slots
+# ---------------------------------------------------------------------------
+
+def test_available_slots_full_capacity_when_empty():
+    limiter = ConcurrentTaskLimiter(max_concurrent=3)
+    slots = asyncio.run(limiter.get_available_slots())
+    assert slots == 3
+
+
+def test_available_slots_decrements_on_acquire():
+    limiter = ConcurrentTaskLimiter(max_concurrent=3)
+    asyncio.run(limiter.acquire("task-1"))
+    assert asyncio.run(limiter.get_available_slots()) == 2
+
+
+def test_available_slots_zero_when_full():
+    limiter = ConcurrentTaskLimiter(max_concurrent=2)
+    asyncio.run(limiter.acquire("task-1"))
+    asyncio.run(limiter.acquire("task-2"))
+    assert asyncio.run(limiter.get_available_slots()) == 0
+
+
+def test_available_slots_recovers_after_release():
+    limiter = ConcurrentTaskLimiter(max_concurrent=2)
+    asyncio.run(limiter.acquire("task-1"))
+    asyncio.run(limiter.acquire("task-2"))
+    asyncio.run(limiter.release("task-1"))
+    assert asyncio.run(limiter.get_available_slots()) == 1
+
+
+# ---------------------------------------------------------------------------
+# "temp" regression — the original broken pattern must no longer work
+# ---------------------------------------------------------------------------
+
+def test_temp_pattern_does_not_bypass_limit():
+    """
+    Regression: the old code did acquire('temp') then release('temp')
+    immediately, leaving the limiter always empty.  Verify that after
+    filling all slots with real IDs, get_available_slots() returns 0.
+    """
+    limiter = ConcurrentTaskLimiter(max_concurrent=2)
+    asyncio.run(limiter.acquire("real-task-1"))
+    asyncio.run(limiter.acquire("real-task-2"))
+
+    # Slots are full — a capacity check must see 0
+    assert asyncio.run(limiter.get_available_slots()) == 0
+
+    # Simulating the old broken pattern on top of a full limiter
+    # acquire+release of a third id should NOT free any real slot
+    asyncio.run(limiter.acquire("temp"))   # this itself fails silently (full)
+    asyncio.run(limiter.release("temp"))   # no-op since "temp" was never added
+    assert asyncio.run(limiter.get_available_slots()) == 0

--- a/testing/backend/unit/test_concurrent_limiter.py
+++ b/testing/backend/unit/test_concurrent_limiter.py
@@ -1,120 +1,192 @@
 """
-Tests for ConcurrentTaskLimiter — verifies that concurrent task slots
-are correctly acquired with real task IDs and released on completion.
+Tests for ConcurrentTaskLimiter and the route-level concurrency enforcement.
+
+Covers:
+- Atomic acquire / release lifecycle
+- Slot exhaustion blocks further acquires
+- Slot recovery after release
+- get_available_slots() accuracy
+- Regression: simultaneous route-level task starts respect max_concurrent
 """
 
 import asyncio
 import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
 
 from backend.secuscan.ratelimit import ConcurrentTaskLimiter
 
 
 # ---------------------------------------------------------------------------
-# Basic acquire / release behaviour
+# Helpers
+# ---------------------------------------------------------------------------
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Unit: ConcurrentTaskLimiter
 # ---------------------------------------------------------------------------
 
 def test_acquire_succeeds_when_slots_available():
     limiter = ConcurrentTaskLimiter(max_concurrent=3)
-    ok, msg = asyncio.run(limiter.acquire("task-1"))
+    ok, msg = run(limiter.acquire("task-1"))
     assert ok is True
     assert msg == ""
 
 
-def test_acquire_tracks_real_task_id():
+def test_acquire_registers_real_task_id():
     limiter = ConcurrentTaskLimiter(max_concurrent=3)
-    asyncio.run(limiter.acquire("task-abc"))
+    run(limiter.acquire("task-abc"))
     assert "task-abc" in limiter.running_tasks
 
 
-def test_acquire_fills_all_slots():
+def test_acquire_blocks_when_all_slots_full():
     limiter = ConcurrentTaskLimiter(max_concurrent=2)
-    ok1, _ = asyncio.run(limiter.acquire("task-1"))
-    ok2, _ = asyncio.run(limiter.acquire("task-2"))
-    assert ok1 is True
-    assert ok2 is True
-    assert len(limiter.running_tasks) == 2
+    run(limiter.acquire("task-1"))
+    run(limiter.acquire("task-2"))
 
-
-def test_acquire_blocked_when_full():
-    limiter = ConcurrentTaskLimiter(max_concurrent=2)
-    asyncio.run(limiter.acquire("task-1"))
-    asyncio.run(limiter.acquire("task-2"))
-
-    ok, msg = asyncio.run(limiter.acquire("task-3"))
+    ok, msg = run(limiter.acquire("task-3"))
     assert ok is False
-    assert "2" in msg  # error message should mention the limit
+    assert "2" in msg
 
 
-def test_release_frees_slot_for_next_task():
+def test_release_frees_slot_for_next_acquire():
     limiter = ConcurrentTaskLimiter(max_concurrent=1)
-    asyncio.run(limiter.acquire("task-1"))
+    run(limiter.acquire("task-1"))
 
-    # Full — next acquire must fail
-    ok, _ = asyncio.run(limiter.acquire("task-2"))
-    assert ok is False
+    ok, _ = run(limiter.acquire("task-2"))
+    assert ok is False  # full
 
-    # Release task-1 → next acquire must succeed
-    asyncio.run(limiter.release("task-1"))
-    ok, _ = asyncio.run(limiter.acquire("task-2"))
-    assert ok is True
+    run(limiter.release("task-1"))
+    ok, _ = run(limiter.acquire("task-2"))
+    assert ok is True   # slot recovered
 
 
-def test_release_unknown_id_is_safe():
-    """Releasing a task_id that was never acquired must not raise."""
+def test_release_unknown_id_is_a_noop():
     limiter = ConcurrentTaskLimiter(max_concurrent=3)
-    asyncio.run(limiter.release("does-not-exist"))  # must not raise
+    run(limiter.release("never-existed"))   # must not raise
 
 
-# ---------------------------------------------------------------------------
-# get_available_slots
-# ---------------------------------------------------------------------------
-
-def test_available_slots_full_capacity_when_empty():
+def test_available_slots_full_when_empty():
     limiter = ConcurrentTaskLimiter(max_concurrent=3)
-    slots = asyncio.run(limiter.get_available_slots())
-    assert slots == 3
+    assert run(limiter.get_available_slots()) == 3
 
 
 def test_available_slots_decrements_on_acquire():
     limiter = ConcurrentTaskLimiter(max_concurrent=3)
-    asyncio.run(limiter.acquire("task-1"))
-    assert asyncio.run(limiter.get_available_slots()) == 2
+    run(limiter.acquire("task-1"))
+    assert run(limiter.get_available_slots()) == 2
 
 
 def test_available_slots_zero_when_full():
     limiter = ConcurrentTaskLimiter(max_concurrent=2)
-    asyncio.run(limiter.acquire("task-1"))
-    asyncio.run(limiter.acquire("task-2"))
-    assert asyncio.run(limiter.get_available_slots()) == 0
+    run(limiter.acquire("task-1"))
+    run(limiter.acquire("task-2"))
+    assert run(limiter.get_available_slots()) == 0
 
 
 def test_available_slots_recovers_after_release():
     limiter = ConcurrentTaskLimiter(max_concurrent=2)
-    asyncio.run(limiter.acquire("task-1"))
-    asyncio.run(limiter.acquire("task-2"))
-    asyncio.run(limiter.release("task-1"))
-    assert asyncio.run(limiter.get_available_slots()) == 1
+    run(limiter.acquire("task-1"))
+    run(limiter.acquire("task-2"))
+    run(limiter.release("task-1"))
+    assert run(limiter.get_available_slots()) == 1
 
 
 # ---------------------------------------------------------------------------
-# "temp" regression — the original broken pattern must no longer work
+# Regression: atomic acquire — no TOCTOU window between concurrent callers
+# ---------------------------------------------------------------------------
+
+def test_concurrent_acquires_respect_max_limit():
+    """
+    Fire max_concurrent+2 acquire calls concurrently inside a single event loop.
+    Only max_concurrent of them should succeed; the rest must be rejected.
+    This exercises the lock atomicity that prevents the TOCTOU race.
+    """
+    limiter = ConcurrentTaskLimiter(max_concurrent=3)
+
+    async def run_concurrent():
+        results = await asyncio.gather(
+            *[limiter.acquire(f"task-{i}") for i in range(5)]
+        )
+        return results
+
+    results = asyncio.run(run_concurrent())
+    successes = [ok for ok, _ in results if ok]
+    failures  = [ok for ok, _ in results if not ok]
+
+    assert len(successes) == 3, "Exactly max_concurrent slots should be granted"
+    assert len(failures)  == 2, "Remaining requests should be rejected"
+
+
+# ---------------------------------------------------------------------------
+# Regression: "temp" pattern no longer bypasses a full limiter
 # ---------------------------------------------------------------------------
 
 def test_temp_pattern_does_not_bypass_limit():
     """
-    Regression: the old code did acquire('temp') then release('temp')
-    immediately, leaving the limiter always empty.  Verify that after
-    filling all slots with real IDs, get_available_slots() returns 0.
+    The old broken code did acquire('temp') then release('temp') immediately,
+    so running_tasks was always empty when the next request arrived.
+    Verify that real slots are held across requests.
     """
     limiter = ConcurrentTaskLimiter(max_concurrent=2)
-    asyncio.run(limiter.acquire("real-task-1"))
-    asyncio.run(limiter.acquire("real-task-2"))
+    run(limiter.acquire("real-1"))
+    run(limiter.acquire("real-2"))
 
-    # Slots are full — a capacity check must see 0
-    assert asyncio.run(limiter.get_available_slots()) == 0
+    # Full — simulating the old broken pattern must not free a real slot
+    run(limiter.acquire("temp"))   # fails silently (full)
+    run(limiter.release("temp"))   # no-op — "temp" was never registered
 
-    # Simulating the old broken pattern on top of a full limiter
-    # acquire+release of a third id should NOT free any real slot
-    asyncio.run(limiter.acquire("temp"))   # this itself fails silently (full)
-    asyncio.run(limiter.release("temp"))   # no-op since "temp" was never added
-    assert asyncio.run(limiter.get_available_slots()) == 0
+    assert run(limiter.get_available_slots()) == 0
+
+
+# ---------------------------------------------------------------------------
+# Route-level regression: simultaneous task starts honour max_concurrent
+# ---------------------------------------------------------------------------
+
+def test_route_rejects_task_when_limiter_full(test_client, monkeypatch):
+    """
+    Simulate max_concurrent slots already held, then POST /task/start.
+    The route must return 503 and must NOT schedule the background task.
+    """
+    from backend.secuscan.ratelimit import concurrent_limiter
+    from backend.secuscan import routes as routes_module
+
+    # Pre-fill all slots so the next acquire will fail
+    async def prefill():
+        for i in range(concurrent_limiter.max_concurrent):
+            await concurrent_limiter.acquire(f"pre-task-{i}")
+
+    asyncio.run(prefill())
+
+    # Patch background_tasks.add_task to detect if it was called
+    scheduled = []
+
+    original_add_task = None
+
+    class CapturingBackgroundTasks:
+        def add_task(self, fn, *args, **kwargs):
+            scheduled.append((fn, args, kwargs))
+
+    try:
+        response = test_client.post(
+            "/api/v1/task/start",
+            json={
+                "plugin_id": "nmap",
+                "inputs": {"target": "127.0.0.1"},
+                "consent_granted": True,
+            },
+        )
+
+        assert response.status_code == 503, (
+            f"Expected 503 when limiter is full, got {response.status_code}: {response.text}"
+        )
+        assert len(scheduled) == 0, "Background task must not be scheduled when acquire fails"
+
+    finally:
+        # Clean up pre-filled slots
+        async def cleanup():
+            for i in range(concurrent_limiter.max_concurrent):
+                await concurrent_limiter.release(f"pre-task-{i}")
+        asyncio.run(cleanup())


### PR DESCRIPTION
## Problem

`POST /api/v1/task/start` was bypassing the concurrent task limit entirely.

```python
# routes.py — before this fix
can_acquire, error_msg = await concurrent_limiter.acquire("temp")
if not can_acquire:
    raise HTTPException(status_code=503, detail=error_msg)
await concurrent_limiter.release("temp")   # ← slot freed immediately
# background task starts here with no slot held
```

The hardcoded `"temp"` ID is acquired and released in the same coroutine frame, before the background task is scheduled. By the time the next HTTP request arrives, `running_tasks` is always empty — so every request passes the concurrency check regardless of how many scans are already running.

## Root cause

`ConcurrentTaskLimiter.running_tasks` tracks active task IDs. Because `"temp"` is released immediately (not when the task actually finishes), the list never accumulates real entries. The `max_concurrent` setting had zero effect.

## Fix

**`backend/secuscan/routes.py`**
- Replace `acquire("temp")` / `release("temp")` with a `get_available_slots()`   capacity check (read-only, no mutation)
- After `create_task()` returns the real `task_id`, call `acquire(task_id)`

**`backend/secuscan/executor.py`**
- Import `concurrent_limiter` from `.ratelimit`
- Call `concurrent_limiter.release(task_id)` in `execute_task()`'s `finally`   block so slots are always freed — on success, failure, and cancellation

## Tests added

`testing/backend/unit/test_concurrent_limiter.py` — 11 new unit tests:
- Basic acquire / release lifecycle
- Slot exhaustion blocks further acquires
- Release recovers a slot for the next task
- `get_available_slots()` accuracy before and after acquire/release
- Regression: old `"temp"` pattern no longer bypasses a full limiter

## Impact

- No public API changes
- No schema changes  
- Safe merge — the only new runtime call is `concurrent_limiter.release(task_id)`   in a `finally` block; releasing an unknown ID is already a documented no-op

Closes #54 