### PR TITLE
test(backend): cover safe report filenames

### DIFF
--- a/testing/backend/unit/test_report_filename.py
+++ b/testing/backend/unit/test_report_filename.py
@@ -1,0 +1,74 @@
+import re
+
+import pytest
+
+from backend.secuscan.routes import build_report_filename
+
+
+@pytest.mark.parametrize(
+    ("task", "expected"),
+    [
+        (
+            {
+                "tool_name": "Nikto Scanner",
+                "target": "https://example.com/admin?x=1",
+                "created_at": "2026-05-14T10:30:00",
+            },
+            "secuscan_nikto-scanner_example-com_2026-05-14.html",
+        ),
+        (
+            {
+                "tool_name": "../../nmap\\scanner",
+                "target": "../etc/passwd",
+                "created_at": "2026-05-14",
+            },
+            "secuscan_nmap-scanner_target_2026-05-14.html",
+        ),
+        (
+            {
+                "tool_name": "shell; rm -rf /",
+                "target": "$(whoami) && cat /etc/passwd",
+                "created_at": "not-a-date",
+            },
+            "secuscan_shell-rm-rf_whoami-cat_report.html",
+        ),
+        (
+            {
+                "tool_name": "測試工具",
+                "target": "例え.テスト",
+                "created_at": "",
+            },
+            "secuscan_scan_target_report.html",
+        ),
+        (
+            {
+                "tool_name": "",
+                "plugin_id": "",
+                "target": "",
+                "created_at": "",
+            },
+            "secuscan_scan_target_report.html",
+        ),
+    ],
+)
+def test_build_report_filename_sanitizes_unsafe_parts(task, expected):
+    filename = build_report_filename(task, "html")
+
+    assert filename == expected
+    assert "/" not in filename
+    assert "\\" not in filename
+    assert ".." not in filename
+    assert re.fullmatch(r"[a-z0-9_.-]+", filename)
+
+
+def test_build_report_filename_preserves_requested_extension():
+    filename = build_report_filename(
+        {
+            "tool_name": "HTTP Inspector",
+            "target": "https://example.com",
+            "created_at": "2026-05-14T10:30:00",
+        },
+        "sarif",
+    )
+
+    assert filename == "secuscan_http-inspector_example-com_2026-05-14.sarif"


### PR DESCRIPTION
## Description
Adds focused backend unit coverage for report download filename generation.

The new tests exercise `build_report_filename()` with spaces, path separators, traversal-like values, shell-like characters, Unicode-only values, empty values, deterministic fallbacks, allowed filename characters, and extension preservation. This is test-only; production filename generation is unchanged.

## Related Issues
Closes #119.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test coverage only

## How Has This Been Tested?
- Baseline: `PYTHONPATH=. .venv/bin/python -m pytest testing/backend/integration/test_routes_sarif.py -q` -> 4 passed
- Baseline: `PYTHONPATH=. .venv/bin/python -m pytest testing/backend/unit/test_reporting.py -q` -> 5 passed
- `PYTHONPATH=. .venv/bin/python -m pytest testing/backend/unit/test_report_filename.py -q` -> 6 passed
- `PYTHONPATH=. .venv/bin/python -m pytest testing/backend/unit/test_report_filename.py testing/backend/integration/test_routes_sarif.py -q` -> 10 passed
- `.venv/bin/ruff check testing/backend/unit/test_report_filename.py` -> all checks passed
- `./testing/test_python.sh` -> passed with exit 0
- `git diff --cached --check`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30`

Focused pytest runs still emit the existing Pydantic v2 deprecation warning from `backend/secuscan/config.py`; this PR does not add a new warning source.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas. N/A: test cases are direct and self-contained.
- [x] I have made corresponding changes to the documentation. N/A: test-only coverage, no behavior or workflow change.
- [x] My changes generate no new warnings.
