### PR TITLE
fix: replace placeholder export button with latest ready report link (#79)

### DIFF
--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
 import { HugeiconsIcon } from '@hugeicons/react'
@@ -89,6 +89,18 @@ export default function Reports() {
     fetchReports()
   }, [])
 
+  // Derive the latest ready report without mutating the reports array.
+  // reduce() scans once, keeping whichever candidate has the later generated_at.
+  const latestReadyReport = useMemo(
+    () =>
+      reports.reduce<Report | null>((best, r) => {
+        if (r.status !== 'ready') return best
+        if (!best) return r
+        return new Date(r.generated_at) > new Date(best.generated_at) ? r : best
+      }, null),
+    [reports],
+  )
+
   const filteredReports = reports.filter((report) => selectedType === 'all' || report.type === selectedType)
 
   return (
@@ -108,6 +120,20 @@ export default function Reports() {
         </div>
 
         <div className="flex items-center gap-6">
+          {/* Latest Report Export Button — compact icon-button, matches Refresh */}
+          <button
+            onClick={() =>
+              latestReadyReport &&
+              window.open(`${API_BASE}/task/${latestReadyReport.task_id}/report/pdf`, '_blank')
+            }
+            disabled={!latestReadyReport}
+            className="bg-charcoal border-4 border-black p-4 text-silver-bright shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] disabled:hover:translate-x-0 disabled:hover:translate-y-0"
+            title={latestReadyReport ? `Export latest briefing: ${latestReadyReport.name}` : 'No ready reports available'}
+            aria-label="Export latest briefing PDF"
+          >
+            <ReportIcon icon={Download01Icon} className="block" />
+          </button>
+
           <button
             onClick={fetchReports}
             className="bg-charcoal border-4 border-black p-4 text-silver-bright shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all"

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -1,367 +1,446 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
-import { useNavigate } from 'react-router-dom'
-import { HugeiconsIcon } from '@hugeicons/react'
-import {
-  Analytics02Icon,
-  Archive02Icon,
-  Download01Icon,
-  File01Icon,
-  KnightShieldIcon,
-  Radar02Icon,
-  Refresh01Icon,
-  ScanEyeIcon,
-  ShieldUserIcon,
-  UserShield02Icon,
-} from '@hugeicons/core-free-icons'
-import { getDashboardSummary, getReports, API_BASE } from '../api'
-import { formatDateLong } from '../utils/date'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import Reports from '../../../src/pages/Reports'
+import { getReports, getDashboardSummary } from '../../../src/api'
 
-type Report = {
-  id: string
-  task_id: string
-  name: string
-  type: 'executive' | 'technical' | 'compliance'
-  generated_at: string
-  status: 'ready' | 'generating' | 'failed'
-  findings: number
-  assets: number
-  pages: number
+vi.mock('../../../src/api', () => ({
+  getReports: vi.fn(),
+  getDashboardSummary: vi.fn(),
+  API_BASE: 'http://127.0.0.1:8000',
+}))
+
+// Stops "window.open is not a function" errors in the test environment
+const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+// ── Shared fixtures ───────────────────────────────────────────────────────────
+
+const readyReport = {
+  id: 'report-1',
+  task_id: 'task-abc-123',
+  name: 'Security Scan — example.com',
+  type: 'technical',
+  generated_at: '2026-05-14T10:00:00Z',
+  status: 'ready',
+  findings: 7,
+  assets: 3,
+  pages: 12,
 }
 
-const containerVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: { staggerChildren: 0.05 },
-  },
+const newerReadyReport = {
+  id: 'report-4',
+  task_id: 'task-jkl-012',
+  name: 'Security Scan — newer.example.com',
+  type: 'executive',
+  generated_at: '2026-05-15T09:00:00Z', // newer than readyReport
+  status: 'ready',
+  findings: 2,
+  assets: 1,
+  pages: 8,
 }
 
-const itemVariants = {
-  hidden: { opacity: 0, scale: 0.95, y: 20 },
-  visible: {
-    opacity: 1,
-    scale: 1,
-    y: 0,
-    transition: { duration: 0.4 },
-  },
+const generatingReport = {
+  id: 'report-2',
+  task_id: 'task-def-456',
+  name: 'Security Scan — staging.example.com',
+  type: 'executive',
+  generated_at: '2026-05-14T11:00:00Z',
+  status: 'generating',
+  findings: 0,
+  assets: 0,
+  pages: 0,
 }
 
-const exportFormats = ['pdf', 'html', 'csv'] as const
-
-function ReportIcon({
-  icon,
-  size = 20,
-  className = '',
-}: {
-  icon: any
-  size?: number
-  className?: string
-}) {
-  return <HugeiconsIcon icon={icon} size={size} strokeWidth={1.9} className={className} />
+const failedReport = {
+  id: 'report-3',
+  task_id: 'task-ghi-789',
+  name: 'Security Scan — api.example.com',
+  type: 'compliance',
+  generated_at: '2026-05-14T12:00:00Z',
+  status: 'failed',
+  findings: 0,
+  assets: 0,
+  pages: 0,
 }
 
-export default function Reports() {
-  const navigate = useNavigate()
-  const [reports, setReports] = useState<Report[]>([])
-  const [summary, setSummary] = useState<any>({ total_findings: 0, total_assets: 0, critical_findings: 0, high_findings: 0, total_attack_surface: 0 })
-  const [selectedType, setSelectedType] = useState('all')
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+const emptySummary = {
+  total_findings: 0,
+  total_assets: 0,
+  critical_findings: 0,
+  high_findings: 0,
+  total_attack_surface: 0,
+}
 
-  const fetchReports = () => {
-    setLoading(true)
-    setError(null)
-    Promise.all([getReports(), getDashboardSummary()])
-      .then(([reportData, summaryData]: any) => {
-        setReports(reportData.reports || [])
-        setSummary(summaryData || {})
-      })
-      .catch(() => {
-        setError('Failed to fetch reports')
-      })
-      .finally(() => {
-        setLoading(false)
-      })
-  }
+// ── Helper ────────────────────────────────────────────────────────────────────
 
-  useEffect(() => {
-    fetchReports()
-  }, [])
-
-  // Derive the latest ready report without mutating the reports array.
-  // reduce() scans once, keeping whichever candidate has the later generated_at.
-  const latestReadyReport = useMemo(
-    () =>
-      reports.reduce<Report | null>((best, r) => {
-        if (r.status !== 'ready') return best
-        if (!best) return r
-        return new Date(r.generated_at) > new Date(best.generated_at) ? r : best
-      }, null),
-    [reports],
-  )
-
-  const filteredReports = reports.filter((report) => selectedType === 'all' || report.type === selectedType)
-
-  return (
-    <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
-      {/* Neo-Brutalist Header */}
-      <header className="relative flex flex-col md:flex-row justify-between items-start md:items-end gap-8 pb-12 border-b-4 border-silver-bright/10 font-black">
-        <div className="space-y-4">
-          <div className="bg-rag-amber text-black px-4 py-1 text-xs uppercase tracking-widest inline-block shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] font-black">
-            Archive_Matrix v8.2
-          </div>
-          <h1 className="text-6xl md:text-8xl text-silver-bright uppercase tracking-tighter leading-none italic font-black">
-            Analytics <span className="text-transparent stroke-white" style={{ WebkitTextStroke: '2px var(--accent-silver-bright)' }}>Archive</span>
-          </h1>
-          <p className="text-sm font-mono text-silver/40 uppercase tracking-widest italic leading-relaxed">
-            HISTORICAL_BRIEFINGS // ENCRYPTED_DOSSIERS // AUDIT_FEED
-          </p>
-        </div>
-
-        <div className="flex items-center gap-6">
-          {/* Latest Report Export Button — compact icon-button, matches Refresh */}
-          <button
-            onClick={() =>
-              latestReadyReport &&
-              window.open(`${API_BASE}/task/${latestReadyReport.task_id}/report/pdf`, '_blank')
-            }
-            disabled={!latestReadyReport}
-            className="bg-charcoal border-4 border-black p-4 text-silver-bright shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] disabled:hover:translate-x-0 disabled:hover:translate-y-0"
-            title={latestReadyReport ? `Export latest briefing: ${latestReadyReport.name}` : 'No ready reports available'}
-            aria-label="Export latest briefing PDF"
-          >
-            <ReportIcon icon={Download01Icon} className="block" />
-          </button>
-
-          <button
-            onClick={fetchReports}
-            className="bg-charcoal border-4 border-black p-4 text-silver-bright shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all"
-            title="Refresh Archive"
-          >
-            <ReportIcon icon={Refresh01Icon} className="block" />
-          </button>
-        </div>
-      </header>
-
-      {/* Loading State */}
-      {loading && (
-        <div className="flex items-center justify-center py-40 gap-6">
-          <div className="animate-spin">
-            <ReportIcon icon={Refresh01Icon} size={48} className="text-silver/20" />
-          </div>
-          <p className="text-[10px] font-black text-silver/20 uppercase tracking-[0.4em] italic animate-pulse">
-            Retrieving Archive Data...
-          </p>
-        </div>
-      )}
-
-      {/* Error State */}
-      {!loading && error && (
-        <div className="border-4 border-rag-red bg-rag-red/10 p-8 flex items-center gap-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
-          <div className="space-y-1">
-            <p className="text-xs font-black text-rag-red uppercase tracking-widest">Archive_Retrieval_Failed</p>
-            <p className="text-[10px] font-mono text-silver/40 uppercase tracking-widest">{error}</p>
-          </div>
-          <button
-            onClick={fetchReports}
-            className="ml-auto bg-rag-red border-4 border-black px-6 py-3 text-[9px] font-black uppercase tracking-widest text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all"
-          >
-            Retry
-          </button>
-        </div>
-      )}
-
-      {!loading && !error && (
-        <>
-          {/* Metrics Row */}
-          <section className="grid grid-cols-2 md:grid-cols-4 gap-6">
-            {[
-              { label: 'Archived_Briefings', val: reports.length, color: 'bg-rag-blue', unit: 'FILES' },
-              { label: 'Surface_Nodes', val: summary.total_assets || 0, color: 'bg-rag-green', unit: 'NODES' },
-              { label: 'Aggregate_Anomalies', val: summary.total_findings || 0, color: 'bg-rag-red', unit: 'TRIGGERS' },
-              { label: 'Archive_Volume', val: '12.4', color: 'bg-rag-amber', unit: 'GB' },
-            ].map((m, i) => (
-              <div key={i} className={`${m.color} border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] flex flex-col justify-between h-40 group hover:-translate-y-1 transition-transform`}>
-                <div className="flex justify-between items-start">
-                  <span className="text-[10px] font-black text-black uppercase tracking-[0.2em] italic">{m.label}</span>
-                  <ReportIcon icon={Archive02Icon} className="text-black/20 group-hover:text-black transition-colors" />
-                </div>
-                <div className="flex items-baseline gap-2">
-                  <span className="text-5xl font-black text-black font-mono leading-none tracking-tighter">{m.val}</span>
-                  <span className="text-[10px] font-black text-black/40 uppercase tracking-widest">{m.unit}</span>
-                </div>
-              </div>
-            ))}
-          </section>
-
-          <div className="grid grid-cols-1 xl:grid-cols-4 gap-12">
-            {/* Filtration Sidebar */}
-            <aside className="xl:col-span-1 space-y-12">
-              <section className="bg-charcoal border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-8">
-                <div className="space-y-4">
-                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Classification_Isolation</label>
-                  <div className="grid grid-cols-1 gap-2">
-                    {['all', 'executive', 'technical', 'compliance'].map(t => (
-                      <button
-                        key={t}
-                        onClick={() => setSelectedType(t)}
-                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
-                          selectedType === t
-                            ? 'bg-rag-red border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
-                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
-                        }`}
-                      >
-                        {t} BRIEFINGS
-                        {selectedType === t && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="p-8 border-4 border-black border-dashed space-y-4 bg-charcoal-dark/50">
-                  <div className="flex items-center gap-3">
-                    <ReportIcon icon={KnightShieldIcon} className="text-rag-green" />
-                    <h4 className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic leading-none">Integrity_Secure</h4>
-                  </div>
-                  <p className="text-[10px] text-silver/40 font-black uppercase tracking-widest leading-loose italic">
-                    Dossiers are cryptographically hashed and recorded. Modifications are strictly detectable by the Enclave audit daemon.
-                  </p>
-                </div>
-              </section>
-            </aside>
-
-            {/* Ledger Section */}
-            <main className="xl:col-span-3 space-y-8">
-              <div className="flex flex-col md:flex-row justify-between items-end gap-6 border-b-4 border-black pb-8">
-                <h2 className="text-5xl font-black text-silver-bright italic uppercase tracking-tighter shrink-0">Historical_Ledger</h2>
-                <div className="h-0.5 bg-black/10 flex-1 mb-2 hidden md:block"></div>
-                <span className="text-[10px] font-mono text-silver/20 uppercase font-black mb-2 animate-pulse">{filteredReports.length} ENTRIES_LOCATED</span>
-              </div>
-
-              <AnimatePresence mode="popLayout">
-                <motion.div
-                  variants={containerVariants}
-                  initial="hidden"
-                  animate="visible"
-                  className="grid grid-cols-1 md:grid-cols-2 gap-8"
-                >
-                  {filteredReports.map((report) => (
-                    <motion.div
-                      key={report.id}
-                      variants={itemVariants}
-                      className="group bg-charcoal border-4 border-black p-10 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:shadow-[14px_14px_0px_0px_rgba(0,0,0,1)] transition-all relative overflow-hidden"
-                    >
-                      {/* Status Top Bar */}
-                      <div className={`absolute top-0 left-0 h-2 transition-all duration-500 ${
-                        report.status === 'ready' ? 'bg-rag-green w-full' :
-                          report.status === 'failed' ? 'bg-rag-red w-full' : 'bg-rag-amber w-1/2 animate-pulse'
-                      }`}></div>
-
-                      <div className="space-y-8 relative z-10">
-                        <div className="flex justify-between items-start">
-                          <span className={`px-2 py-0.5 text-[9px] font-black uppercase italic border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] ${
-                            report.type === 'executive' ? 'bg-silver-bright text-black' :
-                              report.type === 'compliance' ? 'bg-rag-green text-black' :
-                                'bg-rag-blue text-black'
-                          }`}>
-                            {report.type}_TYPE
-                          </span>
-                          <ReportIcon icon={File01Icon} size={24} className="text-silver/10 group-hover:text-silver-bright transition-colors" />
-                        </div>
-
-                        <div>
-                          <h3 className="text-3xl font-black text-silver-bright uppercase tracking-tighter italic leading-tight group-hover:text-rag-red transition-colors font-mono">
-                            {report.name}
-                          </h3>
-                          <div className="w-12 h-1 bg-silver-bright/10 mt-6 group-hover:w-full group-hover:bg-rag-red/30 transition-all duration-700"></div>
-                        </div>
-
-                        <div className="grid grid-cols-3 gap-6 py-6 border-y-2 border-black border-dashed">
-                          <div className="space-y-1">
-                            <span className="text-[8px] font-black text-silver/20 uppercase tracking-widest italic block">Findings</span>
-                            <span className="text-xs font-black font-mono text-silver-bright">{report.findings.toString().padStart(3, '0')}</span>
-                          </div>
-                          <div className="space-y-1 text-center">
-                            <span className="text-[8px] font-black text-silver/20 uppercase tracking-widest italic block">Assets</span>
-                            <span className="text-xs font-black font-mono text-silver-bright">{report.assets.toString().padStart(3, '0')}</span>
-                          </div>
-                          <div className="space-y-1 text-right">
-                            <span className="text-[8px] font-black text-silver/20 uppercase tracking-widest italic block">Pages</span>
-                            <span className="text-xs font-black font-mono text-silver-bright">{report.pages.toString().padStart(3, '0')}</span>
-                          </div>
-                        </div>
-
-                        <div className="flex justify-between items-end pt-2">
-                          <div className="space-y-1">
-                            <p className="text-[8px] font-black uppercase text-silver/20 tracking-[0.3em] italic leading-none">TIMESTAMP</p>
-                            <p className="text-[10px] font-mono text-silver-bright uppercase font-black">{formatDateLong(report.generated_at)}</p>
-                          </div>
-                          <div className="flex gap-4">
-                            <button
-                              onClick={() => navigate(`/task/${report.task_id}`)}
-                              className="bg-charcoal-dark border-4 border-black p-3 text-silver/20 group-hover:text-silver-bright group-hover:bg-black transition-all"
-                              title="View Briefing"
-                            >
-                              <ReportIcon icon={ScanEyeIcon} size={18} />
-                            </button>
-                            {exportFormats.map((format) => (
-                              <button
-                                key={format}
-                                onClick={() => {
-                                  if (report.status !== 'generating') {
-                                    window.open(`${API_BASE}/task/${report.task_id}/report/${format}`, '_blank')
-                                  }
-                                }}
-                                disabled={report.status === 'generating'}
-                                className="bg-charcoal-dark border-4 border-black px-3 py-2 text-[9px] font-black uppercase tracking-widest text-silver/20 group-hover:text-silver-bright group-hover:bg-black transition-all disabled:opacity-30 disabled:cursor-not-allowed disabled:group-hover:text-silver/20 disabled:group-hover:bg-charcoal-dark"
-                                title={report.status === 'generating' ? 'Export unavailable while report is generating' : `Download ${format.toUpperCase()}`}
-                              >
-                                {format}
-                              </button>
-                            ))}
-                          </div>
-                        </div>
-                      </div>
-
-                      {/* Background Hover Icon */}
-                      <div className="absolute -right-12 -bottom-12 opacity-0 group-hover:opacity-[0.03] transition-all duration-1000 transform scale-150 rotate-12 pointer-events-none">
-                        <div className="text-silver-bright">
-                          <ReportIcon
-                            icon={report.type === 'executive' ? Analytics02Icon : report.type === 'compliance' ? UserShield02Icon : ShieldUserIcon}
-                            size={200}
-                          />
-                        </div>
-                      </div>
-                    </motion.div>
-                  ))}
-
-                  {filteredReports.length === 0 && (
-                    <div className="col-span-2 py-40 border-4 border-dashed border-black/5 text-center flex flex-col items-center gap-8 bg-charcoal/30">
-                      <ReportIcon icon={Archive02Icon} size={120} className="text-silver/5" />
-                      <div className="space-y-2">
-                        <p className="text-xl font-black text-silver/20 uppercase tracking-[0.4em] italic">Archive Isolated</p>
-                        <p className="text-xs font-mono text-silver/10 uppercase tracking-widest leading-relaxed">System buffer awaiting briefing generation protocols</p>
-                      </div>
-                    </div>
-                  )}
-                </motion.div>
-              </AnimatePresence>
-            </main>
-          </div>
-        </>
-      )}
-
-      {/* Tactical Footer */}
-      <footer className="pt-24 border-t-4 border-black/5 flex flex-col md:flex-row justify-between items-center gap-8 text-[9px] font-black uppercase tracking-[0.5em] italic opacity-20">
-        <div className="flex items-center gap-6">
-          <div className="w-12 h-1 bg-silver/20"></div>
-          RESTRICTED_ACCESS_ENCLAVE // SYSTEM_ARCHIVE_DAEMON // {new Date().getFullYear()}
-        </div>
-        <div className="flex gap-4">
-          {[1, 2, 3, 4, 5, 6, 7, 8].map(i => <div key={i} className="w-2 h-2 bg-silver/20 rounded-full"></div>)}
-        </div>
-      </footer>
-    </div>
+function renderReports() {
+  return render(
+    <MemoryRouter>
+      <Reports />
+    </MemoryRouter>,
   )
 }
+
+// ── Loading state ─────────────────────────────────────────────────────────────
+
+describe('Reports — loading state', () => {
+
+  it('shows loading spinner while fetching', () => {
+    // Never resolves so the loading state stays visible
+    vi.mocked(getReports).mockReturnValue(new Promise(() => {}))
+    vi.mocked(getDashboardSummary).mockReturnValue(new Promise(() => {}))
+
+    renderReports()
+
+    expect(screen.getByText(/Retrieving Archive Data/i)).toBeInTheDocument()
+  })
+})
+
+// ── Error state ───────────────────────────────────────────────────────────────
+
+describe('Reports — error state', () => {
+  beforeEach(() => {
+    vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
+    vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
+    vi.mocked(getReports).mockClear()  // ← reset call count before each test
+  })
+  it('shows error message when fetch fails', async () => {
+    vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
+    vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
+
+    renderReports()
+
+    expect(await screen.findByText(/Archive_Retrieval_Failed/i)).toBeInTheDocument()
+    expect(screen.getByText(/Failed to fetch reports/i)).toBeInTheDocument()
+  })
+
+  it('shows a retry button when fetch fails', async () => {
+    vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
+    vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
+
+    renderReports()
+
+    expect(await screen.findByRole('button', { name: /Retry/i })).toBeInTheDocument()
+  })
+
+  it('retries fetch when retry button is clicked', async () => {
+    const user = userEvent.setup()
+    vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
+    vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
+
+    renderReports()
+
+    await screen.findByRole('button', { name: /Retry/i })
+    await user.click(screen.getByRole('button', { name: /Retry/i }))
+
+    // getReports should have been called twice — once on load, once on retry
+    expect(vi.mocked(getReports)).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+describe('Reports — empty state', () => {
+  beforeEach(() => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+  })
+
+  it('shows Archive Isolated when there are no reports at all', async () => {
+    renderReports()
+    expect(await screen.findByText(/Archive Isolated/i)).toBeInTheDocument()
+  })
+
+  it('shows Archive Isolated when filter returns no matching reports', async () => {
+    // Only a technical report exists
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
+    const user = userEvent.setup()
+
+    renderReports()
+
+    await screen.findByText(/Security Scan — example.com/i)
+
+    // Filter to executive — no executive reports exist
+    await user.click(screen.getByRole('button', { name: /executive briefings/i }))
+
+    expect(await screen.findByText(/Archive Isolated/i)).toBeInTheDocument()
+  })
+})
+
+// ── Header export button — latest ready report ────────────────────────────────
+
+describe('Reports — header export latest briefing button', () => {
+  beforeEach(() => {
+    openSpy.mockClear()
+  })
+
+  it('renders the Export Latest Briefing button', async () => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    expect(await screen.findByRole('button', { name: /export latest briefing pdf/i })).toBeInTheDocument()
+  })
+
+  it('is enabled when at least one ready report exists', async () => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    const btn = await screen.findByRole('button', { name: /export latest briefing pdf/i })
+    expect(btn).not.toBeDisabled()
+  })
+
+  it('opens the correct PDF URL for the latest ready report', async () => {
+    const user = userEvent.setup()
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    await user.click(await screen.findByRole('button', { name: /export latest briefing pdf/i }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`/task/${readyReport.task_id}/report/pdf`),
+      '_blank',
+    )
+  })
+
+  it('opens the NEWEST ready report when multiple ready reports exist', async () => {
+    // newerReadyReport has a later generated_at than readyReport
+    const user = userEvent.setup()
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport, newerReadyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    await user.click(await screen.findByRole('button', { name: /export latest briefing pdf/i }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`/task/${newerReadyReport.task_id}/report/pdf`),
+      '_blank',
+    )
+    expect(openSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining(`/task/${readyReport.task_id}/report/pdf`),
+      '_blank',
+    )
+  })
+
+  it('never calls the old /task/latest/report/pdf placeholder route', async () => {
+    const user = userEvent.setup()
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    await user.click(await screen.findByRole('button', { name: /export latest briefing pdf/i }))
+
+    expect(openSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('latest'),
+      expect.anything(),
+    )
+  })
+
+  it('is disabled when no ready reports exist', async () => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [generatingReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    const btn = await screen.findByRole('button', { name: /export latest briefing pdf/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('is disabled when the report list is empty', async () => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    const btn = await screen.findByRole('button', { name: /export latest briefing pdf/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('does not open a URL when the button is disabled', async () => {
+    const user = userEvent.setup()
+    vi.mocked(getReports).mockResolvedValue({ reports: [generatingReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    await screen.findByRole('button', { name: /export latest briefing pdf/i })
+    await user.click(screen.getByRole('button', { name: /export latest briefing pdf/i }))
+
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+
+  it('ignores failed reports when determining the latest ready report', async () => {
+    // Only failed report — button should be disabled
+    vi.mocked(getReports).mockResolvedValue({ reports: [failedReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    const btn = await screen.findByRole('button', { name: /export latest briefing pdf/i })
+    expect(btn).toBeDisabled()
+  })
+})
+
+// ── Export buttons — ready report ─────────────────────────────────────────────
+
+describe('Reports — export buttons on a ready report', () => {
+  beforeEach(() => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+    openSpy.mockClear()
+  })
+
+  it('shows PDF, HTML and CSV buttons for a ready report', async () => {
+    renderReports()
+
+    expect(await screen.findByRole('button', { name: /^pdf$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^html$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^csv$/i })).toBeInTheDocument()
+  })
+
+  it('export buttons are enabled for a ready report', async () => {
+    renderReports()
+
+    await screen.findByRole('button', { name: /^pdf$/i })
+
+    expect(screen.getByRole('button', { name: /^pdf$/i })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /^html$/i })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /^csv$/i })).not.toBeDisabled()
+  })
+
+  it('clicking PDF opens the correct backend URL', async () => {
+    const user = userEvent.setup()
+    renderReports()
+
+    await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`/task/${readyReport.task_id}/report/pdf`),
+      '_blank',
+    )
+  })
+
+  it('clicking HTML opens the correct backend URL', async () => {
+    const user = userEvent.setup()
+    renderReports()
+
+    await user.click(await screen.findByRole('button', { name: /^html$/i }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`/task/${readyReport.task_id}/report/html`),
+      '_blank',
+    )
+  })
+
+  it('clicking CSV opens the correct backend URL', async () => {
+    const user = userEvent.setup()
+    renderReports()
+
+    await user.click(await screen.findByRole('button', { name: /^csv$/i }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`/task/${readyReport.task_id}/report/csv`),
+      '_blank',
+    )
+  })
+
+  it('does not use the old placeholder latest-report route', async () => {
+    const user = userEvent.setup()
+    renderReports()
+
+    await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
+
+    expect(openSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('latest'),
+      expect.anything(),
+    )
+  })
+})
+
+// ── Export buttons — non-ready reports ───────────────────────────────────────
+
+describe('Reports — export buttons on a generating report', () => {
+  beforeEach(() => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [generatingReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+    openSpy.mockClear()
+  })
+
+  it('export buttons are disabled when report is generating', async () => {
+    renderReports()
+
+    await screen.findByRole('button', { name: /^pdf$/i })
+
+    expect(screen.getByRole('button', { name: /^pdf$/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^html$/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^csv$/i })).toBeDisabled()
+  })
+
+  it('clicking a disabled button does not open any URL', async () => {
+    const user = userEvent.setup()
+    renderReports()
+
+    await screen.findByRole('button', { name: /^pdf$/i })
+    await user.click(screen.getByRole('button', { name: /^pdf$/i }))
+
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('Reports — export buttons on a failed report', () => {
+  beforeEach(() => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [failedReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+    openSpy.mockClear()
+  })
+
+  it('export buttons are enabled for a failed report since backend supports it', async () => {
+    renderReports()
+
+    await screen.findByRole('button', { name: /^pdf$/i })
+
+    expect(screen.getByRole('button', { name: /^pdf$/i })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /^html$/i })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /^csv$/i })).not.toBeDisabled()
+  })
+})
+
+// ── Filter ────────────────────────────────────────────────────────────────────
+
+describe('Reports — type filter', () => {
+  beforeEach(() => {
+    vi.mocked(getReports).mockResolvedValue({
+      reports: [readyReport, generatingReport],
+    })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+  })
+
+  it('shows all reports when All filter is selected', async () => {
+    renderReports()
+
+    expect(await screen.findByText(/Security Scan — example.com/i)).toBeInTheDocument()
+    expect(screen.getByText(/Security Scan — staging.example.com/i)).toBeInTheDocument()
+  })
+
+  it('shows only matching reports when a type filter is selected', async () => {
+    const user = userEvent.setup()
+    renderReports()
+
+    await screen.findByText(/Security Scan — example.com/i)
+
+    // Filter to executive — only generatingReport is executive
+    await user.click(screen.getByRole('button', { name: /executive briefings/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Security Scan — example.com/i)).not.toBeInTheDocument()
+    })
+    expect(screen.getByText(/Security Scan — staging.example.com/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/testing/unit/pages/Reports.test.tsx
+++ b/frontend/testing/unit/pages/Reports.test.tsx
@@ -27,6 +27,18 @@ const readyReport = {
   pages: 12,
 }
 
+const newerReadyReport = {
+  id: 'report-4',
+  task_id: 'task-jkl-012',
+  name: 'Security Scan — newer.example.com',
+  type: 'executive',
+  generated_at: '2026-05-15T09:00:00Z',
+  status: 'ready',
+  findings: 2,
+  assets: 1,
+  pages: 8,
+}
+
 const generatingReport = {
   id: 'report-2',
   task_id: 'task-def-456',
@@ -92,6 +104,7 @@ describe('Reports — error state', () => {
     vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
     vi.mocked(getReports).mockClear()  // ← reset call count before each test
   })
+
   it('shows error message when fetch fails', async () => {
     vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
     vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
@@ -152,6 +165,127 @@ describe('Reports — empty state', () => {
     await user.click(screen.getByRole('button', { name: /executive briefings/i }))
 
     expect(await screen.findByText(/Archive Isolated/i)).toBeInTheDocument()
+  })
+})
+
+// ── Header export button — latest ready report ────────────────────────────────
+
+describe('Reports — header export latest briefing button', () => {
+  beforeEach(() => {
+    openSpy.mockClear()
+  })
+
+  it('renders the Export Latest Briefing button', async () => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    expect(
+      await screen.findByRole('button', { name: /export latest briefing pdf/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('is enabled when at least one ready report exists', async () => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    const btn = await screen.findByRole('button', { name: /export latest briefing pdf/i })
+    expect(btn).not.toBeDisabled()
+  })
+
+  it('opens the correct PDF URL for the latest ready report', async () => {
+    const user = userEvent.setup()
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    await user.click(await screen.findByRole('button', { name: /export latest briefing pdf/i }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`/task/${readyReport.task_id}/report/pdf`),
+      '_blank',
+    )
+  })
+
+  it('opens the NEWEST ready report when multiple ready reports exist', async () => {
+    const user = userEvent.setup()
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport, newerReadyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    await user.click(await screen.findByRole('button', { name: /export latest briefing pdf/i }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`/task/${newerReadyReport.task_id}/report/pdf`),
+      '_blank',
+    )
+    expect(openSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining(`/task/${readyReport.task_id}/report/pdf`),
+      '_blank',
+    )
+  })
+
+  it('never calls the old /task/latest/report/pdf placeholder route', async () => {
+    const user = userEvent.setup()
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    await user.click(await screen.findByRole('button', { name: /export latest briefing pdf/i }))
+
+    expect(openSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('latest'),
+      expect.anything(),
+    )
+  })
+
+  it('is disabled when no ready reports exist', async () => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [generatingReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    const btn = await screen.findByRole('button', { name: /export latest briefing pdf/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('is disabled when the report list is empty', async () => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    const btn = await screen.findByRole('button', { name: /export latest briefing pdf/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('does not open a URL when the button is disabled', async () => {
+    const user = userEvent.setup()
+    vi.mocked(getReports).mockResolvedValue({ reports: [generatingReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    await screen.findByRole('button', { name: /export latest briefing pdf/i })
+    await user.click(screen.getByRole('button', { name: /export latest briefing pdf/i }))
+
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+
+  it('ignores failed reports when determining the latest ready report', async () => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [failedReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+
+    renderReports()
+
+    const btn = await screen.findByRole('button', { name: /export latest briefing pdf/i })
+    expect(btn).toBeDisabled()
   })
 })
 


### PR DESCRIPTION
## Description
<!-- Provide a clear description of the changes in this PR. -->

## Related Issues
<!-- Link any related issues using #issue-number. -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Provide instructions so we can reproduce. -->

## Checklist
- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

Closes #79

   - Adds Export Latest Briefing button to Reports header
   - Computes latestReadyReport with useMemo + reduce (no mutation, memoized)
   - Button styled as compact icon-button matching existing Refresh button
   - All 76 tests passing