### PR TITLE
Add clear search button to Findings filter bar

### DIFF
--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -397,16 +397,36 @@ export default function Findings() {
         <section className="border-2 border-black bg-charcoal/95 p-4 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] backdrop-blur lg:sticky lg:top-4 lg:z-20">
           <div className="grid gap-4">
             <div className="grid gap-4 2xl:grid-cols-[minmax(320px,1fr)_auto] 2xl:items-end">
-              <div className="space-y-2">
-                <label className={filterLabelClass}>Search</label>
-                <input
-                  type="text"
-                  value={searchQuery}
-                  onChange={(event) => setSearchQuery(event.target.value)}
-                  placeholder="Title, target, CVE, remediation..."
-                  className={`${filterControlClass} px-4 placeholder:text-silver/20`}
-                />
-              </div>
+             <div className="space-y-2">
+  <label className={filterLabelClass}>Search</label>
+
+  <div className="relative">
+    <input
+      type="text"
+      value={searchQuery}
+      onChange={(event) => setSearchQuery(event.target.value)}
+      placeholder="Title, target, CVE, remediation..."
+      className={`${filterControlClass} px-4 pr-12 placeholder:text-silver/20`}
+    />
+
+    {searchQuery.trim() && (
+      <button
+        type="button"
+        aria-label="Clear search"
+        onClick={() => setSearchQuery('')}
+        className="
+          absolute right-3 top-1/2
+          -translate-y-1/2
+          text-silver/50
+          hover:text-silver-bright
+          transition
+        "
+      >
+        ✕
+      </button>
+    )}
+  </div>
+</div>
 
               <div className="flex flex-wrap gap-2 pb-2 sm:pb-0 2xl:max-w-[760px] 2xl:justify-end">
                 <button


### PR DESCRIPTION
## Description

Added a clear-search button to the Findings filter bar. The button appears only when the search input contains text and clears the search query when clicked, restoring the unfiltered findings list. Also included an accessible label for keyboard and screen-reader support.

## Related Issues

Closes #103

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## How Has This Been Tested?

* Ran the frontend locally using:

  ```bash
  npm run dev
  ```
* Verified that:

  * Clear button appears only when search input has text.
  * Clicking the button clears the input and restores all findings.
  * Existing severity and filter behavior continues to work.
  * Keyboard navigation and accessibility label function correctly.

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.

##Screenshot :
<img width="960" height="483" alt="image" src="https://github.com/user-attachments/assets/d0df8886-aab9-4c62-aa5e-0fa62948d552" />
