### PR TITLE
Add single‑plugin validation command

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -14,101 +14,100 @@ Last synced: 2026-05-11
 
 ## Safety Levels
 
-| Level       | Meaning                                                                                                      |
-| ----------- | ------------------------------------------------------------------------------------------------------------ |
-| `safe`      | Passive or low-impact discovery that is less likely to modify target state.                                  |
-| `intrusive` | Active probing, crawling, brute-force checks, or remote interaction that can generate noticeable traffic.    |
-| `exploit`   | Validation or exploitation workflows that can extract data, change state, or create higher operational risk. |
+| Level | Meaning |
+| --- | --- |
+| `safe` | Passive or low-impact discovery that is less likely to modify target state. |
+| `intrusive` | Active probing, crawling, brute-force checks, or remote interaction that can generate noticeable traffic. |
+| `exploit` | Validation or exploitation workflows that can extract data, change state, or create higher operational risk. |
 
 Only run scans against systems you own or are explicitly authorized to assess.
 
 ## Category Summary
 
-| Category        | Count |
-| --------------- | ----: |
-| `recon`         |    19 |
-| `vulnerability` |    12 |
-| `robots`        |     5 |
-| `web`           |     5 |
-| `exploit`       |     5 |
-| `network`       |     3 |
-| `expert`        |     3 |
-| `code`          |     2 |
-| `forensics`     |     2 |
-| `utils`         |     2 |
-| `execution`     |     1 |
-| `security`      |     1 |
+| Category | Count |
+| --- | ---: |
+| `recon` | 19 |
+| `vulnerability` | 12 |
+| `robots` | 5 |
+| `web` | 5 |
+| `exploit` | 5 |
+| `network` | 3 |
+| `expert` | 3 |
+| `code` | 2 |
+| `forensics` | 2 |
+| `utils` | 2 |
+| `execution` | 1 |
+| `security` | 1 |
 
 ## Plugin Index
 
-| Plugin                      | ID                       | Category        | Safety      | Primary Binary | Summary                                                                   |
-| --------------------------- | ------------------------ | --------------- | ----------- | -------------- | ------------------------------------------------------------------------- |
-| Amass                       | `amass`                  | `recon`         | `safe`      | `amass`        | Deep attack-surface mapping and subdomain discovery.                      |
-| API Scanner                 | `api_scanner`            | `vulnerability` | `intrusive` | `nuclei`       | Check for specific API vulnerabilities (REST and GraphQL).                |
-| Cloud Scanner               | `cloud_scanner`          | `vulnerability` | `intrusive` | `python3`      | Cloud infrastructure security (AWS/GCP/Azure).                            |
-| S3 / Blob Auditor           | `cloud_storage_auditor`  | `vulnerability` | `safe`      | `uncover`      | Find misconfigured S3 buckets and exposed cloud storage.                  |
-| Code Analyzer (Bandit)      | `code_analyzer`          | `code`          | `safe`      | `bandit`       | Static analysis for Python code.                                          |
-| Container Scan (Trivy)      | `container_scanner`      | `network`       | `safe`      | `trivy`        | Scan Docker images and registries for known vulnerabilities.              |
-| Crawler                     | `crawler`                | `robots`        | `intrusive` | `katana`       | Recursive web crawler for link discovery.                                 |
-| Directory Discovery         | `dir_discovery`          | `web`           | `intrusive` | `ffuf`         | Discover hidden directories and files on web servers.                     |
-| DNS Reconnaissance          | `dns_enum`               | `recon`         | `safe`      | `dnsrecon`     | Enumerate DNS records and configurations.                                 |
-| dnsx                        | `dnsx`                   | `recon`         | `safe`      | `dnsx`         | DNS resolution and wildcard-aware validation at scale.                    |
-| Domain Finder               | `domain-finder`          | `recon`         | `safe`      | `amass`        | Discover additional domain names of target organization.                  |
-| Drupal Security Scan        | `droopescan`             | `vulnerability` | `intrusive` | `droopescan`   | Drupal-focused CMS scanner for version and surface enumeration.           |
-| Payload Fuzzer              | `fuzzer`                 | `robots`        | `exploit`   | `python3`      | Autonomously fuzz target fields with massive dictionaries.                |
-| Google Hacking              | `google-dorking`         | `recon`         | `safe`      | `python3`      | Find publicly indexed information about target.                           |
-| Password Recovery Audit     | `hashcat`                | `expert`        | `exploit`   | `hashcat`      | Password recovery and hash audit workflow.                                |
-| HTTP Inspector              | `http_inspector`         | `web`           | `safe`      | `curl`         | Inspect HTTP/HTTPS endpoints for headers, cookies, and TLS configuration. |
-| HTTP Request Logger         | `http_request_logger`    | `exploit`       | `intrusive` | `httpx`        | Handle incoming HTTP requests and record data.                            |
-| httpx                       | `httpx`                  | `recon`         | `safe`      | `httpx`        | Live host probing with status, title, and technology fingerprinting.      |
-| IaC Scanner (Checkov)       | `iac_scanner`            | `vulnerability` | `safe`      | `python3`      | Analyze Terraform and CloudFormation code for flaws.                      |
-| ICMP Ping                   | `icmp_ping`              | `utils`         | `safe`      | `ping`         | Check if a server is live and responds to ICMP Echo requests.             |
-| Joomla Security Scan        | `joomscan`               | `vulnerability` | `intrusive` | `joomscan`     | Joomla security scanner for version and common weakness discovery.        |
-| Katana                      | `katana`                 | `recon`         | `intrusive` | `katana`       | Web crawling for endpoint and route discovery.                            |
-| K8s Scanner                 | `kubernetes_scanner`     | `vulnerability` | `intrusive` | `python3`      | Kubernetes cluster security assessment.                                   |
-| Exploitation Connector      | `metasploit`             | `expert`        | `exploit`   | `msfconsole`   | Metasploit connector for controlled exploit-module execution.             |
-| Network Scanner             | `network_scanner`        | `vulnerability` | `intrusive` | `nmap`         | Check for 10,000+ CVEs and server misconfigurations.                      |
-| Nikto                       | `nikto`                  | `web`           | `intrusive` | `nikto`        | Web server vulnerability scanner powered by the Nikto CLI.                |
-| Network Scanning            | `nmap`                   | `network`       | `safe`      | `nmap`         | Network discovery and port scanning tool.                                 |
-| Template Vulnerability Scan | `nuclei`                 | `web`           | `intrusive` | `nuclei`       | Fast and customizable vulnerability scanner.                              |
-| Password Auditor            | `password_auditor`       | `vulnerability` | `intrusive` | `python3`      | Discover weak credentials in network services and web apps.               |
-| People Hunter               | `people-email-discovery` | `recon`         | `safe`      | `theHarvester` | Discover email addresses and social media profiles.                       |
-| Port Scanner                | `port-scanner`           | `recon`         | `intrusive` | `nmap`         | Detect open ports and fingerprint services.                               |
-| Advanced Network Recon      | `scapy_recon`            | `network`       | `safe`      | `python3`      | Advanced network probing using Scapy.                                     |
-| Secret Scanner              | `secret_scanner`         | `code`          | `safe`      | `gitleaks`     | Scan directories for hardcoded secrets.                                   |
-| Sharepoint Scanner          | `sharepoint_scanner`     | `vulnerability` | `intrusive` | `nuclei`       | Check SharePoint for security issues, misconfigs, and more.               |
-| Sitemap Generator           | `sitemap_gen`            | `robots`        | `intrusive` | `katana`       | Build complete XML sitemaps by autonomously parsing targets.              |
-| Sniper: Auto-Exploiter      | `sniper`                 | `exploit`       | `exploit`   | `python3`      | Validate critical CVEs by automatic exploitation.                         |
-| Spider                      | `spider`                 | `robots`        | `intrusive` | `katana`       | Advanced web spider with JS execution support.                            |
-| SQL Injection Feasibility   | `sqli_checker`           | `expert`        | `intrusive` | `ghauri`       | SQL injection feasibility scanner powered by Ghauri.                      |
-| SQLi Exploiter              | `sqli_exploiter`         | `exploit`       | `exploit`   | `sqlmap`       | Exploit SQL injection in web apps to extract data.                        |
-| SQL Injection Testing       | `sqlmap`                 | `web`           | `exploit`   | `sqlmap`       | Automatic SQL injection and database takeover tool.                       |
-| SSH Runner                  | `ssh_runner`             | `execution`     | `intrusive` | `ssh`          | Remote command execution via SSH.                                         |
-| Subdomain Finder            | `subdomain-finder`       | `recon`         | `safe`      | `subfinder`    | Discover subdomains of a domain.                                          |
-| Subdomain Scanner           | `subdomain_discovery`    | `recon`         | `safe`      | `subfinder`    | Enumerate subdomains using passive sources.                               |
-| Subdomain Takeover          | `subdomain_takeover`     | `exploit`       | `intrusive` | `subfinder`    | Discover dangling DNS entries pointing to external services.              |
-| Subfinder                   | `subfinder`              | `recon`         | `safe`      | `subfinder`    | Fast passive subdomain enumeration.                                       |
-| theHarvester                | `theharvester`           | `recon`         | `safe`      | `theHarvester` | OSINT collection for emails, domains, and hosts.                          |
-| TLS Security Analysis       | `tls_inspector`          | `security`      | `safe`      | `openssl`      | Examine TLS/SSL certificates and cipher configurations.                   |
-| Uncover                     | `uncover`                | `recon`         | `safe`      | `uncover`      | Discover internet-exposed assets from external search sources.            |
-| URL Fuzzer                  | `url-fuzzer-2`           | `recon`         | `intrusive` | `ffuf`         | Discover hidden files and directories.                                    |
-| urlfinder                   | `urlfinder`              | `recon`         | `safe`      | `urlfinder`    | Passive historical URL collection.                                        |
-| Virtual Hosts Finder        | `virtual-host-finder`    | `recon`         | `intrusive` | `ffuf`         | Find multiple websites hosted on the same server.                         |
-| Volatility                  | `volatility`             | `forensics`     | `intrusive` | `volatility3`  | Memory forensics workflow using Volatility 3 plugins.                     |
-| WAF Detector                | `waf-detection`          | `recon`         | `safe`      | `wafw00f`      | Fingerprint the Web Application Firewall behind target app.               |
-| WAF Detector                | `waf_detector`           | `robots`        | `safe`      | `wafw00f`      | Automatically identify Web Application Firewalls protecting targets.      |
-| Website Recon               | `website-recon-2`        | `recon`         | `safe`      | `httpx`        | Fingerprint web technologies of target website.                           |
-| Domain Registration Lookup  | `whois_lookup`           | `utils`         | `safe`      | `python3`      | Domain registration information lookup.                                   |
-| WordPress Security Scan     | `wpscan`                 | `vulnerability` | `intrusive` | `wpscan`       | WordPress security scanner for plugin, theme, and core risk visibility.   |
-| XSS Exploiter               | `xss_exploiter`          | `exploit`       | `exploit`   | `python3`      | Exploit XSS in real-life attacks to extract cookies and data.             |
-| Binary Signature Scan       | `yara_scan`              | `forensics`     | `intrusive` | `yara`         | Binary and file-system signature matching with YARA rules.                |
-| DAST Web Proxy (ZAP)        | `zap_scanner`            | `vulnerability` | `exploit`   | `python3`      | Dynamic proxy spidering and payload injection.                            |
+| Plugin | ID | Category | Safety | Primary Binary | Summary |
+| --- | --- | --- | --- | --- | --- |
+| Amass | `amass` | `recon` | `safe` | `amass` | Deep attack-surface mapping and subdomain discovery. |
+| API Scanner | `api_scanner` | `vulnerability` | `intrusive` | `nuclei` | Check for specific API vulnerabilities (REST and GraphQL). |
+| Cloud Scanner | `cloud_scanner` | `vulnerability` | `intrusive` | `python3` | Cloud infrastructure security (AWS/GCP/Azure). |
+| S3 / Blob Auditor | `cloud_storage_auditor` | `vulnerability` | `safe` | `uncover` | Find misconfigured S3 buckets and exposed cloud storage. |
+| Code Analyzer (Bandit) | `code_analyzer` | `code` | `safe` | `bandit` | Static analysis for Python code. |
+| Container Scan (Trivy) | `container_scanner` | `network` | `safe` | `trivy` | Scan Docker images and registries for known vulnerabilities. |
+| Crawler | `crawler` | `robots` | `intrusive` | `katana` | Recursive web crawler for link discovery. |
+| Directory Discovery | `dir_discovery` | `web` | `intrusive` | `ffuf` | Discover hidden directories and files on web servers. |
+| DNS Reconnaissance | `dns_enum` | `recon` | `safe` | `dnsrecon` | Enumerate DNS records and configurations. |
+| dnsx | `dnsx` | `recon` | `safe` | `dnsx` | DNS resolution and wildcard-aware validation at scale. |
+| Domain Finder | `domain-finder` | `recon` | `safe` | `amass` | Discover additional domain names of target organization. |
+| Drupal Security Scan | `droopescan` | `vulnerability` | `intrusive` | `droopescan` | Drupal-focused CMS scanner for version and surface enumeration. |
+| Payload Fuzzer | `fuzzer` | `robots` | `exploit` | `python3` | Autonomously fuzz target fields with massive dictionaries. |
+| Google Hacking | `google-dorking` | `recon` | `safe` | `python3` | Find publicly indexed information about target. |
+| Password Recovery Audit | `hashcat` | `expert` | `exploit` | `hashcat` | Password recovery and hash audit workflow. |
+| HTTP Inspector | `http_inspector` | `web` | `safe` | `curl` | Inspect HTTP/HTTPS endpoints for headers, cookies, and TLS configuration. |
+| HTTP Request Logger | `http_request_logger` | `exploit` | `intrusive` | `httpx` | Handle incoming HTTP requests and record data. |
+| httpx | `httpx` | `recon` | `safe` | `httpx` | Live host probing with status, title, and technology fingerprinting. |
+| IaC Scanner (Checkov) | `iac_scanner` | `vulnerability` | `safe` | `python3` | Analyze Terraform and CloudFormation code for flaws. |
+| ICMP Ping | `icmp_ping` | `utils` | `safe` | `ping` | Check if a server is live and responds to ICMP Echo requests. |
+| Joomla Security Scan | `joomscan` | `vulnerability` | `intrusive` | `joomscan` | Joomla security scanner for version and common weakness discovery. |
+| Katana | `katana` | `recon` | `intrusive` | `katana` | Web crawling for endpoint and route discovery. |
+| K8s Scanner | `kubernetes_scanner` | `vulnerability` | `intrusive` | `python3` | Kubernetes cluster security assessment. |
+| Exploitation Connector | `metasploit` | `expert` | `exploit` | `msfconsole` | Metasploit connector for controlled exploit-module execution. |
+| Network Scanner | `network_scanner` | `vulnerability` | `intrusive` | `nmap` | Check for 10,000+ CVEs and server misconfigurations. |
+| Nikto | `nikto` | `web` | `intrusive` | `nikto` | Web server vulnerability scanner powered by the Nikto CLI. |
+| Network Scanning | `nmap` | `network` | `safe` | `nmap` | Network discovery and port scanning tool. |
+| Template Vulnerability Scan | `nuclei` | `web` | `intrusive` | `nuclei` | Fast and customizable vulnerability scanner. |
+| Password Auditor | `password_auditor` | `vulnerability` | `intrusive` | `python3` | Discover weak credentials in network services and web apps. |
+| People Hunter | `people-email-discovery` | `recon` | `safe` | `theHarvester` | Discover email addresses and social media profiles. |
+| Port Scanner | `port-scanner` | `recon` | `intrusive` | `nmap` | Detect open ports and fingerprint services. |
+| Advanced Network Recon | `scapy_recon` | `network` | `safe` | `python3` | Advanced network probing using Scapy. |
+| Secret Scanner | `secret_scanner` | `code` | `safe` | `gitleaks` | Scan directories for hardcoded secrets. |
+| Sharepoint Scanner | `sharepoint_scanner` | `vulnerability` | `intrusive` | `nuclei` | Check SharePoint for security issues, misconfigs, and more. |
+| Sitemap Generator | `sitemap_gen` | `robots` | `intrusive` | `katana` | Build complete XML sitemaps by autonomously parsing targets. |
+| Sniper: Auto-Exploiter | `sniper` | `exploit` | `exploit` | `python3` | Validate critical CVEs by automatic exploitation. |
+| Spider | `spider` | `robots` | `intrusive` | `katana` | Advanced web spider with JS execution support. |
+| SQL Injection Feasibility | `sqli_checker` | `expert` | `intrusive` | `ghauri` | SQL injection feasibility scanner powered by Ghauri. |
+| SQLi Exploiter | `sqli_exploiter` | `exploit` | `exploit` | `sqlmap` | Exploit SQL injection in web apps to extract data. |
+| SQL Injection Testing | `sqlmap` | `web` | `exploit` | `sqlmap` | Automatic SQL injection and database takeover tool. |
+| SSH Runner | `ssh_runner` | `execution` | `intrusive` | `ssh` | Remote command execution via SSH. |
+| Subdomain Finder | `subdomain-finder` | `recon` | `safe` | `subfinder` | Discover subdomains of a domain. |
+| Subdomain Scanner | `subdomain_discovery` | `recon` | `safe` | `subfinder` | Enumerate subdomains using passive sources. |
+| Subdomain Takeover | `subdomain_takeover` | `exploit` | `intrusive` | `subfinder` | Discover dangling DNS entries pointing to external services. |
+| Subfinder | `subfinder` | `recon` | `safe` | `subfinder` | Fast passive subdomain enumeration. |
+| theHarvester | `theharvester` | `recon` | `safe` | `theHarvester` | OSINT collection for emails, domains, and hosts. |
+| TLS Security Analysis | `tls_inspector` | `security` | `safe` | `openssl` | Examine TLS/SSL certificates and cipher configurations. |
+| Uncover | `uncover` | `recon` | `safe` | `uncover` | Discover internet-exposed assets from external search sources. |
+| URL Fuzzer | `url-fuzzer-2` | `recon` | `intrusive` | `ffuf` | Discover hidden files and directories. |
+| urlfinder | `urlfinder` | `recon` | `safe` | `urlfinder` | Passive historical URL collection. |
+| Virtual Hosts Finder | `virtual-host-finder` | `recon` | `intrusive` | `ffuf` | Find multiple websites hosted on the same server. |
+| Volatility | `volatility` | `forensics` | `intrusive` | `volatility3` | Memory forensics workflow using Volatility 3 plugins. |
+| WAF Detector | `waf-detection` | `recon` | `safe` | `wafw00f` | Fingerprint the Web Application Firewall behind target app. |
+| WAF Detector | `waf_detector` | `robots` | `safe` | `wafw00f` | Automatically identify Web Application Firewalls protecting targets. |
+| Website Recon | `website-recon-2` | `recon` | `safe` | `httpx` | Fingerprint web technologies of target website. |
+| Domain Registration Lookup | `whois_lookup` | `utils` | `safe` | `python3` | Domain registration information lookup. |
+| WordPress Security Scan | `wpscan` | `vulnerability` | `intrusive` | `wpscan` | WordPress security scanner for plugin, theme, and core risk visibility. |
+| XSS Exploiter | `xss_exploiter` | `exploit` | `exploit` | `python3` | Exploit XSS in real-life attacks to extract cookies and data. |
+| Binary Signature Scan | `yara_scan` | `forensics` | `intrusive` | `yara` | Binary and file-system signature matching with YARA rules. |
+| DAST Web Proxy (ZAP) | `zap_scanner` | `vulnerability` | `exploit` | `python3` | Dynamic proxy spidering and payload injection. |
 
 ## Maintenance Notes
 
 - If a plugin is added, renamed, or removed, update this file from the plugin metadata rather than editing counts by hand.
 - Prefer keeping `id`, category, safety level, and dependency names aligned with each plugin's `metadata.json`.
-
 ## Checksum Maintenance
 
 Plugin metadata files include integrity checksums. If you edit a plugin's
@@ -133,7 +132,6 @@ python scripts/refresh_plugin_checksum.py --all --dry-run
 ```
 
 Run this script any time you:
-
 - Edit a plugin's `metadata.json` fields
 - Edit a plugin's `parser.py`
 - Add a new plugin

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -14,100 +14,101 @@ Last synced: 2026-05-11
 
 ## Safety Levels
 
-| Level | Meaning |
-| --- | --- |
-| `safe` | Passive or low-impact discovery that is less likely to modify target state. |
-| `intrusive` | Active probing, crawling, brute-force checks, or remote interaction that can generate noticeable traffic. |
-| `exploit` | Validation or exploitation workflows that can extract data, change state, or create higher operational risk. |
+| Level       | Meaning                                                                                                      |
+| ----------- | ------------------------------------------------------------------------------------------------------------ |
+| `safe`      | Passive or low-impact discovery that is less likely to modify target state.                                  |
+| `intrusive` | Active probing, crawling, brute-force checks, or remote interaction that can generate noticeable traffic.    |
+| `exploit`   | Validation or exploitation workflows that can extract data, change state, or create higher operational risk. |
 
 Only run scans against systems you own or are explicitly authorized to assess.
 
 ## Category Summary
 
-| Category | Count |
-| --- | ---: |
-| `recon` | 19 |
-| `vulnerability` | 12 |
-| `robots` | 5 |
-| `web` | 5 |
-| `exploit` | 5 |
-| `network` | 3 |
-| `expert` | 3 |
-| `code` | 2 |
-| `forensics` | 2 |
-| `utils` | 2 |
-| `execution` | 1 |
-| `security` | 1 |
+| Category        | Count |
+| --------------- | ----: |
+| `recon`         |    19 |
+| `vulnerability` |    12 |
+| `robots`        |     5 |
+| `web`           |     5 |
+| `exploit`       |     5 |
+| `network`       |     3 |
+| `expert`        |     3 |
+| `code`          |     2 |
+| `forensics`     |     2 |
+| `utils`         |     2 |
+| `execution`     |     1 |
+| `security`      |     1 |
 
 ## Plugin Index
 
-| Plugin | ID | Category | Safety | Primary Binary | Summary |
-| --- | --- | --- | --- | --- | --- |
-| Amass | `amass` | `recon` | `safe` | `amass` | Deep attack-surface mapping and subdomain discovery. |
-| API Scanner | `api_scanner` | `vulnerability` | `intrusive` | `nuclei` | Check for specific API vulnerabilities (REST and GraphQL). |
-| Cloud Scanner | `cloud_scanner` | `vulnerability` | `intrusive` | `python3` | Cloud infrastructure security (AWS/GCP/Azure). |
-| S3 / Blob Auditor | `cloud_storage_auditor` | `vulnerability` | `safe` | `uncover` | Find misconfigured S3 buckets and exposed cloud storage. |
-| Code Analyzer (Bandit) | `code_analyzer` | `code` | `safe` | `bandit` | Static analysis for Python code. |
-| Container Scan (Trivy) | `container_scanner` | `network` | `safe` | `trivy` | Scan Docker images and registries for known vulnerabilities. |
-| Crawler | `crawler` | `robots` | `intrusive` | `katana` | Recursive web crawler for link discovery. |
-| Directory Discovery | `dir_discovery` | `web` | `intrusive` | `ffuf` | Discover hidden directories and files on web servers. |
-| DNS Reconnaissance | `dns_enum` | `recon` | `safe` | `dnsrecon` | Enumerate DNS records and configurations. |
-| dnsx | `dnsx` | `recon` | `safe` | `dnsx` | DNS resolution and wildcard-aware validation at scale. |
-| Domain Finder | `domain-finder` | `recon` | `safe` | `amass` | Discover additional domain names of target organization. |
-| Drupal Security Scan | `droopescan` | `vulnerability` | `intrusive` | `droopescan` | Drupal-focused CMS scanner for version and surface enumeration. |
-| Payload Fuzzer | `fuzzer` | `robots` | `exploit` | `python3` | Autonomously fuzz target fields with massive dictionaries. |
-| Google Hacking | `google-dorking` | `recon` | `safe` | `python3` | Find publicly indexed information about target. |
-| Password Recovery Audit | `hashcat` | `expert` | `exploit` | `hashcat` | Password recovery and hash audit workflow. |
-| HTTP Inspector | `http_inspector` | `web` | `safe` | `curl` | Inspect HTTP/HTTPS endpoints for headers, cookies, and TLS configuration. |
-| HTTP Request Logger | `http_request_logger` | `exploit` | `intrusive` | `httpx` | Handle incoming HTTP requests and record data. |
-| httpx | `httpx` | `recon` | `safe` | `httpx` | Live host probing with status, title, and technology fingerprinting. |
-| IaC Scanner (Checkov) | `iac_scanner` | `vulnerability` | `safe` | `python3` | Analyze Terraform and CloudFormation code for flaws. |
-| ICMP Ping | `icmp_ping` | `utils` | `safe` | `ping` | Check if a server is live and responds to ICMP Echo requests. |
-| Joomla Security Scan | `joomscan` | `vulnerability` | `intrusive` | `joomscan` | Joomla security scanner for version and common weakness discovery. |
-| Katana | `katana` | `recon` | `intrusive` | `katana` | Web crawling for endpoint and route discovery. |
-| K8s Scanner | `kubernetes_scanner` | `vulnerability` | `intrusive` | `python3` | Kubernetes cluster security assessment. |
-| Exploitation Connector | `metasploit` | `expert` | `exploit` | `msfconsole` | Metasploit connector for controlled exploit-module execution. |
-| Network Scanner | `network_scanner` | `vulnerability` | `intrusive` | `nmap` | Check for 10,000+ CVEs and server misconfigurations. |
-| Nikto | `nikto` | `web` | `intrusive` | `nikto` | Web server vulnerability scanner powered by the Nikto CLI. |
-| Network Scanning | `nmap` | `network` | `safe` | `nmap` | Network discovery and port scanning tool. |
-| Template Vulnerability Scan | `nuclei` | `web` | `intrusive` | `nuclei` | Fast and customizable vulnerability scanner. |
-| Password Auditor | `password_auditor` | `vulnerability` | `intrusive` | `python3` | Discover weak credentials in network services and web apps. |
-| People Hunter | `people-email-discovery` | `recon` | `safe` | `theHarvester` | Discover email addresses and social media profiles. |
-| Port Scanner | `port-scanner` | `recon` | `intrusive` | `nmap` | Detect open ports and fingerprint services. |
-| Advanced Network Recon | `scapy_recon` | `network` | `safe` | `python3` | Advanced network probing using Scapy. |
-| Secret Scanner | `secret_scanner` | `code` | `safe` | `gitleaks` | Scan directories for hardcoded secrets. |
-| Sharepoint Scanner | `sharepoint_scanner` | `vulnerability` | `intrusive` | `nuclei` | Check SharePoint for security issues, misconfigs, and more. |
-| Sitemap Generator | `sitemap_gen` | `robots` | `intrusive` | `katana` | Build complete XML sitemaps by autonomously parsing targets. |
-| Sniper: Auto-Exploiter | `sniper` | `exploit` | `exploit` | `python3` | Validate critical CVEs by automatic exploitation. |
-| Spider | `spider` | `robots` | `intrusive` | `katana` | Advanced web spider with JS execution support. |
-| SQL Injection Feasibility | `sqli_checker` | `expert` | `intrusive` | `ghauri` | SQL injection feasibility scanner powered by Ghauri. |
-| SQLi Exploiter | `sqli_exploiter` | `exploit` | `exploit` | `sqlmap` | Exploit SQL injection in web apps to extract data. |
-| SQL Injection Testing | `sqlmap` | `web` | `exploit` | `sqlmap` | Automatic SQL injection and database takeover tool. |
-| SSH Runner | `ssh_runner` | `execution` | `intrusive` | `ssh` | Remote command execution via SSH. |
-| Subdomain Finder | `subdomain-finder` | `recon` | `safe` | `subfinder` | Discover subdomains of a domain. |
-| Subdomain Scanner | `subdomain_discovery` | `recon` | `safe` | `subfinder` | Enumerate subdomains using passive sources. |
-| Subdomain Takeover | `subdomain_takeover` | `exploit` | `intrusive` | `subfinder` | Discover dangling DNS entries pointing to external services. |
-| Subfinder | `subfinder` | `recon` | `safe` | `subfinder` | Fast passive subdomain enumeration. |
-| theHarvester | `theharvester` | `recon` | `safe` | `theHarvester` | OSINT collection for emails, domains, and hosts. |
-| TLS Security Analysis | `tls_inspector` | `security` | `safe` | `openssl` | Examine TLS/SSL certificates and cipher configurations. |
-| Uncover | `uncover` | `recon` | `safe` | `uncover` | Discover internet-exposed assets from external search sources. |
-| URL Fuzzer | `url-fuzzer-2` | `recon` | `intrusive` | `ffuf` | Discover hidden files and directories. |
-| urlfinder | `urlfinder` | `recon` | `safe` | `urlfinder` | Passive historical URL collection. |
-| Virtual Hosts Finder | `virtual-host-finder` | `recon` | `intrusive` | `ffuf` | Find multiple websites hosted on the same server. |
-| Volatility | `volatility` | `forensics` | `intrusive` | `volatility3` | Memory forensics workflow using Volatility 3 plugins. |
-| WAF Detector | `waf-detection` | `recon` | `safe` | `wafw00f` | Fingerprint the Web Application Firewall behind target app. |
-| WAF Detector | `waf_detector` | `robots` | `safe` | `wafw00f` | Automatically identify Web Application Firewalls protecting targets. |
-| Website Recon | `website-recon-2` | `recon` | `safe` | `httpx` | Fingerprint web technologies of target website. |
-| Domain Registration Lookup | `whois_lookup` | `utils` | `safe` | `python3` | Domain registration information lookup. |
-| WordPress Security Scan | `wpscan` | `vulnerability` | `intrusive` | `wpscan` | WordPress security scanner for plugin, theme, and core risk visibility. |
-| XSS Exploiter | `xss_exploiter` | `exploit` | `exploit` | `python3` | Exploit XSS in real-life attacks to extract cookies and data. |
-| Binary Signature Scan | `yara_scan` | `forensics` | `intrusive` | `yara` | Binary and file-system signature matching with YARA rules. |
-| DAST Web Proxy (ZAP) | `zap_scanner` | `vulnerability` | `exploit` | `python3` | Dynamic proxy spidering and payload injection. |
+| Plugin                      | ID                       | Category        | Safety      | Primary Binary | Summary                                                                   |
+| --------------------------- | ------------------------ | --------------- | ----------- | -------------- | ------------------------------------------------------------------------- |
+| Amass                       | `amass`                  | `recon`         | `safe`      | `amass`        | Deep attack-surface mapping and subdomain discovery.                      |
+| API Scanner                 | `api_scanner`            | `vulnerability` | `intrusive` | `nuclei`       | Check for specific API vulnerabilities (REST and GraphQL).                |
+| Cloud Scanner               | `cloud_scanner`          | `vulnerability` | `intrusive` | `python3`      | Cloud infrastructure security (AWS/GCP/Azure).                            |
+| S3 / Blob Auditor           | `cloud_storage_auditor`  | `vulnerability` | `safe`      | `uncover`      | Find misconfigured S3 buckets and exposed cloud storage.                  |
+| Code Analyzer (Bandit)      | `code_analyzer`          | `code`          | `safe`      | `bandit`       | Static analysis for Python code.                                          |
+| Container Scan (Trivy)      | `container_scanner`      | `network`       | `safe`      | `trivy`        | Scan Docker images and registries for known vulnerabilities.              |
+| Crawler                     | `crawler`                | `robots`        | `intrusive` | `katana`       | Recursive web crawler for link discovery.                                 |
+| Directory Discovery         | `dir_discovery`          | `web`           | `intrusive` | `ffuf`         | Discover hidden directories and files on web servers.                     |
+| DNS Reconnaissance          | `dns_enum`               | `recon`         | `safe`      | `dnsrecon`     | Enumerate DNS records and configurations.                                 |
+| dnsx                        | `dnsx`                   | `recon`         | `safe`      | `dnsx`         | DNS resolution and wildcard-aware validation at scale.                    |
+| Domain Finder               | `domain-finder`          | `recon`         | `safe`      | `amass`        | Discover additional domain names of target organization.                  |
+| Drupal Security Scan        | `droopescan`             | `vulnerability` | `intrusive` | `droopescan`   | Drupal-focused CMS scanner for version and surface enumeration.           |
+| Payload Fuzzer              | `fuzzer`                 | `robots`        | `exploit`   | `python3`      | Autonomously fuzz target fields with massive dictionaries.                |
+| Google Hacking              | `google-dorking`         | `recon`         | `safe`      | `python3`      | Find publicly indexed information about target.                           |
+| Password Recovery Audit     | `hashcat`                | `expert`        | `exploit`   | `hashcat`      | Password recovery and hash audit workflow.                                |
+| HTTP Inspector              | `http_inspector`         | `web`           | `safe`      | `curl`         | Inspect HTTP/HTTPS endpoints for headers, cookies, and TLS configuration. |
+| HTTP Request Logger         | `http_request_logger`    | `exploit`       | `intrusive` | `httpx`        | Handle incoming HTTP requests and record data.                            |
+| httpx                       | `httpx`                  | `recon`         | `safe`      | `httpx`        | Live host probing with status, title, and technology fingerprinting.      |
+| IaC Scanner (Checkov)       | `iac_scanner`            | `vulnerability` | `safe`      | `python3`      | Analyze Terraform and CloudFormation code for flaws.                      |
+| ICMP Ping                   | `icmp_ping`              | `utils`         | `safe`      | `ping`         | Check if a server is live and responds to ICMP Echo requests.             |
+| Joomla Security Scan        | `joomscan`               | `vulnerability` | `intrusive` | `joomscan`     | Joomla security scanner for version and common weakness discovery.        |
+| Katana                      | `katana`                 | `recon`         | `intrusive` | `katana`       | Web crawling for endpoint and route discovery.                            |
+| K8s Scanner                 | `kubernetes_scanner`     | `vulnerability` | `intrusive` | `python3`      | Kubernetes cluster security assessment.                                   |
+| Exploitation Connector      | `metasploit`             | `expert`        | `exploit`   | `msfconsole`   | Metasploit connector for controlled exploit-module execution.             |
+| Network Scanner             | `network_scanner`        | `vulnerability` | `intrusive` | `nmap`         | Check for 10,000+ CVEs and server misconfigurations.                      |
+| Nikto                       | `nikto`                  | `web`           | `intrusive` | `nikto`        | Web server vulnerability scanner powered by the Nikto CLI.                |
+| Network Scanning            | `nmap`                   | `network`       | `safe`      | `nmap`         | Network discovery and port scanning tool.                                 |
+| Template Vulnerability Scan | `nuclei`                 | `web`           | `intrusive` | `nuclei`       | Fast and customizable vulnerability scanner.                              |
+| Password Auditor            | `password_auditor`       | `vulnerability` | `intrusive` | `python3`      | Discover weak credentials in network services and web apps.               |
+| People Hunter               | `people-email-discovery` | `recon`         | `safe`      | `theHarvester` | Discover email addresses and social media profiles.                       |
+| Port Scanner                | `port-scanner`           | `recon`         | `intrusive` | `nmap`         | Detect open ports and fingerprint services.                               |
+| Advanced Network Recon      | `scapy_recon`            | `network`       | `safe`      | `python3`      | Advanced network probing using Scapy.                                     |
+| Secret Scanner              | `secret_scanner`         | `code`          | `safe`      | `gitleaks`     | Scan directories for hardcoded secrets.                                   |
+| Sharepoint Scanner          | `sharepoint_scanner`     | `vulnerability` | `intrusive` | `nuclei`       | Check SharePoint for security issues, misconfigs, and more.               |
+| Sitemap Generator           | `sitemap_gen`            | `robots`        | `intrusive` | `katana`       | Build complete XML sitemaps by autonomously parsing targets.              |
+| Sniper: Auto-Exploiter      | `sniper`                 | `exploit`       | `exploit`   | `python3`      | Validate critical CVEs by automatic exploitation.                         |
+| Spider                      | `spider`                 | `robots`        | `intrusive` | `katana`       | Advanced web spider with JS execution support.                            |
+| SQL Injection Feasibility   | `sqli_checker`           | `expert`        | `intrusive` | `ghauri`       | SQL injection feasibility scanner powered by Ghauri.                      |
+| SQLi Exploiter              | `sqli_exploiter`         | `exploit`       | `exploit`   | `sqlmap`       | Exploit SQL injection in web apps to extract data.                        |
+| SQL Injection Testing       | `sqlmap`                 | `web`           | `exploit`   | `sqlmap`       | Automatic SQL injection and database takeover tool.                       |
+| SSH Runner                  | `ssh_runner`             | `execution`     | `intrusive` | `ssh`          | Remote command execution via SSH.                                         |
+| Subdomain Finder            | `subdomain-finder`       | `recon`         | `safe`      | `subfinder`    | Discover subdomains of a domain.                                          |
+| Subdomain Scanner           | `subdomain_discovery`    | `recon`         | `safe`      | `subfinder`    | Enumerate subdomains using passive sources.                               |
+| Subdomain Takeover          | `subdomain_takeover`     | `exploit`       | `intrusive` | `subfinder`    | Discover dangling DNS entries pointing to external services.              |
+| Subfinder                   | `subfinder`              | `recon`         | `safe`      | `subfinder`    | Fast passive subdomain enumeration.                                       |
+| theHarvester                | `theharvester`           | `recon`         | `safe`      | `theHarvester` | OSINT collection for emails, domains, and hosts.                          |
+| TLS Security Analysis       | `tls_inspector`          | `security`      | `safe`      | `openssl`      | Examine TLS/SSL certificates and cipher configurations.                   |
+| Uncover                     | `uncover`                | `recon`         | `safe`      | `uncover`      | Discover internet-exposed assets from external search sources.            |
+| URL Fuzzer                  | `url-fuzzer-2`           | `recon`         | `intrusive` | `ffuf`         | Discover hidden files and directories.                                    |
+| urlfinder                   | `urlfinder`              | `recon`         | `safe`      | `urlfinder`    | Passive historical URL collection.                                        |
+| Virtual Hosts Finder        | `virtual-host-finder`    | `recon`         | `intrusive` | `ffuf`         | Find multiple websites hosted on the same server.                         |
+| Volatility                  | `volatility`             | `forensics`     | `intrusive` | `volatility3`  | Memory forensics workflow using Volatility 3 plugins.                     |
+| WAF Detector                | `waf-detection`          | `recon`         | `safe`      | `wafw00f`      | Fingerprint the Web Application Firewall behind target app.               |
+| WAF Detector                | `waf_detector`           | `robots`        | `safe`      | `wafw00f`      | Automatically identify Web Application Firewalls protecting targets.      |
+| Website Recon               | `website-recon-2`        | `recon`         | `safe`      | `httpx`        | Fingerprint web technologies of target website.                           |
+| Domain Registration Lookup  | `whois_lookup`           | `utils`         | `safe`      | `python3`      | Domain registration information lookup.                                   |
+| WordPress Security Scan     | `wpscan`                 | `vulnerability` | `intrusive` | `wpscan`       | WordPress security scanner for plugin, theme, and core risk visibility.   |
+| XSS Exploiter               | `xss_exploiter`          | `exploit`       | `exploit`   | `python3`      | Exploit XSS in real-life attacks to extract cookies and data.             |
+| Binary Signature Scan       | `yara_scan`              | `forensics`     | `intrusive` | `yara`         | Binary and file-system signature matching with YARA rules.                |
+| DAST Web Proxy (ZAP)        | `zap_scanner`            | `vulnerability` | `exploit`   | `python3`      | Dynamic proxy spidering and payload injection.                            |
 
 ## Maintenance Notes
 
 - If a plugin is added, renamed, or removed, update this file from the plugin metadata rather than editing counts by hand.
 - Prefer keeping `id`, category, safety level, and dependency names aligned with each plugin's `metadata.json`.
+
 ## Checksum Maintenance
 
 Plugin metadata files include integrity checksums. If you edit a plugin's
@@ -132,6 +133,7 @@ python scripts/refresh_plugin_checksum.py --all --dry-run
 ```
 
 Run this script any time you:
+
 - Edit a plugin's `metadata.json` fields
 - Edit a plugin's `parser.py`
 - Add a new plugin
@@ -141,3 +143,21 @@ After refreshing, run the backend tests to confirm the plugin loads correctly:
 ```bash
 cd backend && python -m pytest
 ```
+
+## Plugin Validation
+
+Validate a single plugin without loading all plugins:
+
+```bash
+# Validate by plugin id
+python scripts/validate_plugin.py --plugin <plugin-id>
+
+# Example
+python scripts/validate_plugin.py --plugin nmap
+
+# Or pass a path to the plugin directory
+python scripts/validate_plugin.py --plugin plugins/nmap
+```
+
+The validation checks metadata JSON, required fields, checksums, and custom
+parser imports when applicable.

--- a/scripts/validate_plugin.py
+++ b/scripts/validate_plugin.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+validate_plugin.py
+
+Validate a single plugin without loading all plugins.
+
+Checks:
+- Metadata JSON is valid and matches the PluginMetadata schema.
+- Required fields like engine.type and safety.level are present and valid.
+- Checksum matches the computed digest.
+- Custom parser imports cleanly and exposes a parse() function.
+
+Usage:
+  python scripts/validate_plugin.py --plugin nmap
+  python scripts/validate_plugin.py --plugin plugins/nmap
+  python scripts/validate_plugin.py --plugin /abs/path/to/plugins/nmap
+  python scripts/validate_plugin.py --plugin nmap --plugins-dir /custom/plugins
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from pydantic import ValidationError
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.secuscan.models import PluginMetadata
+from backend.secuscan.plugins import PluginManager
+
+
+ALLOWED_ENGINE_TYPES = {"cli", "python", "docker"}
+ALLOWED_SAFETY_LEVELS = {"safe", "intrusive", "exploit"}
+
+
+def resolve_plugin_dir(plugin_arg: str, plugins_dir: Path) -> Path:
+    candidate = Path(plugin_arg)
+    if candidate.exists():
+        if candidate.is_file() and candidate.name == "metadata.json":
+            return candidate.parent
+        if candidate.is_dir():
+            return candidate
+    return plugins_dir / plugin_arg
+
+
+def _import_parser(parser_file: Path, plugin_id: str) -> Optional[str]:
+    try:
+        spec = importlib.util.spec_from_file_location(f"parser_{plugin_id}", parser_file)
+        if spec is None or spec.loader is None:
+            return f"Unable to load parser module from {parser_file}"
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        return f"Failed to import parser.py for {plugin_id}: {exc}"
+
+    if not hasattr(module, "parse"):
+        return f"parser.py for {plugin_id} is missing a parse() function"
+
+    return None
+
+
+def _compute_normalized_digest(metadata: dict, parser_file: Path) -> str:
+    metadata_payload = dict(metadata)
+    metadata_payload.pop("checksum", None)
+    metadata_payload.pop("signature", None)
+    metadata_canonical = json.dumps(metadata_payload, sort_keys=True, separators=(",", ":"))
+    metadata_digest = hashlib.sha256(metadata_canonical.encode("utf-8")).hexdigest()
+
+    if parser_file.exists():
+        parser_text = parser_file.read_text(encoding="utf-8")
+        parser_text = parser_text.replace("\r\n", "\n")
+        parser_digest = hashlib.sha256(parser_text.encode("utf-8")).hexdigest()
+    else:
+        parser_digest = ""
+
+    return hashlib.sha256(f"{metadata_digest}:{parser_digest}".encode("utf-8")).hexdigest()
+
+
+def validate_plugin(plugin_dir: Path) -> bool:
+    errors: List[str] = []
+
+    metadata_file = plugin_dir / "metadata.json"
+    parser_file = plugin_dir / "parser.py"
+
+    if not plugin_dir.exists():
+        errors.append(f"Plugin directory not found: {plugin_dir}")
+    if not metadata_file.exists():
+        errors.append(f"metadata.json not found in {plugin_dir}")
+
+    if errors:
+        for message in errors:
+            print(f"[ERROR] {message}", file=sys.stderr)
+        return False
+
+    try:
+        metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"[ERROR] Invalid JSON in {metadata_file}: {exc}", file=sys.stderr)
+        return False
+
+    try:
+        plugin = PluginMetadata(**metadata)
+    except ValidationError as exc:
+        print("[ERROR] Metadata schema validation failed:", file=sys.stderr)
+        print(str(exc), file=sys.stderr)
+        return False
+
+    plugin_id = plugin.id or plugin_dir.name
+
+    engine_type = plugin.engine.get("type")
+    if engine_type not in ALLOWED_ENGINE_TYPES:
+        errors.append(
+            f"Invalid engine.type for {plugin_id}: {engine_type} (expected one of {sorted(ALLOWED_ENGINE_TYPES)})"
+        )
+
+    safety_level = plugin.safety.get("level")
+    if safety_level not in ALLOWED_SAFETY_LEVELS:
+        errors.append(
+            f"Invalid safety.level for {plugin_id}: {safety_level} (expected one of {sorted(ALLOWED_SAFETY_LEVELS)})"
+        )
+
+    checksum = metadata.get("checksum")
+    if not checksum:
+        errors.append(f"Missing checksum in metadata.json for {plugin_id}")
+    else:
+        try:
+            expected = PluginManager.compute_plugin_digest(metadata_file, parser_file)
+        except Exception as exc:
+            errors.append(f"Failed to compute checksum for {plugin_id}: {exc}")
+        else:
+            if checksum != expected:
+                normalized_expected = None
+                if parser_file.exists():
+                    try:
+                        normalized_expected = _compute_normalized_digest(metadata, parser_file)
+                    except Exception:
+                        normalized_expected = None
+
+                if normalized_expected and checksum == normalized_expected:
+                    print(
+                        f"[WARNING] {plugin_id} parser.py uses CRLF line endings; checksum matches LF-normalized content.",
+                        file=sys.stderr,
+                    )
+                else:
+                    errors.append(
+                        f"Checksum mismatch for {plugin_id}: expected {expected}, found {checksum}"
+                    )
+
+    parser_type = plugin.output.get("parser")
+    if parser_type == "custom" or parser_file.exists():
+        if not parser_file.exists():
+            errors.append(f"Custom parser specified but parser.py not found for {plugin_id}")
+        else:
+            parser_error = _import_parser(parser_file, plugin_id)
+            if parser_error:
+                errors.append(parser_error)
+
+    if errors:
+        for message in errors:
+            print(f"[ERROR] {message}", file=sys.stderr)
+        return False
+
+    print(f"[OK] {plugin_id} validated successfully")
+    return True
+
+
+def main() -> None:
+    default_plugins_dir = ROOT / "plugins"
+
+    parser = argparse.ArgumentParser(
+        description="Validate a single plugin without loading all plugins.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python scripts/validate_plugin.py --plugin nmap
+  python scripts/validate_plugin.py --plugin plugins/nmap
+  python scripts/validate_plugin.py --plugin /abs/path/to/plugins/nmap
+  python scripts/validate_plugin.py --plugin nmap --plugins-dir /custom/plugins
+        """,
+    )
+    parser.add_argument(
+        "--plugin",
+        required=True,
+        help="Plugin id (folder name) or path to the plugin directory",
+    )
+    parser.add_argument(
+        "--plugins-dir",
+        type=Path,
+        default=default_plugins_dir,
+        help=f"Plugins directory when using an id (default: {default_plugins_dir})",
+    )
+
+    args = parser.parse_args()
+    plugin_dir = resolve_plugin_dir(args.plugin, args.plugins_dir)
+
+    success = validate_plugin(plugin_dir)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_plugin.py
+++ b/scripts/validate_plugin.py
@@ -65,6 +65,9 @@ def _import_parser(parser_file: Path, plugin_id: str) -> Optional[str]:
     if not hasattr(module, "parse"):
         return f"parser.py for {plugin_id} is missing a parse() function"
 
+    if not callable(module.parse):
+        return f"parser.py for {plugin_id} defines parse, but it is not callable"
+
     return None
 
 
@@ -93,7 +96,9 @@ def validate_plugin(plugin_dir: Path) -> bool:
 
     if not plugin_dir.exists():
         errors.append(f"Plugin directory not found: {plugin_dir}")
-    if not metadata_file.exists():
+    elif not plugin_dir.is_dir():
+        errors.append(f"Plugin path is not a directory: {plugin_dir}")
+    elif not metadata_file.exists():
         errors.append(f"metadata.json not found in {plugin_dir}")
 
     if errors:
@@ -146,9 +151,9 @@ def validate_plugin(plugin_dir: Path) -> bool:
                         normalized_expected = None
 
                 if normalized_expected and checksum == normalized_expected:
-                    print(
-                        f"[WARNING] {plugin_id} parser.py uses CRLF line endings; checksum matches LF-normalized content.",
-                        file=sys.stderr,
+                    errors.append(
+                        f"Checksum mismatch for {plugin_id}: expected {expected}, found {checksum}. "
+                        "parser.py appears to use CRLF line endings; re-checkout with LF to match backend validation."
                     )
                 else:
                     errors.append(

--- a/scripts/validate_plugin.py
+++ b/scripts/validate_plugin.py
@@ -45,9 +45,11 @@ ALLOWED_SAFETY_LEVELS = {"safe", "intrusive", "exploit"}
 def resolve_plugin_dir(plugin_arg: str, plugins_dir: Path) -> Path:
     candidate = Path(plugin_arg)
     if candidate.exists():
-        if candidate.is_file() and candidate.name == "metadata.json":
-            return candidate.parent
         if candidate.is_dir():
+            return candidate
+        if candidate.is_file():
+            if candidate.name == "metadata.json":
+                return candidate.parent
             return candidate
     return plugins_dir / plugin_arg
 

--- a/testing/backend/unit/test_validate_plugin.py
+++ b/testing/backend/unit/test_validate_plugin.py
@@ -104,6 +104,6 @@ def test_fails_on_invalid_metadata(tmp_path):
 
 
 def test_fails_when_plugin_path_is_file(tmp_path):
-    plugin_dir = make_plugin(tmp_path, "file-path")
-    metadata_file = plugin_dir / "metadata.json"
-    assert validate_plugin(metadata_file) is False
+    marker_file = tmp_path / "not-a-plugin.txt"
+    marker_file.write_text("not a plugin", encoding="utf-8")
+    assert validate_plugin(marker_file) is False

--- a/testing/backend/unit/test_validate_plugin.py
+++ b/testing/backend/unit/test_validate_plugin.py
@@ -1,0 +1,98 @@
+"""
+Tests for scripts/validate_plugin.py
+
+What we're testing:
+- Valid plugin passes validation
+- Missing or mismatched checksum fails
+- Custom parser import requirements are enforced
+- Invalid metadata fails schema validation
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add repo root to sys.path so we can import the script directly
+repo_root = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(repo_root))
+
+from backend.secuscan.plugins import PluginManager
+from scripts.validate_plugin import validate_plugin
+
+
+def make_plugin(
+    tmp_path: Path,
+    plugin_id: str,
+    *,
+    checksum: str | None = "auto",
+    parser_type: str = "custom",
+    parser_content: str | None = "def parse(output): return []",
+    include_name: bool = True,
+) -> Path:
+    plugin_dir = tmp_path / plugin_id
+    plugin_dir.mkdir()
+
+    metadata = {
+        "id": plugin_id,
+        "version": "1.0.0",
+        "description": "Test plugin",
+        "category": "recon",
+        "engine": {"type": "cli", "binary": "echo"},
+        "command_template": ["echo", "{target}"],
+        "fields": [
+            {"id": "target", "label": "Target", "type": "string", "required": True}
+        ],
+        "presets": {},
+        "output": {"format": "text", "parser": parser_type},
+        "safety": {"level": "safe"},
+    }
+
+    if include_name:
+        metadata["name"] = f"Test Plugin {plugin_id}"
+
+    if parser_content is not None:
+        (plugin_dir / "parser.py").write_text(parser_content, encoding="utf-8")
+
+    metadata_file = plugin_dir / "metadata.json"
+    metadata_file.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+
+    if checksum == "auto":
+        expected = PluginManager.compute_plugin_digest(metadata_file, plugin_dir / "parser.py")
+        metadata["checksum"] = expected
+    elif checksum is not None:
+        metadata["checksum"] = checksum
+
+    metadata_file.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    return plugin_dir
+
+
+def test_validate_plugin_success(tmp_path):
+    plugin_dir = make_plugin(tmp_path, "test-plugin")
+    assert validate_plugin(plugin_dir) is True
+
+
+def test_fails_when_checksum_missing(tmp_path):
+    plugin_dir = make_plugin(tmp_path, "missing-checksum", checksum=None)
+    assert validate_plugin(plugin_dir) is False
+
+
+def test_fails_when_checksum_mismatch(tmp_path):
+    plugin_dir = make_plugin(tmp_path, "bad-checksum", checksum="wrong")
+    assert validate_plugin(plugin_dir) is False
+
+
+def test_fails_when_custom_parser_missing(tmp_path):
+    plugin_dir = make_plugin(tmp_path, "missing-parser", parser_content=None)
+    assert validate_plugin(plugin_dir) is False
+
+
+def test_fails_when_parser_missing_parse_function(tmp_path):
+    plugin_dir = make_plugin(tmp_path, "bad-parser", parser_content="def nope(): return []")
+    assert validate_plugin(plugin_dir) is False
+
+
+def test_fails_on_invalid_metadata(tmp_path):
+    plugin_dir = make_plugin(tmp_path, "invalid-metadata", include_name=False)
+    assert validate_plugin(plugin_dir) is False

--- a/testing/backend/unit/test_validate_plugin.py
+++ b/testing/backend/unit/test_validate_plugin.py
@@ -93,6 +93,17 @@ def test_fails_when_parser_missing_parse_function(tmp_path):
     assert validate_plugin(plugin_dir) is False
 
 
+def test_fails_when_parser_parse_not_callable(tmp_path):
+    plugin_dir = make_plugin(tmp_path, "bad-parser-callable", parser_content="parse = 123")
+    assert validate_plugin(plugin_dir) is False
+
+
 def test_fails_on_invalid_metadata(tmp_path):
     plugin_dir = make_plugin(tmp_path, "invalid-metadata", include_name=False)
     assert validate_plugin(plugin_dir) is False
+
+
+def test_fails_when_plugin_path_is_file(tmp_path):
+    plugin_dir = make_plugin(tmp_path, "file-path")
+    metadata_file = plugin_dir / "metadata.json"
+    assert validate_plugin(metadata_file) is False


### PR DESCRIPTION
**Summary**  
Adds a script to validate one plugin by id/path, plus tests and docs.

**Changes**  
- Add validate_plugin.py for single‑plugin validation  
- Add unit tests for success/failure cases  
- Document usage in PLUGINS.md

**Testing**  
- `python -m pytest testing/backend/unit/test_validate_plugin.py`

**Issue #93**
@utksh1 