### PR TITLE
fix(backend): add structured error responses for failed report generation

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -3,6 +3,7 @@ API routes for SecuScan backend
 """
 
 from fastapi import APIRouter, HTTPException, BackgroundTasks, Response
+from fastapi.responses import JSONResponse
 from typing import Any, Optional, List, Dict, Callable
 import json
 import logging
@@ -98,6 +99,21 @@ async def invalidate_view_cache():
     cache = await get_cache()
     for prefix in ["summary:", "findings:", "reports:", "tasks:"]:
         await cache.delete_prefix(prefix)
+
+
+def _report_generation_error_response(task_id: str, report_format: str) -> JSONResponse:
+    logger.exception("Report generation failed for task_id=%s format=%s", task_id, report_format)
+    return JSONResponse(
+        status_code=500,
+        content={
+            "error": "report_generation_failed",
+            "message": f"Failed to generate {report_format.upper()} report",
+            "details": {
+                "task_id": task_id,
+                "format": report_format,
+            },
+        },
+    )
 
 
 async def get_plugin_manager_for_request():
@@ -299,8 +315,11 @@ async def download_csv_report(task_id: str):
     if task_row["status"] not in ["completed", "failed"]:
         raise HTTPException(status_code=400, detail="Task is not finished yet")
 
-    structured_data = json.loads(task_row["structured_json"]) if task_row["structured_json"] else {}
-    csv_data = reporting.generate_csv_report(dict(task_row), {"structured": structured_data})
+    try:
+        structured_data = json.loads(task_row["structured_json"]) if task_row["structured_json"] else {}
+        csv_data = reporting.generate_csv_report(dict(task_row), {"structured": structured_data})
+    except Exception:
+        return _report_generation_error_response(task_id, "csv")
 
     return Response(
         content=csv_data,
@@ -323,8 +342,11 @@ async def download_html_report(task_id: str):
     if task_row["status"] not in ["completed", "failed"]:
         raise HTTPException(status_code=400, detail="Task is not finished yet")
 
-    structured_data = json.loads(task_row["structured_json"]) if task_row["structured_json"] else {}
-    html_content = reporting.generate_html_report(dict(task_row), {"structured": structured_data})
+    try:
+        structured_data = json.loads(task_row["structured_json"]) if task_row["structured_json"] else {}
+        html_content = reporting.generate_html_report(dict(task_row), {"structured": structured_data})
+    except Exception:
+        return _report_generation_error_response(task_id, "html")
 
     return Response(
         content=html_content,
@@ -347,8 +369,11 @@ async def download_pdf_report(task_id: str):
     if task_row["status"] not in ["completed", "failed"]:
         raise HTTPException(status_code=400, detail="Task is not finished yet")
 
-    structured_data = json.loads(task_row["structured_json"]) if task_row["structured_json"] else {}
-    pdf_bytes = bytes(reporting.generate_pdf_report(dict(task_row), {"structured": structured_data}))
+    try:
+        structured_data = json.loads(task_row["structured_json"]) if task_row["structured_json"] else {}
+        pdf_bytes = bytes(reporting.generate_pdf_report(dict(task_row), {"structured": structured_data}))
+    except Exception:
+        return _report_generation_error_response(task_id, "pdf")
 
     return Response(
         content=pdf_bytes,
@@ -372,8 +397,11 @@ async def download_sarif_report(task_id: str):
     if task_row["status"] not in ["completed", "failed"]:
         raise HTTPException(status_code=400, detail="Task is not finished yet")
 
-    structured_data = json.loads(task_row["structured_json"]) if task_row["structured_json"] else {}
-    sarif_data = reporting.generate_sarif_report(dict(task_row), {"structured": structured_data})
+    try:
+        structured_data = json.loads(task_row["structured_json"]) if task_row["structured_json"] else {}
+        sarif_data = reporting.generate_sarif_report(dict(task_row), {"structured": structured_data})
+    except Exception:
+        return _report_generation_error_response(task_id, "sarif")
 
     return Response(
         content=sarif_data,

--- a/testing/backend/integration/test_routes_sarif.py
+++ b/testing/backend/integration/test_routes_sarif.py
@@ -1,5 +1,8 @@
 import json
 import asyncio
+from unittest.mock import patch
+
+import pytest
 from backend.secuscan.database import get_db
 
 async def insert_mock_completed_task(task_id: str):
@@ -118,3 +121,28 @@ def test_download_sarif_report_failed_task(test_client):
     assert response.headers["content-type"] == "application/sarif+json"
     sarif = response.json()
     assert len(sarif["runs"][0]["results"]) == 0
+
+
+@pytest.mark.parametrize(
+    "report_format, patch_target",
+    [
+        ("csv", "backend.secuscan.routes.reporting.generate_csv_report"),
+        ("html", "backend.secuscan.routes.reporting.generate_html_report"),
+        ("pdf", "backend.secuscan.routes.reporting.generate_pdf_report"),
+        ("sarif", "backend.secuscan.routes.reporting.generate_sarif_report"),
+    ],
+)
+def test_download_report_generation_failure_returns_structured_error(test_client, report_format, patch_target):
+    task_id = f"test-task-report-fail-{report_format}"
+    asyncio.run(insert_mock_completed_task(task_id))
+
+    with patch(patch_target, side_effect=RuntimeError("boom internal trace")):
+        response = test_client.get(f"/api/v1/task/{task_id}/report/{report_format}")
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["error"] == "report_generation_failed"
+    assert body["message"] == f"Failed to generate {report_format.upper()} report"
+    assert body["details"]["task_id"] == task_id
+    assert body["details"]["format"] == report_format
+    assert "boom internal trace" not in json.dumps(body)


### PR DESCRIPTION
## Description

This PR improves backend error handling for report generation failures by returning structured and consistent API error responses instead of exposing raw exceptions.

### Changes made:

* Added targeted exception handling for report generation routes
* Implemented structured 500 error responses
* Prevented raw stack traces from being exposed in API responses
* Improved backend response consistency and reliability

## Related Issues

Fixes #86

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## How Has This Been Tested?

* Tested report generation routes manually
* Simulated report generation failures
* Verified that structured error responses are returned instead of raw exceptions

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.