### PR TITLE
feat(#125): queue position and pending count feedback

### DIFF
--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -535,7 +535,19 @@ class TaskExecutor:
         )
         if not task_row:
             return None
-            
+
+        queue_position = None
+        pending_count = None
+
+        if task_row["status"] == TaskStatus.QUEUED.value:
+            queued_rows = await db.fetchall(
+                "SELECT id FROM tasks WHERE status = ? ORDER BY created_at ASC",
+                (TaskStatus.QUEUED.value,)
+            )
+            ids = [r["id"] for r in queued_rows]
+            pending_count = len(ids)
+            queue_position = (ids.index(task_id) + 1) if task_id in ids else None
+
         return {
             "task_id": task_row["id"],
             "plugin_id": task_row["plugin_id"],
@@ -549,7 +561,9 @@ class TaskExecutor:
             "exit_code": task_row["exit_code"],
             "error_message": task_row["error_message"],
             "preset": task_row["preset"],
-            "inputs": json.loads(task_row["inputs_json"] or "{}")
+            "inputs": json.loads(task_row["inputs_json"] or "{}"),
+            "queue_position": queue_position,
+            "pending_count": pending_count,
         }
 
     async def _upsert_findings_and_report(self, db, task_id: str, plugin, plugin_id: str, target: str, status: str, output: str = ""):

--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -17,6 +17,8 @@ interface Task {
     duration_seconds?: number
     inputs?: any
     preset?: string
+    queue_position?: number
+    pending_count?: number
 }
 
 const statusFilters = [
@@ -301,6 +303,11 @@ export default function Scans() {
                                                         }`}>
                                                             {task.status}
                                                         </span>
+                                                        {task.status === 'queued' && task.queue_position && (
+                                                            <span className="text-[9px] font-mono text-rag-amber uppercase tracking-widest">
+                                                                Queue #{task.queue_position}/{task.pending_count}
+                                                            </span>
+                                                        )}
                                                         <span className="text-[10px] font-mono text-silver/20 uppercase tracking-widest italic">
                                                             OP_ID_{task.task_id.split('-')[0].toUpperCase()}
                                                         </span>

--- a/frontend/src/pages/TaskDetails.tsx
+++ b/frontend/src/pages/TaskDetails.tsx
@@ -41,6 +41,8 @@ interface Task {
     error_message?: string
     inputs?: Record<string, any>
     preset?: string
+    queue_position?: number
+    pending_count?: number
 }
 
 interface Finding {
@@ -645,8 +647,10 @@ export default function TaskDetails() {
                 />
                 <DetailCard
                     label="MISSION_START"
-                    value={startedTime}
-                    subValue={task.started_at ? formatDateLong(task.started_at) : 'PENDING'}
+                    value={task.status === 'queued' && task.queue_position ? `QUEUE #${task.queue_position}` : startedTime}
+                    subValue={task.status === 'queued' && task.pending_count
+                        ? `${task.pending_count} SCAN${task.pending_count > 1 ? 'S' : ''} PENDING`
+                        : task.started_at ? formatDateLong(task.started_at) : 'PENDING'}
                 />
                 <DetailCard
                     label="SCAN_DURATION"

--- a/testing/backend/test_queue_position.py
+++ b/testing/backend/test_queue_position.py
@@ -1,0 +1,108 @@
+"""
+Tests for queue_position and pending_count in get_task_status().
+Covers: queued tasks get position, non-queued tasks get None.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from backend.secuscan.executor import TaskExecutor
+from backend.secuscan.models import TaskStatus
+
+
+def make_task_row(task_id: str, status: str, created_at: str = "2026-01-01T00:00:00"):
+    return {
+        "id": task_id,
+        "plugin_id": "nmap",
+        "tool_name": "Nmap",
+        "target": "127.0.0.1",
+        "status": status,
+        "created_at": created_at,
+        "started_at": None,
+        "completed_at": None,
+        "duration_seconds": None,
+        "exit_code": None,
+        "error_message": None,
+        "preset": None,
+        "inputs_json": "{}",
+    }
+
+
+@pytest.mark.asyncio
+async def test_queued_task_gets_correct_position():
+    executor = TaskExecutor()
+    task_ids = ["aaa", "bbb", "ccc"]
+
+    mock_db = AsyncMock()
+    mock_db.fetchone.return_value = make_task_row("bbb", TaskStatus.QUEUED.value)
+    mock_db.fetchall.return_value = [
+        {"id": "aaa"},
+        {"id": "bbb"},
+        {"id": "ccc"},
+    ]
+
+    with patch("backend.secuscan.executor.get_db", return_value=AsyncMock(return_value=mock_db)):
+        with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+            result = await executor.get_task_status.__wrapped__(executor, "bbb") \
+                if hasattr(executor.get_task_status, "__wrapped__") \
+                else await _call_with_mock_db(executor, "bbb", mock_db)
+
+    assert result["queue_position"] == 2
+    assert result["pending_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_completed_task_has_no_queue_metadata():
+    executor = TaskExecutor()
+
+    mock_db = AsyncMock()
+    mock_db.fetchone.return_value = make_task_row("aaa", TaskStatus.COMPLETED.value)
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        result = await _call_with_mock_db(executor, "aaa", mock_db)
+
+    assert result["queue_position"] is None
+    assert result["pending_count"] is None
+
+
+@pytest.mark.asyncio
+async def test_running_task_has_no_queue_metadata():
+    executor = TaskExecutor()
+
+    mock_db = AsyncMock()
+    mock_db.fetchone.return_value = make_task_row("aaa", TaskStatus.RUNNING.value)
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        result = await _call_with_mock_db(executor, "aaa", mock_db)
+
+    assert result["queue_position"] is None
+    assert result["pending_count"] is None
+
+
+@pytest.mark.asyncio
+async def test_first_queued_task_is_position_one():
+    executor = TaskExecutor()
+
+    mock_db = AsyncMock()
+    mock_db.fetchone.return_value = make_task_row("aaa", TaskStatus.QUEUED.value)
+    mock_db.fetchall.return_value = [{"id": "aaa"}]
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        result = await _call_with_mock_db(executor, "aaa", mock_db)
+
+    assert result["queue_position"] == 1
+    assert result["pending_count"] == 1
+
+
+async def _call_with_mock_db(executor, task_id, mock_db):
+    """Helper to call get_task_status with a mocked db."""
+    import backend.secuscan.executor as executor_module
+    original = executor_module.get_db
+
+    async def mock_get_db():
+        return mock_db
+
+    executor_module.get_db = mock_get_db
+    try:
+        return await executor.get_task_status(task_id)
+    finally:
+        executor_module.get_db = original


### PR DESCRIPTION
Closes #125

## Changes
- `backend/secuscan/executor.py` — `get_task_status()` now returns `queue_position` and `pending_count` for queued tasks, `null` for all other states
- `frontend/src/pages/Scans.tsx` — Queue badge shows `Queue #N/total` next to status for queued tasks
- `frontend/src/pages/TaskDetails.tsx` — MISSION_START detail card shows queue position when task is queued
- `testing/backend/test_queue_position.py` — 4 passing tests

## Acceptance criteria
- [x] Backend exposes queue metadata without breaking existing clients
- [x] Frontend displays queued state clearly in Scans and TaskDetails
- [x] Backend tests for queue metadata
- [x] No schema changes, no migrations, fully backward compatible