### PR TITLE
docs: add command reference table to frontend README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -412,8 +412,11 @@ All commands must be run from the `frontend/` directory.
 | `npm run preview` | Preview the production build locally (port 8080) |
 | `npm run typecheck` | Run TypeScript type checking without emitting files |
 | `npm run test` | Run unit tests with Vitest |
+| `npm run test:watch` | Run unit tests in watch mode (re-runs on file changes) |
 | `npm run quality` | Run the quality gate checks |
+| `npm run quality:full` | Run quality checks, typecheck, and tests together |
 | `npm run e2e` | Run end-to-end tests with Playwright |
+| `npm run e2e:ui` | Run end-to-end tests with Playwright's interactive UI |
 
 ---
 ## 🧪 Testing

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -401,7 +401,21 @@ function MyComponent() {
 ```
 
 ---
+## Available Commands
 
+All commands must be run from the `frontend/` directory.
+
+| Command | Description |
+|---|---|
+| `npm run dev` | Start the Vite development server |
+| `npm run build` | Compile TypeScript and build for production |
+| `npm run preview` | Preview the production build locally (port 8080) |
+| `npm run typecheck` | Run TypeScript type checking without emitting files |
+| `npm run test` | Run unit tests with Vitest |
+| `npm run quality` | Run the quality gate checks |
+| `npm run e2e` | Run end-to-end tests with Playwright |
+
+---
 ## 🧪 Testing
 
 ### Manual Testing Checklist


### PR DESCRIPTION
## Description
Adds an Available Commands section to frontend/README.md with a table of all npm scripts, so contributors don't have to inspect package.json to discover them.

Commands included: dev, build, preview, typecheck, test, test:watch, quality, quality:full, e2e, e2e:ui

## Related Issues
Closes #74

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
Verified rendering in VS Code Markdown preview and on GitHub (fork).

## Checklist
- [ ] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
