### PR TITLE
feat: Add pagination metadata (next/previous) to tasks list endpoint

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -646,13 +646,34 @@ async def list_tasks(
         t["inputs"] = t.pop("inputs_json", {})
 
     total_pages = (total + per_page - 1) // per_page if per_page > 0 else 0
+    
+    # Calculate next and previous page numbers
+    next_page = page + 1 if page < total_pages else None
+    prev_page = page - 1 if page > 1 else None
+    
+    # Function to build URL with all query parameters
+    def build_page_url(page_num):
+        if page_num is None:
+            return None
+        # Start with page and per_page
+        params_list = [f"page={page_num}", f"per_page={per_page}"]
+        # Add filters if they exist
+        if plugin_id:
+            params_list.append(f"plugin_id={plugin_id}")
+        if status:
+            params_list.append(f"status={status}")
+        # Join with & and return
+        return f"/api/v1/tasks?{'&'.join(params_list)}"
+    
     return {
         "tasks": tasks_list,
         "pagination": {
             "page": page,
             "per_page": per_page,
             "total_pages": total_pages,
-            "total_items": total
+            "total_items": total,
+            "next": build_page_url(next_page),      # ← NEW
+            "previous": build_page_url(prev_page)    # ← NEW
         }
     }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,43 @@
+# SecuScan API Documentation
+
+## Tasks API
+
+### List Tasks with Pagination
+
+**Endpoint:** `GET /api/v1/tasks`
+
+**Description:** Returns a paginated list of all scan tasks with navigation metadata.
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| page | integer | No | 1 | Page number (1-indexed) |
+| per_page | integer | No | 25 | Items per page (1-100) |
+| plugin_id | string | No | null | Filter by plugin ID |
+| status | string | No | null | Filter by status |
+
+**Response (200 OK):**
+
+```json
+{
+  "tasks": [...],
+  "pagination": {
+    "page": 1,
+    "per_page": 25,
+    "total_pages": 4,
+    "total_items": 87,
+    "next": "/api/v1/tasks?page=2&per_page=25",
+    "previous": null
+  }
+}
+
+
+
+"""
+# Basic pagination
+curl "http://localhost:8000/api/v1/tasks?page=2&per_page=10"
+
+# With filters
+curl "http://localhost:8000/api/v1/tasks?status=completed&plugin_id=nmap&page=1&per_page=20"
+"""

--- a/testing/backend/test_task_pagination.py
+++ b/testing/backend/test_task_pagination.py
@@ -1,0 +1,88 @@
+"""
+Tests for pagination metadata in tasks list endpoint.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from backend.secuscan.main import app
+from backend.secuscan.database import init_db
+
+# IMPORTANT: Initialize database before any tests run
+@pytest.fixture(scope="session", autouse=True)
+def setup_database():
+    """Initialize database for testing"""
+    import asyncio
+    asyncio.run(init_db())
+
+client = TestClient(app)
+
+
+class TestTasksPagination:
+    """Test pagination metadata for /api/v1/tasks endpoint"""
+    
+    def test_pagination_has_next_previous_fields(self):
+        """Test that next and previous fields exist in response"""
+        response = client.get("/api/v1/tasks")
+        
+        # Check if we got a response
+        if response.status_code == 200:
+            data = response.json()
+            assert "pagination" in data
+            pagination = data["pagination"]
+            
+            # These fields should always exist
+            assert "next" in pagination
+            assert "previous" in pagination
+            assert "page" in pagination
+            assert "per_page" in pagination
+            assert "total_items" in pagination
+            assert "total_pages" in pagination
+            print("✅ All pagination fields present!")
+        else:
+            pytest.fail(f"API returned {response.status_code}")
+    
+    def test_default_pagination_values(self):
+        """Test default page=1, per_page=25"""
+        response = client.get("/api/v1/tasks")
+        assert response.status_code == 200
+        
+        pagination = response.json()["pagination"]
+        assert pagination["page"] == 1
+        assert pagination["per_page"] == 25
+        print(f"✅ Default values: page={pagination['page']}, per_page={pagination['per_page']}")
+    
+    def test_custom_per_page(self):
+        """Test that per_page parameter is respected"""
+        response = client.get("/api/v1/tasks?page=1&per_page=10")
+        assert response.status_code == 200
+        
+        pagination = response.json()["pagination"]
+        assert pagination["per_page"] == 10
+        print(f"✅ Custom per_page=10 works")
+    
+    def test_first_page_previous_is_null(self):
+        """Test that previous is None on first page"""
+        response = client.get("/api/v1/tasks?page=1&per_page=10")
+        assert response.status_code == 200
+        
+        pagination = response.json()["pagination"]
+        assert pagination["previous"] is None
+        print("✅ First page has previous=None")
+    
+    def test_next_url_preserves_filters(self):
+        """Test that next URL keeps filter parameters"""
+        response = client.get(
+            "/api/v1/tasks?page=1&per_page=5&status=completed&plugin_id=nmap"
+        )
+        assert response.status_code == 200
+        
+        data = response.json()
+        next_url = data["pagination"]["next"]
+        
+        if next_url:  # If there are more pages
+            assert "per_page=5" in next_url
+            assert "status=completed" in next_url
+            assert "plugin_id=nmap" in next_url
+            print(f"✅ Next URL preserves filters: {next_url}")
+        else:
+            print("ℹ️ No next page (database might be empty)")


### PR DESCRIPTION
## Description
Added pagination metadata (`next` and `previous` URLs) to the `/api/v1/tasks` endpoint to enable efficient frontend navigation through large task histories.

### What Changed?
- **Backend (`routes.py`):** Added `next` and `previous` fields to pagination response
- **URL Building:** Implemented helper function that preserves filter parameters (`plugin_id`, `status`) in pagination URLs
- **Backward Compatible:** Existing response structure unchanged, old clients ignore new fields
- **Tests:** Added comprehensive integration tests for pagination behavior
- **Documentation:** Created `docs/API.md` with complete API documentation

### API Response Example
**Before:**
```json
{
  "tasks": [...],
  "pagination": {
    "page": 1,
    "per_page": 25,
    "total_pages": 4,
    "total_items": 87
  }
}

{
  "tasks": [...],
  "pagination": {
    "page": 1,
    "per_page": 25,
    "total_pages": 4,
    "total_items": 87,
    "next": "/api/v1/tasks?page=2&per_page=25",
    "previous": null
  }
}

# Test 1: Default pagination
curl "http://127.0.0.1:8000/api/v1/tasks"
# ✅ Response includes "next" and "previous" fields

# Test 2: Custom page and per_page
curl "http://127.0.0.1:8000/api/v1/tasks?page=2&per_page=10"
# ✅ Returns page 2 with 10 items per page

# Test 3: Filters preserved in pagination URLs
curl "http://127.0.0.1:8000/api/v1/tasks?page=1&per_page=5&status=completed&plugin_id=nmap"
# ✅ next URL contains all filter parameters

# Test 4: First page edge case
curl "http://127.0.0.1:8000/api/v1/tasks?page=1&per_page=10"
# ✅ previous = null

# Test 5: Last page edge case
curl "http://127.0.0.1:8000/api/v1/tasks?page=100&per_page=10"
# ✅ next = null


