### PR TITLE
Add pagination data

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -131,7 +131,7 @@ async def list_plugins():
     """List all available plugins"""
     plugin_manager = await get_plugin_manager_for_request()
     plugins = plugin_manager.list_plugins()
-    
+
     return PluginListResponse(
         plugins=plugins,
         total=len(plugins)
@@ -458,7 +458,7 @@ async def get_task_result(task_id: str):
 
     if ports := structured.get("open_ports"):
         summary.append(f"Perimeter analysis confirmed {len(ports)} active network entry points.")
-    
+
     if techs := structured.get("technologies"):
         summary.append(f"Fingerprinting identified {len(techs)} unique technologies powering the target infrastructure.")
 
@@ -500,10 +500,10 @@ async def get_task_result(task_id: str):
 async def cancel_task(task_id: str):
     """Cancel a running task"""
     cancelled = await executor.cancel_task(task_id)
-    
+
     if not cancelled:
         raise HTTPException(status_code=404, detail="Task not found or not running")
-    
+
     return {
         "task_id": task_id,
         "status": "cancelled",
@@ -517,11 +517,11 @@ async def get_dashboard_summary():
 
     async def build():
         db = await get_db()
-        
+
         # Get data
         raw_findings = await db.fetchall("SELECT * FROM findings ORDER BY discovered_at DESC")
         findings = parse_json_fields(raw_findings, ["metadata_json"])
-        
+
         task_stats = await db.fetchone(
             """
             SELECT
@@ -646,11 +646,11 @@ async def list_tasks(
         t["inputs"] = t.pop("inputs_json", {})
 
     total_pages = (total + per_page - 1) // per_page if per_page > 0 else 0
-    
+
     # Calculate next and previous page numbers
     next_page = page + 1 if page < total_pages else None
     prev_page = page - 1 if page > 1 else None
-    
+
     # Function to build URL with all query parameters
     def build_page_url(page_num):
         if page_num is None:
@@ -664,7 +664,7 @@ async def list_tasks(
             params_list.append(f"status={status}")
         # Join with & and return
         return f"/api/v1/tasks?{'&'.join(params_list)}"
-    
+
     return {
         "tasks": tasks_list,
         "pagination": {
@@ -681,17 +681,17 @@ async def list_tasks(
 async def delete_task_records(task_ids: List[str]):
     """Helper to delete database records and files for multiple tasks."""
     db = await get_db()
-    
+
     # Get raw output paths for file cleanup
     placeholders = ",".join(["?"] * len(task_ids))
     task_rows = await db.fetchall(f"SELECT raw_output_path FROM tasks WHERE id IN ({placeholders})", tuple(task_ids))
-    
+
     # Delete associated data
     await db.execute(f"DELETE FROM findings WHERE task_id IN ({placeholders})", tuple(task_ids))
     await db.execute(f"DELETE FROM reports WHERE task_id IN ({placeholders})", tuple(task_ids))
     await db.execute(f"DELETE FROM audit_log WHERE task_id IN ({placeholders})", tuple(task_ids))
     await db.execute(f"DELETE FROM tasks WHERE id IN ({placeholders})", tuple(task_ids))
-    
+
     # Cleanup files on disk
     for row in task_rows:
         if row and row["raw_output_path"]:
@@ -706,7 +706,7 @@ async def delete_task_records(task_ids: List[str]):
 async def delete_task(task_id: str):
     """Delete a task and its associated data (findings, reports, audit logs, and files)"""
     db = await get_db()
-    
+
     # Check if task is running
     status = await executor.get_task_status(task_id)
     if status and status.get("status") == "running":
@@ -714,7 +714,7 @@ async def delete_task(task_id: str):
 
     await delete_task_records([task_id])
     await invalidate_view_cache()
-    
+
     return {
         "task_id": task_id,
         "deleted": True
@@ -725,7 +725,7 @@ async def delete_task(task_id: str):
 async def bulk_delete_tasks(task_ids: List[str]):
     """Delete multiple tasks at once"""
     db = await get_db()
-    
+
     # Check if any tasks are running
     placeholders = ",".join(["?"] * len(task_ids))
     running_tasks = await db.fetchone(f"SELECT id FROM tasks WHERE id IN ({placeholders}) AND status = 'running' LIMIT 1", tuple(task_ids))
@@ -734,7 +734,7 @@ async def bulk_delete_tasks(task_ids: List[str]):
 
     await delete_task_records(task_ids)
     await invalidate_view_cache()
-    
+
     return {
         "deleted_count": len(task_ids),
         "success": True
@@ -745,7 +745,7 @@ async def bulk_delete_tasks(task_ids: List[str]):
 async def clear_all_tasks():
     """Wipe all scan history and associated data (findings, reports, assets, attack surface)"""
     db = await get_db()
-    
+
     # Prevent clearing if any tasks are running
     running_tasks = await db.fetchone("SELECT id FROM tasks WHERE status = 'running' LIMIT 1")
     if running_tasks:
@@ -759,7 +759,7 @@ async def clear_all_tasks():
 
     # Purge other tables
     await db.execute("DELETE FROM findings")
-    
+
     # Fallback cleanup for any orphaned files in data directories
     for subdir in ["raw", "reports"]:
         dir_path = Path(settings.data_dir) / subdir
@@ -774,7 +774,7 @@ async def clear_all_tasks():
                     logger.error(f"Failed to cleanup {item}: {e}")
 
     await invalidate_view_cache()
-    
+
     return {
         "cleared": True,
         "message": "All scan history and associated data has been purged."
@@ -963,7 +963,7 @@ async def trigger_workflow_tick():
 async def get_finding_details(finding_id: str):
     """Get detailed information for a specific finding"""
     db = await get_db()
-    
+
     finding_row = await db.fetchone(
         """
         SELECT f.*, t.tool_name, t.target as task_target
@@ -973,17 +973,17 @@ async def get_finding_details(finding_id: str):
         """,
         (finding_id,)
     )
-    
+
     if not finding_row:
         raise HTTPException(status_code=404, detail="Finding not found")
-        
+
     metadata = {}
     if finding_row["metadata_json"]:
         try:
             metadata = json.loads(finding_row["metadata_json"])
         except json.JSONDecodeError:
             metadata = {}
-            
+
     return {
         "id": finding_row["id"],
         "task_id": finding_row["task_id"],
@@ -1007,14 +1007,14 @@ async def get_finding_details(finding_id: str):
 async def get_attack_surface():
     """Return an aggregated view of the monitored attack surface."""
     db = await get_db()
-    
+
     # We aggregate unique targets from tasks and findings
     tasks = await db.fetchall("SELECT DISTINCT target, tool_name, created_at FROM tasks ORDER BY created_at DESC")
     findings = await db.fetchall("SELECT DISTINCT target, category, severity, discovered_at FROM findings ORDER BY discovered_at DESC")
-    
+
     entries = []
     seen_targets = set()
-    
+
     # Add findings as high-priority surface entries
     for f in findings:
         target = f["target"]
@@ -1029,7 +1029,7 @@ async def get_attack_surface():
                 "last_seen": f["discovered_at"]
             })
             seen_targets.add(target)
-            
+
     # Add other scanned targets
     for t in tasks:
         target = t["target"]
@@ -1044,7 +1044,7 @@ async def get_attack_surface():
                 "last_seen": t["created_at"]
             })
             seen_targets.add(target)
-            
+
     return {"entries": entries}
 
 

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -646,13 +646,34 @@ async def list_tasks(
         t["inputs"] = t.pop("inputs_json", {})
 
     total_pages = (total + per_page - 1) // per_page if per_page > 0 else 0
+    
+    # Calculate next and previous page numbers
+    next_page = page + 1 if page < total_pages else None
+    prev_page = page - 1 if page > 1 else None
+    
+    # Function to build URL with all query parameters
+    def build_page_url(page_num):
+        if page_num is None:
+            return None
+        # Start with page and per_page
+        params_list = [f"page={page_num}", f"per_page={per_page}"]
+        # Add filters if they exist
+        if plugin_id:
+            params_list.append(f"plugin_id={plugin_id}")
+        if status:
+            params_list.append(f"status={status}")
+        # Join with & and return
+        return f"/api/v1/tasks?{'&'.join(params_list)}"
+    
     return {
         "tasks": tasks_list,
         "pagination": {
             "page": page,
             "per_page": per_page,
             "total_pages": total_pages,
-            "total_items": total
+            "total_items": total,
+            "next": build_page_url(next_page),      # ← NEW
+            "previous": build_page_url(prev_page)    # ← NEW
         }
     }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,43 @@
+# SecuScan API Documentation
+
+## Tasks API
+
+### List Tasks with Pagination
+
+**Endpoint:** `GET /api/v1/tasks`
+
+**Description:** Returns a paginated list of all scan tasks with navigation metadata.
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| page | integer | No | 1 | Page number (1-indexed) |
+| per_page | integer | No | 25 | Items per page (1-100) |
+| plugin_id | string | No | null | Filter by plugin ID |
+| status | string | No | null | Filter by status |
+
+**Response (200 OK):**
+
+```json
+{
+  "tasks": [...],
+  "pagination": {
+    "page": 1,
+    "per_page": 25,
+    "total_pages": 4,
+    "total_items": 87,
+    "next": "/api/v1/tasks?page=2&per_page=25",
+    "previous": null
+  }
+}
+
+
+
+"""
+# Basic pagination
+curl "http://localhost:8000/api/v1/tasks?page=2&per_page=10"
+
+# With filters
+curl "http://localhost:8000/api/v1/tasks?status=completed&plugin_id=nmap&page=1&per_page=20"
+"""

--- a/testing/backend/test_task_pagination.py
+++ b/testing/backend/test_task_pagination.py
@@ -1,0 +1,88 @@
+"""
+Tests for pagination metadata in tasks list endpoint.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from backend.secuscan.main import app
+from backend.secuscan.database import init_db
+
+# IMPORTANT: Initialize database before any tests run
+@pytest.fixture(scope="session", autouse=True)
+def setup_database():
+    """Initialize database for testing"""
+    import asyncio
+    asyncio.run(init_db())
+
+client = TestClient(app)
+
+
+class TestTasksPagination:
+    """Test pagination metadata for /api/v1/tasks endpoint"""
+    
+    def test_pagination_has_next_previous_fields(self):
+        """Test that next and previous fields exist in response"""
+        response = client.get("/api/v1/tasks")
+        
+        # Check if we got a response
+        if response.status_code == 200:
+            data = response.json()
+            assert "pagination" in data
+            pagination = data["pagination"]
+            
+            # These fields should always exist
+            assert "next" in pagination
+            assert "previous" in pagination
+            assert "page" in pagination
+            assert "per_page" in pagination
+            assert "total_items" in pagination
+            assert "total_pages" in pagination
+            print("✅ All pagination fields present!")
+        else:
+            pytest.fail(f"API returned {response.status_code}")
+    
+    def test_default_pagination_values(self):
+        """Test default page=1, per_page=25"""
+        response = client.get("/api/v1/tasks")
+        assert response.status_code == 200
+        
+        pagination = response.json()["pagination"]
+        assert pagination["page"] == 1
+        assert pagination["per_page"] == 25
+        print(f"✅ Default values: page={pagination['page']}, per_page={pagination['per_page']}")
+    
+    def test_custom_per_page(self):
+        """Test that per_page parameter is respected"""
+        response = client.get("/api/v1/tasks?page=1&per_page=10")
+        assert response.status_code == 200
+        
+        pagination = response.json()["pagination"]
+        assert pagination["per_page"] == 10
+        print(f"✅ Custom per_page=10 works")
+    
+    def test_first_page_previous_is_null(self):
+        """Test that previous is None on first page"""
+        response = client.get("/api/v1/tasks?page=1&per_page=10")
+        assert response.status_code == 200
+        
+        pagination = response.json()["pagination"]
+        assert pagination["previous"] is None
+        print("✅ First page has previous=None")
+    
+    def test_next_url_preserves_filters(self):
+        """Test that next URL keeps filter parameters"""
+        response = client.get(
+            "/api/v1/tasks?page=1&per_page=5&status=completed&plugin_id=nmap"
+        )
+        assert response.status_code == 200
+        
+        data = response.json()
+        next_url = data["pagination"]["next"]
+        
+        if next_url:  # If there are more pages
+            assert "per_page=5" in next_url
+            assert "status=completed" in next_url
+            assert "plugin_id=nmap" in next_url
+            print(f"✅ Next URL preserves filters: {next_url}")
+        else:
+            print("ℹ️ No next page (database might be empty)")

--- a/testing/backend/test_task_pagination.py
+++ b/testing/backend/test_task_pagination.py
@@ -19,17 +19,17 @@ client = TestClient(app)
 
 class TestTasksPagination:
     """Test pagination metadata for /api/v1/tasks endpoint"""
-    
+
     def test_pagination_has_next_previous_fields(self):
         """Test that next and previous fields exist in response"""
         response = client.get("/api/v1/tasks")
-        
+
         # Check if we got a response
         if response.status_code == 200:
             data = response.json()
             assert "pagination" in data
             pagination = data["pagination"]
-            
+
             # These fields should always exist
             assert "next" in pagination
             assert "previous" in pagination
@@ -40,45 +40,45 @@ class TestTasksPagination:
             print("✅ All pagination fields present!")
         else:
             pytest.fail(f"API returned {response.status_code}")
-    
+
     def test_default_pagination_values(self):
         """Test default page=1, per_page=25"""
         response = client.get("/api/v1/tasks")
         assert response.status_code == 200
-        
+
         pagination = response.json()["pagination"]
         assert pagination["page"] == 1
         assert pagination["per_page"] == 25
         print(f"✅ Default values: page={pagination['page']}, per_page={pagination['per_page']}")
-    
+
     def test_custom_per_page(self):
         """Test that per_page parameter is respected"""
         response = client.get("/api/v1/tasks?page=1&per_page=10")
         assert response.status_code == 200
-        
+
         pagination = response.json()["pagination"]
         assert pagination["per_page"] == 10
         print(f"✅ Custom per_page=10 works")
-    
+
     def test_first_page_previous_is_null(self):
         """Test that previous is None on first page"""
         response = client.get("/api/v1/tasks?page=1&per_page=10")
         assert response.status_code == 200
-        
+
         pagination = response.json()["pagination"]
         assert pagination["previous"] is None
         print("✅ First page has previous=None")
-    
+
     def test_next_url_preserves_filters(self):
         """Test that next URL keeps filter parameters"""
         response = client.get(
             "/api/v1/tasks?page=1&per_page=5&status=completed&plugin_id=nmap"
         )
         assert response.status_code == 200
-        
+
         data = response.json()
         next_url = data["pagination"]["next"]
-        
+
         if next_url:  # If there are more pages
             assert "per_page=5" in next_url
             assert "status=completed" in next_url


### PR DESCRIPTION
## Description

Added pagination metadata (`next` and `previous` URLs) to the `/api/v1/tasks` endpoint to enable efficient frontend navigation through large task histories.

### What Changed?

**Backend (`backend/secuscan/api/routes.py`):**
- Added `next` and `previous` fields to pagination response
- Implemented URL building that preserves filter parameters (`plugin_id`, `status`)
- Maintained backward compatibility (existing fields unchanged)

**Tests (`testing/backend/test_task_pagination.py`):**
- Added comprehensive integration tests for pagination behavior
- Tests for default values, custom parameters, and edge cases
- Tests for filter preservation in pagination URLs

**Documentation (`docs/API.md`):**
- Created complete API documentation for tasks endpoint
- Documented query parameters (`page`, `per_page`)
- Added response format examples with pagination metadata

### API Response Example

**Before:**
```json
{
  "tasks": [...],
  "pagination": {
    "page": 1,
    "per_page": 25,
    "total_pages": 4,
    "total_items": 87
  }
}
**After:**
````json
{
  "tasks": [...],
  "pagination": {
    "page": 1,
    "per_page": 25,
    "total_pages": 4,
    "total_items": 87,
    "next": "/api/v1/tasks?page=2&per_page=25",
    "previous": null
  }
}


Parameter | Type     | Default | Description
page         | integer | 1 | Page number (1-indexed)
per_page | integer| 25 | Number of tasks per page (max 100)
plugin_id | string   | null | Filter tasks by specific plugin
status       | string  | null | Filter by task status
<img width="1899" height="757" alt="Screenshot 2026-05-19 132531" src="https://github.com/user-attachments/assets/15d4895f-5567-4288-964e-1dc6ad261cac" />
