### PR TITLE
fix(report): quote Content-Disposition filenames and add download route tests

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -305,7 +305,7 @@ async def download_csv_report(task_id: str):
     return Response(
         content=csv_data,
         media_type="text/csv",
-        headers={"Content-Disposition": f"attachment; filename={build_report_filename(dict(task_row), 'csv')}"}
+        headers={"Content-Disposition": f'attachment; filename="{build_report_filename(dict(task_row), "csv")}"'}
     )
 
 @router.get("/task/{task_id}/report/html")
@@ -329,7 +329,7 @@ async def download_html_report(task_id: str):
     return Response(
         content=html_content,
         media_type="text/html",
-        headers={"Content-Disposition": f"attachment; filename={build_report_filename(dict(task_row), 'html')}"}
+        headers={"Content-Disposition": f'attachment; filename="{build_report_filename(dict(task_row), "html")}"'}
     )
 
 @router.get("/task/{task_id}/report/pdf")
@@ -348,12 +348,12 @@ async def download_pdf_report(task_id: str):
         raise HTTPException(status_code=400, detail="Task is not finished yet")
 
     structured_data = json.loads(task_row["structured_json"]) if task_row["structured_json"] else {}
-    pdf_bytes = bytes(reporting.generate_pdf_report(dict(task_row), {"structured": structured_data}))
+    pdf_bytes = reporting.generate_pdf_report(dict(task_row), {"structured": structured_data})
 
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",
-        headers={"Content-Disposition": f"attachment; filename={build_report_filename(dict(task_row), 'pdf')}"}
+        headers={"Content-Disposition": f'attachment; filename="{build_report_filename(dict(task_row), "pdf")}"'}
     )
 
 
@@ -378,7 +378,7 @@ async def download_sarif_report(task_id: str):
     return Response(
         content=sarif_data,
         media_type="application/sarif+json",
-        headers={"Content-Disposition": f"attachment; filename={build_report_filename(dict(task_row), 'sarif')}"}
+        headers={"Content-Disposition": f'attachment; filename="{build_report_filename(dict(task_row), "sarif")}"'}
     )
 
 

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -370,10 +370,8 @@ async def download_pdf_report(task_id: str):
         raise HTTPException(status_code=400, detail="Task is not finished yet")
 
     structured_data = json.loads(task_row["structured_json"]) if task_row["structured_json"] else {}
-    pdf_bytes = reporting.generate_pdf_report(dict(task_row), {"structured": structured_data})
     try:
-        structured_data = json.loads(task_row["structured_json"]) if task_row["structured_json"] else {}
-        pdf_bytes = bytes(reporting.generate_pdf_report(dict(task_row), {"structured": structured_data}))
+        pdf_bytes = reporting.generate_pdf_report(dict(task_row), {"structured": structured_data})
     except Exception:
         return _report_generation_error_response(task_id, "pdf")
 

--- a/testing/backend/integration/test_report_filenames.py
+++ b/testing/backend/integration/test_report_filenames.py
@@ -1,0 +1,145 @@
+import json
+import sqlite3
+
+from backend.secuscan.config import settings
+
+
+def _seed_task(task_id: str, tool: str, target: str, created_at: str, status: str = "completed"):
+    conn = sqlite3.connect(settings.database_path)
+    conn.execute(
+        """
+        INSERT INTO tasks (id, plugin_id, tool_name, target, status, created_at, preset, inputs_json, command_used, structured_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            task_id,
+            tool,
+            tool,
+            target,
+            status,
+            created_at,
+            "standard",
+            json.dumps({"target": target}),
+            f"{tool} {target}",
+            json.dumps({"findings": []}),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+def test_csv_filename_url_target(test_client):
+    task_id = "fn-csv-url-001"
+    _seed_task(task_id, "http_inspector", "https://example.com", "2026-04-10T12:00:00")
+
+    response = test_client.get(f"/api/v1/task/{task_id}/report/csv")
+    assert response.status_code == 200
+    cd = response.headers["content-disposition"]
+    assert "attachment" in cd
+    assert "secuscan_http-inspector_example-com_2026-04-10.csv" in cd
+
+
+def test_csv_filename_hostport_target(test_client):
+    task_id = "fn-csv-hp-001"
+    _seed_task(task_id, "port_scanner", "192.168.1.1:8080", "2026-03-05T08:00:00")
+
+    response = test_client.get(f"/api/v1/task/{task_id}/report/csv")
+    assert response.status_code == 200
+    cd = response.headers["content-disposition"]
+    assert "secuscan_port-scanner_192-168-1-1-8080_2026-03-05.csv" in cd
+
+
+# ---------------------------------------------------------------------------
+# HTML
+# ---------------------------------------------------------------------------
+
+def test_html_filename_url_target(test_client):
+    task_id = "fn-html-url-001"
+    _seed_task(task_id, "nikto", "http://testsite.local", "2026-02-20T09:30:00")
+
+    response = test_client.get(f"/api/v1/task/{task_id}/report/html")
+    assert response.status_code == 200
+    cd = response.headers["content-disposition"]
+    assert "secuscan_nikto_testsite-local_2026-02-20.html" in cd
+
+
+def test_html_filename_hostport_target(test_client):
+    task_id = "fn-html-hp-001"
+    _seed_task(task_id, "recon_scanner", "10.0.0.5:443", "2026-01-15T14:00:00")
+
+    response = test_client.get(f"/api/v1/task/{task_id}/report/html")
+    assert response.status_code == 200
+    cd = response.headers["content-disposition"]
+    assert "secuscan_recon-scanner_10-0-0-5-443_2026-01-15.html" in cd
+
+
+# ---------------------------------------------------------------------------
+# PDF
+# ---------------------------------------------------------------------------
+
+def test_pdf_filename_url_target(test_client):
+    task_id = "fn-pdf-url-001"
+    _seed_task(task_id, "http_inspector", "https://target.example.org", "2026-05-01T00:00:00")
+
+    response = test_client.get(f"/api/v1/task/{task_id}/report/pdf")
+    assert response.status_code == 200
+    cd = response.headers["content-disposition"]
+    assert "secuscan_http-inspector_target-example-org_2026-05-01.pdf" in cd
+
+
+def test_pdf_filename_hostport_target(test_client):
+    task_id = "fn-pdf-hp-001"
+    _seed_task(task_id, "port_scanner", "172.16.0.1:22", "2026-04-22T18:00:00")
+
+    response = test_client.get(f"/api/v1/task/{task_id}/report/pdf")
+    assert response.status_code == 200
+    cd = response.headers["content-disposition"]
+    assert "secuscan_port-scanner_172-16-0-1-22_2026-04-22.pdf" in cd
+
+
+# ---------------------------------------------------------------------------
+# SARIF
+# ---------------------------------------------------------------------------
+
+def test_sarif_filename_url_target(test_client):
+    task_id = "fn-sarif-url-001"
+    _seed_task(task_id, "http_inspector", "https://scan.example.com", "2026-05-10T10:00:00")
+
+    response = test_client.get(f"/api/v1/task/{task_id}/report/sarif")
+    assert response.status_code == 200
+    cd = response.headers["content-disposition"]
+    assert "secuscan_http-inspector_scan-example-com_2026-05-10.sarif" in cd
+
+
+def test_sarif_filename_hostport_target(test_client):
+    task_id = "fn-sarif-hp-001"
+    _seed_task(task_id, "recon_scanner", "203.0.113.5:80", "2026-05-11T11:00:00")
+
+    response = test_client.get(f"/api/v1/task/{task_id}/report/sarif")
+    assert response.status_code == 200
+    cd = response.headers["content-disposition"]
+    assert "secuscan_recon-scanner_203-0-113-5-80_2026-05-11.sarif" in cd
+
+
+# ---------------------------------------------------------------------------
+# Error paths — 404 and unfinished task do not produce download headers
+# ---------------------------------------------------------------------------
+
+def test_report_404_for_missing_task(test_client):
+    response = test_client.get("/api/v1/task/does-not-exist-xyz/report/csv")
+    assert response.status_code == 404
+    assert "Task not found" in response.json()["detail"]
+
+
+def test_report_400_for_unfinished_task(test_client):
+    task_id = "fn-running-001"
+    _seed_task(task_id, "http_inspector", "https://example.com", "2026-05-14T10:00:00", status="running")
+
+    for fmt in ("csv", "html", "pdf", "sarif"):
+        response = test_client.get(f"/api/v1/task/{task_id}/report/{fmt}")
+        assert response.status_code == 400
+        assert "Task is not finished yet" in response.json()["detail"]

--- a/testing/backend/integration/test_routes_sarif.py
+++ b/testing/backend/integration/test_routes_sarif.py
@@ -69,8 +69,9 @@ def test_download_sarif_report_success(test_client):
 
     # Verify Content-Disposition header
     assert "attachment" in response.headers["content-disposition"]
-    assert "filename=secuscan_http-inspector_example-com_" in response.headers["content-disposition"]
-    assert response.headers["content-disposition"].endswith(".sarif")
+    assert "filename=" in response.headers["content-disposition"]
+    assert "secuscan_http-inspector_example-com_" in response.headers["content-disposition"]
+    assert ".sarif" in response.headers["content-disposition"]
 
     # Verify SARIF payload
     sarif = response.json()


### PR DESCRIPTION
## Summary

  Report download endpoints now return RFC 6266-compliant `Content-Disposition`
  headers, and integration tests verify the sanitised filename format for all
  four export types.

  ## Changes

  ### `backend/secuscan/routes.py`
  - Quoted filenames in `Content-Disposition` across all four download routes
    (`csv`, `html`, `pdf`, `sarif`) — `filename="..."` instead of bare `filename=...`
    returns `bytes`
    
  ### `testing/backend/integration/test_report_filenames.py` (new)
  - 10 tests covering URL targets and host:port targets for CSV, HTML, PDF, SARIF
  - Asserts sanitised filenames: `secuscan_{tool}_{target}_{date}.{ext}`
  - Covers 404 for missing tasks and 400 for unfinished tasks

  ### `testing/backend/integration/test_routes_sarif.py`
  - Fixed `.endswith(".sarif")` assertion that broke after filename quoting

  ## Test plan
  - [ ] `python -m pytest testing/backend/integration/test_report_filenames.py -v` — 10 passed
  - [ ] `python -m pytest testing/backend/integration/test_routes_sarif.py testing/backend/integration/test_routes.py -v` — 9 passed

  Closes #83

<img width="2124" height="1086" alt="Screenshot 2026-05-19 at 2 58 15 PM" src="https://github.com/user-attachments/assets/cbe7c84e-f03b-4860-af89-7f2b15784e59" />
<img width="2150" height="1622" alt="Screenshot 2026-05-19 at 2 59 01 PM" src="https://github.com/user-attachments/assets/6bcccd13-59ed-4b80-be94-0053833cba68" />
<img width="2150" height="1568" alt="Screenshot 2026-05-19 at 2 59 09 PM" src="https://github.com/user-attachments/assets/5fe6e860-31cb-43b0-9d2c-aaac52f28633" />
