### PR TITLE
feat: save and apply preferred export format via localStorage

### DIFF
--- a/frontend/src/hooks/usePreferredExportFormat.ts
+++ b/frontend/src/hooks/usePreferredExportFormat.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react'
+
+const STORAGE_KEY = 'secuscan:preferred-export-format'
+
+export function usePreferredExportFormat() {
+    const [preferred, setPreferred] = useState<string | null>(
+        () => localStorage.getItem(STORAGE_KEY)
+    )
+
+    function savePreference(format: string) {
+        localStorage.setItem(STORAGE_KEY, format)
+        setPreferred(format)
+    }
+
+    return { preferred, savePreference }
+}

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -16,6 +16,7 @@ import {
 } from '@hugeicons/core-free-icons'
 import { getDashboardSummary, getReports, API_BASE } from '../api'
 import { formatDateLong } from '../utils/date'
+import { usePreferredExportFormat } from '../hooks/usePreferredExportFormat'
 
 type Report = {
   id: string
@@ -47,7 +48,7 @@ const itemVariants = {
   },
 }
 
-const exportFormats = ['pdf', 'html', 'csv'] as const
+const exportFormats = ['pdf', 'html', 'csv' , 'sarif'] as const
 
 function ReportIcon({
   icon,
@@ -68,6 +69,7 @@ export default function Reports() {
   const [selectedType, setSelectedType] = useState('all')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const { preferred, savePreference } = usePreferredExportFormat()
 
   const fetchReports = () => {
     setLoading(true)
@@ -279,17 +281,24 @@ export default function Reports() {
                             >
                               <ReportIcon icon={ScanEyeIcon} size={18} />
                             </button>
-                            {exportFormats.map((format) => (
+                            {[...exportFormats].sort((a, b) =>
+                              a === preferred ? -1 : b === preferred ? 1 : 0
+                            ).map((format) => (
                               <button
                                 key={format}
                                 onClick={() => {
                                   if (report.status !== 'generating') {
+                                    savePreference(format)
                                     window.open(`${API_BASE}/task/${report.task_id}/report/${format}`, '_blank')
                                   }
                                 }}
                                 disabled={report.status === 'generating'}
-                                className="bg-charcoal-dark border-4 border-black px-3 py-2 text-[9px] font-black uppercase tracking-widest text-silver/20 group-hover:text-silver-bright group-hover:bg-black transition-all disabled:opacity-30 disabled:cursor-not-allowed disabled:group-hover:text-silver/20 disabled:group-hover:bg-charcoal-dark"
-                                title={report.status === 'generating' ? 'Export unavailable while report is generating' : `Download ${format.toUpperCase()}`}
+                                className={`border-4 border-black px-3 py-2 text-[9px] font-black uppercase tracking-widest transition-all disabled:opacity-30 disabled:cursor-not-allowed disabled:group-hover:text-silver/20 disabled:group-hover:bg-charcoal-dark ${
+                                  format === preferred
+                                    ? 'bg-rag-amber text-black group-hover:bg-rag-amber'
+                                    : 'bg-charcoal-dark text-silver/20 group-hover:text-silver-bright group-hover:bg-black'
+                                }`}
+                                title={report.status === 'generating' ? 'Export unavailable while report is generating' : `Download ${format.toUpperCase()}${format === preferred ? ' (preferred)' : ''}`}
                               >
                                 {format}
                               </button>

--- a/frontend/testing/unit/pages/Reports.preferredFormat.test.tsx
+++ b/frontend/testing/unit/pages/Reports.preferredFormat.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import Reports from '../../../src/pages/Reports'
+import { getReports, getDashboardSummary } from '../../../src/api'
+
+vi.mock('../../../src/api', () => ({
+    getReports: vi.fn(),
+    getDashboardSummary: vi.fn(),
+    API_BASE: 'http://127.0.0.1:8000',
+}))
+
+vi.spyOn(window, 'open').mockImplementation(() => null)
+
+const readyReport = {
+    id: 'report-1',
+    task_id: 'task-abc-123',
+    name: 'Security Scan — example.com',
+    type: 'technical',
+    generated_at: '2026-05-14T10:00:00Z',
+    status: 'ready',
+    findings: 7,
+    assets: 3,
+    pages: 12,
+}
+
+const emptySummary = {
+    total_findings: 0,
+    total_assets: 0,
+    critical_findings: 0,
+    high_findings: 0,
+    total_attack_surface: 0,
+}
+
+function renderReports() {
+    return render(
+        <MemoryRouter>
+            <Reports />
+        </MemoryRouter>,
+    )
+}
+
+beforeEach(() => {
+    localStorage.clear()
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+})
+
+describe('Reports — preferred export format', () => {
+    it('saves preferred format to localStorage when export button is clicked', async () => {
+        const user = userEvent.setup()
+        renderReports()
+
+        await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
+
+        expect(localStorage.getItem('secuscan:preferred-export-format')).toBe('pdf')
+    })
+
+    it('updates preferred format when a different format is clicked', async () => {
+        const user = userEvent.setup()
+        renderReports()
+
+        await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
+        await user.click(screen.getByRole('button', { name: /^csv$/i }))
+
+        expect(localStorage.getItem('secuscan:preferred-export-format')).toBe('csv')
+    })
+
+    it('highlights the preferred format button on load', async () => {
+        localStorage.setItem('secuscan:preferred-export-format', 'html')
+        renderReports()
+
+        const htmlBtn = await screen.findByRole('button', { name: /^html$/i })
+
+        expect(htmlBtn.className).toContain('bg-rag-amber')
+    })
+
+    it('preferred format button appears first', async () => {
+        localStorage.setItem('secuscan:preferred-export-format', 'csv')
+        renderReports()
+
+        await screen.findByRole('button', { name: /^csv$/i })
+
+        const buttons = screen.getAllByRole('button', { name: /^(pdf|html|csv)$/i })
+        expect(buttons[0].textContent?.toLowerCase()).toBe('csv')
+    })
+
+    it('preference survives a remount (simulates page reload)', async () => {
+        const user = userEvent.setup()
+        const { unmount } = renderReports()
+
+        await user.click(await screen.findByRole('button', { name: /^html$/i }))
+        unmount()
+
+        renderReports()
+
+        const htmlBtn = await screen.findByRole('button', { name: /^html$/i })
+        expect(htmlBtn.className).toContain('bg-rag-amber')
+    })
+})


### PR DESCRIPTION
## Description
Users who repeatedly export the same format had to manually select it every time. This PR adds a preferred export format saved to localStorage and applied automatically on return. The preferred format is highlighted in amber and sorted to the first position among the export buttons. SARIF is included since the backend already supports it (reporting.py, routes.py). Preference updates automatically whenever the user clicks any export button.
A new usePreferredExportFormat hook handles all localStorage read/write, keeping Reports.tsx clean and the logic reusable.

## Related Issues
Closes #123

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Added 5 focused unit tests in frontend/testing/unit/pages/Reports.preferredFormat.test.tsx covering:

1.Saving the preference to localStorage on click
2.Updating when a different format is clicked
3.Highlighting the preferred button on load
4.Ordering the preferred format first
5.Preference surviving a remount (simulates page reload)
All 13 test files, 72 tests passing.

Also manually verified in the browser using mock report data  and screenshots attached showing the amber highlight on the preferred format and correct reordering after reload.
<img width="1512" height="787" alt="image" src="https://github.com/user-attachments/assets/ed6d1c2e-1ec5-4829-b845-8a7741224054" />
<img width="1568" height="758" alt="image" src="https://github.com/user-attachments/assets/c886f5d6-5fac-410e-9cc3-26ed4a28d339" />
<img width="1523" height="784" alt="image" src="https://github.com/user-attachments/assets/19150b72-49d4-4791-99b8-c9df127c9384" />

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
