### PR TITLE
docs: document frontend production build path, API base URL, and SPA fallback

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -213,7 +213,7 @@ Add new endpoints in `src/services/api.js`:
 ```javascript
 export const api = {
   // ... existing methods
-  
+
   myNewEndpoint: (param) => request(`/my-endpoint/${param}`, {
     method: 'POST',
     body: JSON.stringify({ data: 'value' })
@@ -242,7 +242,7 @@ async function handleAction() {
 ### `<Layout>`
 Main app layout with sidebar navigation.
 
-**Props:** 
+**Props:**
 - `children` - Page content
 
 **Usage:**
@@ -353,9 +353,9 @@ import { useApp } from '../context/AppContext'
 
 function MyComponent() {
   const { plugins, settings, loading } = useApp()
-  
+
   if (loading) return <div>Loading...</div>
-  
+
   return <div>{plugins.length} plugins</div>
 }
 ```
@@ -494,14 +494,14 @@ The frontend resolves the backend URL via `src/api.ts::resolveApiBase()` in this
 | 2 | Window location heuristic | Dev server on a non-5173 port |
 | 3 | Vite proxy (`/api` → backend) | Local dev on port 5173 (default) |
 
-**`VITE_API_BASE` must be set at build time**, not at runtime. Vite inlines `import.meta.env` values during the 
+**`VITE_API_BASE` must be set at build time**, not at runtime. Vite inlines `import.meta.env` values during the
 build step — changing the env var after building has no effect.
 
 ```bash
 VITE_API_BASE=http://your-backend-host:8081/api/v1 npm run build
 ```
 
-Or create `frontend/.env.production`: 
+Or create `frontend/.env.production`:
 VITE_API_BASE=http://your-backend-host:8081/api/v1
 
 > ⚠️ Do not confuse `VITE_API_BASE` (frontend, build-time) with `VITE_API_PROXY_TARGET` (Vite dev server only — has no effect in a production build).
@@ -619,5 +619,5 @@ For issues or questions:
 
 ---
 
-**Last Updated:** October 29, 2025  
+**Last Updated:** October 29, 2025
 **Version:** 0.1.0-alpha

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -39,30 +39,30 @@ npm run preview
 frontend/
 ├── src/
 │   ├── components/          # Reusable UI components
-│   │   ├── Layout.jsx       # Main app layout with sidebar
-│   │   ├── ConsentModal.jsx # Consent confirmation dialog
-│   │   ├── DynamicForm.jsx  # Form generator from plugin schema
-│   │   └── TaskCard.jsx     # Task display card
+│   │   ├── AppShell.tsx     # Main app layout with sidebar
+│   │   ├── ConsentModal.tsx # Consent confirmation dialog
+│   │   ├── DynamicForm.tsx  # Form generator from plugin schema
+│   │   └── TaskCard.tsx     # Task display card
 │   │
 │   ├── pages/               # Route components
-│   │   ├── Scanner.jsx      # Main scanning interface
-│   │   ├── TaskHistory.jsx  # Task history list
-│   │   ├── TaskDetails.jsx  # Individual task view
-│   │   └── Settings.jsx     # Settings page
+│   │   ├── Scanner.tsx      # Main scanning interface
+│   │   ├── Scans.tsx        # Task history list
+│   │   ├── TaskDetails.tsx  # Individual task view
+│   │   └── Settings.tsx     # Settings page
 │   │
 │   ├── context/             # React Context for state
-│   │   └── AppContext.jsx   # Global app state
+│   │   └── AppContext.tsx   # Global app state
 │   │
 │   ├── services/            # API integration
-│   │   └── api.js           # Backend API client
+│   │   └── api.ts           # Backend API client
 │   │
-│   ├── App.jsx              # Main app component with routing
+│   ├── App.tsx              # Main app component with routing
 │   ├── App.css              # App-specific styles
-│   ├── main.jsx             # React entry point
+│   ├── main.tsx             # React entry point
 │   └── index.css            # Global styles
 │
 ├── index.html               # HTML template
-├── vite.config.js           # Vite configuration
+├── vite.config.ts           # Vite configuration
 ├── package.json             # Dependencies
 └── README.md                # This file
 ```
@@ -465,35 +465,118 @@ server: {
 
 ---
 
-## 📦 Deployment
+## 🏭 Production Deployment
 
-### Build for Production
+### 1. Build the frontend
 
 ```bash
-# Install dependencies
-npm install
-
-# Create production build
+cd frontend
+npm ci
 npm run build
 ```
 
-Output in `dist/` directory.
+Output lands in `frontend/dist/`. Verify locally before deploying:
 
-### Serve with Backend
-
-Option 1: **Static File Serving**
-```python
-# In backend/main.py
-from fastapi.staticfiles import StaticFiles
-
-app.mount("/", StaticFiles(directory="frontend/dist", html=True), name="frontend")
-```
-
-Option 2: **Separate Web Server**
 ```bash
-# Serve frontend with nginx/caddy/apache
-# Point backend API calls to backend server
+npm run preview
+# Serves dist/ at http://127.0.0.1:8080
 ```
+
+---
+
+### 2. Set the API base URL at build time
+
+The frontend resolves the backend URL via `src/api.ts::resolveApiBase()` in this priority order:
+
+| Priority | Mechanism | When to use |
+|----------|-----------|-------------|
+| 1 | `VITE_API_BASE` env var | Production — always set this |
+| 2 | Window location heuristic | Dev server on a non-5173 port |
+| 3 | Vite proxy (`/api` → backend) | Local dev on port 5173 (default) |
+
+**`VITE_API_BASE` must be set at build time**, not at runtime. Vite inlines `import.meta.env` values during the 
+build step — changing the env var after building has no effect.
+
+```bash
+VITE_API_BASE=http://your-backend-host:8081/api/v1 npm run build
+```
+
+Or create `frontend/.env.production`: 
+VITE_API_BASE=http://your-backend-host:8081/api/v1
+
+> ⚠️ Do not confuse `VITE_API_BASE` (frontend, build-time) with `VITE_API_PROXY_TARGET` (Vite dev server only — has no effect in a production build).
+
+---
+
+### 3. Serve the built frontend
+
+> ⚠️ `backend/secuscan/main.py` currently imports `StaticFiles` but does not mount the `dist/` directory. The backend cannot serve the frontend
+> yet. Use one of the options below until that is wired up.
+
+**Option A — nginx (recommended)**
+
+```nginx
+server {
+    listen 80;
+    root /path/to/frontend/dist;
+    index index.html;
+
+    # SPA fallback — required for React Router
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy API calls to the backend
+    location /api/ {
+        proxy_pass http://127.0.0.1:8081;
+        proxy_set_header Host $host;
+    }
+}
+```
+
+**Option B — quick local verification**
+
+```bash
+npx serve dist --single
+# --single enables the SPA fallback for React Router
+```
+
+---
+
+### 4. SPA route fallback — why it matters
+
+SecuScan uses React Router for client-side navigation. If a user visits `/task/abc123` directly or refreshes the page on any route, the web
+server looks for a real file at that path, finds nothing, and returns a **404**.
+
+The fix is always the same: serve `index.html` for any path that does not match a real static file. The nginx `try_files` directive and
+`serve --single` flag above both handle this. Without it, every direct link and browser refresh on a non-root route breaks.
+
+---
+
+### 5. Docker Compose note
+
+The current `docker-compose.yml` runs the frontend service with `npm run dev` (Vite development server). This is intentional for
+contributor workflows and is **not production-ready**. A multi-stage frontend Dockerfile is not yet present in the repository.
+
+---
+
+### Troubleshooting
+
+**404 on page refresh or direct URL**
+The SPA fallback is missing. Add `try_files $uri /index.html` to your nginx config or use `npx serve dist --single`.
+
+**All API calls fail after deploying**
+`VITE_API_BASE` was not set at build time. Rebuild with the correct value:
+```bash
+VITE_API_BASE=http://your-backend:8081/api/v1 npm run build
+```
+
+**`VITE_API_PROXY_TARGET` has no effect in production**
+This variable only configures the Vite dev server proxy. It is completely ignored in the production build.
+
+**CORS errors in the browser console**
+Add your frontend's origin to the backend config in `.env`:
+SECUSCAN_CORS_ALLOWED_ORIGINS=http://your-frontend-host
 
 ---
 


### PR DESCRIPTION
## Changes

- **Build instructions** — `npm ci && npm run build`, verify with `npm run preview`
- **API base URL** — explains `resolveApiBase()` priority order from `src/api.ts`, clarifies that `VITE_API_BASE` must be set at build time (Vite inlines env vars), and distinguishes it from `VITE_API_PROXY_TARGET` which is dev-only
- **Serving options** — nginx config with `try_files` SPA fallback + API proxy block; `npx serve dist --single` for quick local checks
- **StaticFiles note** — honestly documents that `backend/main.py` imports but does not mount `StaticFiles`, so the backend cannot serve the frontend yet
- **SPA fallback explanation** — explains why `try_files` / `--single` is required for React Router and what breaks without it
- **Troubleshooting** — 404-on-refresh, missing VITE_API_BASE, CORS errors
- **Stale file references** — corrects .jsx → .tsx and actual component names throughout the Project Structure section

## No code changes
Docs only. All commands and config snippets verified against the actual repo.

Closes #101 