### PR TITLE
feat(api): add plugin summary endpoint

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -121,6 +121,38 @@ async def list_plugins():
         total=len(plugins)
     )
 
+@router.get("/plugins/summary")
+async def get_plugins_summary():
+    """Return plugin summary statistics"""
+
+    plugin_manager = await get_plugin_manager_for_request()
+    plugins = plugin_manager.list_plugins()
+
+    total_plugins = len(plugins)
+    runnable_count = 0
+    unavailable_count = 0
+    category_counts: Dict[str, int] = {}
+
+    for plugin in plugins:
+        category = getattr(plugin, "category", "unknown")
+
+        category_counts[category] = (
+            category_counts.get(category, 0) + 1
+        )
+
+        availability = plugin.get("availability", {})
+        runnable = availability.get("runnable", False)
+
+        if runnable:
+            runnable_count += 1
+        else:
+            unavailable_count += 1
+    return {
+        "total_plugins": total_plugins,
+        "runnable_count": runnable_count,
+        "unavailable_count": unavailable_count,
+        "category_counts": dict(sorted(category_counts.items()))
+    }
 
 @router.get("/plugin/{plugin_id}/schema")
 async def get_plugin_schema(plugin_id: str):

--- a/testing/backend/integration/test_routes.py
+++ b/testing/backend/integration/test_routes.py
@@ -28,6 +28,29 @@ def test_list_plugins(test_client):
         assert "runnable" in first["availability"]
         assert "missing_binaries" in first["availability"]
 
+def test_plugin_summary(test_client):
+    """Test plugin summary endpoint."""
+
+    response = test_client.get("/api/v1/plugins/summary")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert "total_plugins" in data
+    assert "runnable_count" in data
+    assert "unavailable_count" in data
+    assert "category_counts" in data
+
+    assert isinstance(data["total_plugins"], int)
+    assert isinstance(data["runnable_count"], int)
+    assert isinstance(data["unavailable_count"], int)
+    assert isinstance(data["category_counts"], dict)
+    assert (
+    data["runnable_count"] +
+    data["unavailable_count"]
+    ) == data["total_plugins"]
+
 
 def test_start_task(test_client):
     """Test starting a task with a mocked executor."""


### PR DESCRIPTION
## Description

Adds a new backend endpoint under `/api/v1/plugins/summary` that returns:

* Total plugin count
* Runnable plugin count
* Unavailable plugin count
* Plugin counts grouped by category

The implementation reuses existing plugin manager data and avoids unnecessary filesystem rescans.

## Related Issues

Closes #124

## Type of Change

* [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested locally using:

```bash
pytest testing/backend/integration/test_routes.py -k plugin_summary -v
```

Result:

```text
1 passed
```

Also verified the endpoint manually at:

```text
http://127.0.0.1:8000/api/v1/plugins/summary
```

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [x] My changes generate no new warnings.

Note: Existing `test_start_task` integration test fails locally due to environment/plugin availability setup on Windows, but the newly added `test_plugin_summary` passes successfully.