### PR TITLE
feat: add pagination controls to Scans history (#114)

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -645,7 +645,7 @@ async def list_tasks(
             t["task_id"] = t.pop("id")
         t["inputs"] = t.pop("inputs_json", {})
 
-    total_pages = (total + per_page - 1)  per_page if per_page > 0 else 0
+    total_pages = (total + per_page - 1) // per_page if per_page > 0 else 0
     return {
         "tasks": tasks_list,
         "pagination": {

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -645,7 +645,7 @@ async def list_tasks(
             t["task_id"] = t.pop("id")
         t["inputs"] = t.pop("inputs_json", {})
 
-    total_pages = (total + per_page - 1) // per_page if per_page > 0 else 0
+    total_pages = (total + per_page - 1)  per_page if per_page > 0 else 0
     return {
         "tasks": tasks_list,
         "pagination": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -142,6 +142,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -503,6 +504,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -551,6 +553,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -560,6 +563,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
       "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -1658,8 +1662,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1782,6 +1785,7 @@
       "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.21.0"
       }
@@ -1812,6 +1816,7 @@
       "integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1823,6 +1828,7 @@
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -1953,7 +1959,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1964,7 +1969,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2135,6 +2139,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2596,8 +2601,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -3038,6 +3042,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3206,7 +3211,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3489,6 +3493,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3636,7 +3641,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3651,8 +3655,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3700,6 +3703,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3712,6 +3716,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3741,6 +3746,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3871,7 +3877,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4344,6 +4351,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4568,6 +4576,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5204,6 +5213,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5755,6 +5765,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+interface PaginationProps {
+  page: number
+  total: number
+  limit: number
+  loading: boolean
+  onPrev: () => void
+  onNext: () => void
+}
+
+export default function Pagination({ page, total, limit, loading, onPrev, onNext }: PaginationProps) {
+  const start = total === 0 ? 0 : (page - 1) * limit + 1
+  const end = Math.min(page * limit, total)
+  const isFirst = page === 1
+  const isLast = end >= total
+
+  return (
+    <div className="flex flex-col sm:flex-row items-center justify-between gap-6 border-t-4 border-silver-bright/10 pt-8">
+      <p className="text-[10px] font-mono text-silver/30 uppercase tracking-widest italic">
+        Showing_Records: <span className="text-silver-bright">{start}–{end}</span> // Total: <span className="text-rag-blue">{total}</span>
+      </p>
+      <div className="flex items-center gap-4">
+        <button
+          onClick={onPrev}
+          disabled={isFirst || loading}
+          className="px-6 py-3 text-[10px] font-black uppercase tracking-widest border-2 border-silver-bright/10 text-silver/40 hover:border-rag-blue hover:text-rag-blue transition-all flex items-center gap-2 disabled:opacity-20 disabled:cursor-not-allowed italic"
+        >
+          <span className="material-symbols-outlined text-sm">arrow_back</span>
+          Prev_Page
+        </button>
+        <div className="bg-charcoal-dark border-2 border-black px-4 py-3 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]">
+          <span className="text-[10px] font-black font-mono text-rag-blue">{page}</span>
+        </div>
+        <button
+          onClick={onNext}
+          disabled={isLast || loading}
+          className="px-6 py-3 text-[10px] font-black uppercase tracking-widest border-2 border-silver-bright/10 text-silver/40 hover:border-rag-blue hover:text-rag-blue transition-all flex items-center gap-2 disabled:opacity-20 disabled:cursor-not-allowed italic"
+        >
+          Next_Page
+          <span className="material-symbols-outlined text-sm">arrow_forward</span>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,24 +1,35 @@
-import React from 'react'
+import React from "react";
 
 interface PaginationProps {
-  page: number
-  total: number
-  limit: number
-  loading: boolean
-  onPrev: () => void
-  onNext: () => void
+  page: number;
+  total: number;
+  limit: number;
+  loading: boolean;
+  onPrev: () => void;
+  onNext: () => void;
 }
 
-export default function Pagination({ page, total, limit, loading, onPrev, onNext }: PaginationProps) {
-  const start = total === 0 ? 0 : (page - 1) * limit + 1
-  const end = Math.min(page * limit, total)
-  const isFirst = page === 1
-  const isLast = end >= total
+export default function Pagination({
+  page,
+  total,
+  limit,
+  loading,
+  onPrev,
+  onNext,
+}: PaginationProps) {
+  const start = total === 0 ? 0 : (page - 1) * limit + 1;
+  const end = Math.min(page * limit, total);
+  const isFirst = page === 1;
+  const isLast = end >= total;
 
   return (
     <div className="flex flex-col sm:flex-row items-center justify-between gap-6 border-t-4 border-silver-bright/10 pt-8">
       <p className="text-[10px] font-mono text-silver/30 uppercase tracking-widest italic">
-        Showing_Records: <span className="text-silver-bright">{start}–{end}</span> // Total: <span className="text-rag-blue">{total}</span>
+        Showing_Records:{" "}
+        <span className="text-silver-bright">
+          {start}–{end}
+        </span>{" "}
+        // Total: <span className="text-rag-blue">{total}</span>
       </p>
       <div className="flex items-center gap-4">
         <button
@@ -30,7 +41,9 @@ export default function Pagination({ page, total, limit, loading, onPrev, onNext
           Prev_Page
         </button>
         <div className="bg-charcoal-dark border-2 border-black px-4 py-3 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]">
-          <span className="text-[10px] font-black font-mono text-rag-blue">{page}</span>
+          <span className="text-[10px] font-black font-mono text-rag-blue">
+            {page}
+          </span>
         </div>
         <button
           onClick={onNext}
@@ -38,9 +51,11 @@ export default function Pagination({ page, total, limit, loading, onPrev, onNext
           className="px-6 py-3 text-[10px] font-black uppercase tracking-widest border-2 border-silver-bright/10 text-silver/40 hover:border-rag-blue hover:text-rag-blue transition-all flex items-center gap-2 disabled:opacity-20 disabled:cursor-not-allowed italic"
         >
           Next_Page
-          <span className="material-symbols-outlined text-sm">arrow_forward</span>
+          <span className="material-symbols-outlined text-sm">
+            arrow_forward
+          </span>
         </button>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { API_BASE, deleteTask, clearAllTasks, bulkDeleteTasks } from '../api'
 import { routePath } from '../routes'
 import { parseDateSafe, formatLocaleDate, formatLocaleTime } from '../utils/date'
+import Pagination from '../components/Pagination'
 
 interface Task {
     task_id: string
@@ -54,27 +55,38 @@ export default function Scans() {
     const [filter, setFilter] = useState('all')
     const [expandedId, setExpandedId] = useState<string | null>(null)
     const [selectedIds, setSelectedIds] = useState<string[]>([])
+    const [page, setPage] = useState(1)
+    const [total, setTotal] = useState(0)
+    const PAGE_LIMIT = 10
 
     useEffect(() => {
         loadTasks()
         const interval = setInterval(loadTasks, 5000)
         return () => clearInterval(interval)
-    }, [filter])
+    }, [filter, page])
 
     async function loadTasks() {
         try {
-            const url = filter === 'all'
-                ? `${API_BASE}/tasks`
-                : `${API_BASE}/tasks?status=${filter}`
+            const params = new URLSearchParams()
+            if (filter !== 'all') params.set('status', filter)
+            params.set('page', String(page))
+            params.set('per_page', String(PAGE_LIMIT))  
 
-            const res = await fetch(url)
+            const res = await fetch(`${API_BASE}/tasks?${params.toString()}`)
             const data = await res.json()
             setTasks(data.tasks || [])
+            if (data.pagination?.total_items !== undefined) {
+                setTotal(data.pagination.total_items)  
+            }
         } catch (err) {
             console.error('Failed to load tasks:', err)
         } finally {
             setLoading(false)
         }
+    }
+    function handleFilterChange(value: string) {
+        setFilter(value)
+        setPage(1)
     }
 
     async function handleRescan(task: Task) {
@@ -182,7 +194,7 @@ export default function Scans() {
                     Operational <span className="text-transparent stroke-white" style={{ WebkitTextStroke: '1px var(--accent-silver-bright)' }}>Registry</span>
                   </h1>
                   <p className="text-sm font-mono text-silver/40 uppercase tracking-widest italic flex items-center gap-4">
-                    Total_Registry_Keys: {tasks.length} // SYSTEM_STATUS: {loading ? 'SYNCING...' : 'SYNCED'}
+                    Total_Registry_Keys: {total} // SYSTEM_STATUS: {loading ? 'SYNCING...' : 'SYNCED'}
                     <span className={`w-2 h-2 rounded-full ${loading ? 'bg-rag-amber animate-pulse' : 'bg-rag-green'}`}></span>
                   </p>
                 </div>
@@ -215,7 +227,7 @@ export default function Scans() {
                     {statusFilters.map(f => (
                         <button
                             key={f.value}
-                            onClick={() => setFilter(f.value)}
+                            onClick={() => handleFilterChange(f.value)}
                             className={`px-6 py-3 text-[10px] font-black uppercase tracking-widest transition-all border-2 flex items-center gap-2 ${
                                 filter === f.value 
                                 ? 'bg-silver-bright text-black border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] -translate-x-0.5 -translate-y-0.5' 
@@ -430,6 +442,16 @@ export default function Scans() {
                         </div>
                     )}
                 </AnimatePresence>
+                {total > PAGE_LIMIT && (
+                    <Pagination
+                        page={page}
+                        total={total}
+                        limit={PAGE_LIMIT}
+                        loading={loading}
+                        onPrev={() => setPage(p => p - 1)}
+                        onNext={() => setPage(p => p + 1)}
+                    />
+                )}
             </section>
 
             {/* Floating Bulk Action Bar */}

--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -1,506 +1,625 @@
-import React, { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { motion, AnimatePresence } from 'framer-motion'
-import { API_BASE, deleteTask, clearAllTasks, bulkDeleteTasks } from '../api'
-import { routePath } from '../routes'
-import { parseDateSafe, formatLocaleDate, formatLocaleTime } from '../utils/date'
-import Pagination from '../components/Pagination'
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { motion, AnimatePresence } from "framer-motion";
+import { API_BASE, deleteTask, clearAllTasks, bulkDeleteTasks } from "../api";
+import { routePath } from "../routes";
+import {
+  parseDateSafe,
+  formatLocaleDate,
+  formatLocaleTime,
+} from "../utils/date";
+import Pagination from "../components/Pagination";
 
 interface Task {
-    task_id: string
-    plugin_id: string
-    tool: string
-    target: string
-    status: 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
-    created_at: string
-    started_at?: string
-    completed_at?: string
-    duration_seconds?: number
-    inputs?: any
-    preset?: string
-    queue_position?: number
-    pending_count?: number
+  task_id: string;
+  plugin_id: string;
+  tool: string;
+  target: string;
+  status: "queued" | "running" | "completed" | "failed" | "cancelled";
+  created_at: string;
+  started_at?: string;
+  completed_at?: string;
+  duration_seconds?: number;
+  inputs?: any;
+  preset?: string;
+  queue_position?: number;
+  pending_count?: number;
 }
 
 const statusFilters = [
-    { value: 'all', label: 'ALL_OPERATIONS' },
-    { value: 'running', label: 'ACTIVE_EXECUTION' },
-    { value: 'completed', label: 'TERMINATED_SUCCESS' },
-    { value: 'failed', label: 'SYSTEM_FAILURE' },
-    { value: 'cancelled', label: 'MANUAL_ABORT' }
-]
+  { value: "all", label: "ALL_OPERATIONS" },
+  { value: "running", label: "ACTIVE_EXECUTION" },
+  { value: "completed", label: "TERMINATED_SUCCESS" },
+  { value: "failed", label: "SYSTEM_FAILURE" },
+  { value: "cancelled", label: "MANUAL_ABORT" },
+];
 
 const containerVariants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
-    transition: { staggerChildren: 0.1 }
-  }
-} as const
+    transition: { staggerChildren: 0.1 },
+  },
+} as const;
 
 const itemVariants = {
   hidden: { opacity: 0, scale: 0.95, y: 20 },
-  visible: { 
-    opacity: 1, 
-    scale: 1, 
+  visible: {
+    opacity: 1,
+    scale: 1,
     y: 0,
-    transition: { type: 'spring', stiffness: 200, damping: 20 } as any
-  }
-} as const
+    transition: { type: "spring", stiffness: 200, damping: 20 } as any,
+  },
+} as const;
 
 export default function Scans() {
-    const navigate = useNavigate()
-    const [tasks, setTasks] = useState<Task[]>([])
-    const [loading, setLoading] = useState(true)
-    const [filter, setFilter] = useState('all')
-    const [expandedId, setExpandedId] = useState<string | null>(null)
-    const [selectedIds, setSelectedIds] = useState<string[]>([])
-    const [page, setPage] = useState(1)
-    const [total, setTotal] = useState(0)
-    const PAGE_LIMIT = 10
+  const navigate = useNavigate();
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState("all");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const PAGE_LIMIT = 10;
 
-    useEffect(() => {
-        loadTasks()
-        const interval = setInterval(loadTasks, 5000)
-        return () => clearInterval(interval)
-    }, [filter, page])
+  useEffect(() => {
+    loadTasks();
+    const interval = setInterval(loadTasks, 5000);
+    return () => clearInterval(interval);
+  }, [filter, page]);
 
-    async function loadTasks() {
-        try {
-            const params = new URLSearchParams()
-            if (filter !== 'all') params.set('status', filter)
-            params.set('page', String(page))
-            params.set('per_page', String(PAGE_LIMIT))  
+  async function loadTasks() {
+    try {
+      const params = new URLSearchParams();
+      if (filter !== "all") params.set("status", filter);
+      params.set("page", String(page));
+      params.set("per_page", String(PAGE_LIMIT));
 
-            const res = await fetch(`${API_BASE}/tasks?${params.toString()}`)
-            const data = await res.json()
-            setTasks(data.tasks || [])
-            if (data.pagination?.total_items !== undefined) {
-                setTotal(data.pagination.total_items)  
-            }
-        } catch (err) {
-            console.error('Failed to load tasks:', err)
-        } finally {
-            setLoading(false)
-        }
+      const res = await fetch(`${API_BASE}/tasks?${params.toString()}`);
+      const data = await res.json();
+      setTasks(data.tasks || []);
+      if (data.pagination?.total_items !== undefined) {
+        setTotal(data.pagination.total_items);
+      }
+    } catch (err) {
+      console.error("Failed to load tasks:", err);
+    } finally {
+      setLoading(false);
     }
-    function handleFilterChange(value: string) {
-        setFilter(value)
-        setPage(1)
+  }
+  function handleFilterChange(value: string) {
+    setFilter(value);
+    setPage(1);
+  }
+
+  async function handleRescan(task: Task) {
+    try {
+      const res = await fetch(`${API_BASE}/task/start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          plugin_id: task.plugin_id,
+          inputs: task.inputs || {},
+          consent_granted: true,
+          preset: task.preset,
+        }),
+      });
+      const data = await res.json();
+      if (data.task_id) {
+        navigate(routePath.task(data.task_id));
+      }
+    } catch (err) {
+      console.error("Rescan failed:", err);
     }
+  }
 
-    async function handleRescan(task: Task) {
-        try {
-            const res = await fetch(`${API_BASE}/task/start`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    plugin_id: task.plugin_id,
-                    inputs: task.inputs || {},
-                    consent_granted: true,
-                    preset: task.preset
-                })
-            })
-            const data = await res.json()
-            if (data.task_id) {
-                navigate(routePath.task(data.task_id))
-            }
-        } catch (err) {
-            console.error('Rescan failed:', err)
-        }
-    }
-
-    async function handleTaskDelete(taskId: string) {
-        if (!window.confirm('Are you sure you want to delete this scan record? This will also remove associated findings and reports.')) {
-            return
-        }
-
-        try {
-            await deleteTask(taskId)
-            setTasks(prev => prev.filter(t => t.task_id !== taskId))
-            if (expandedId === taskId) setExpandedId(null)
-        } catch (err) {
-            console.error('Failed to delete task:', err)
-            alert('Failed to delete task. It might still be running.')
-        }
+  async function handleTaskDelete(taskId: string) {
+    if (
+      !window.confirm(
+        "Are you sure you want to delete this scan record? This will also remove associated findings and reports.",
+      )
+    ) {
+      return;
     }
 
-    async function handleClearAll() {
-        if (!window.confirm('CRITICAL: Are you sure you want to PURGE ALL RECORDS? This will wipe all scan history, findings, assets, and reports. This action is irreversible.')) {
-            return
-        }
+    try {
+      await deleteTask(taskId);
+      setTasks((prev) => prev.filter((t) => t.task_id !== taskId));
+      if (expandedId === taskId) setExpandedId(null);
+    } catch (err) {
+      console.error("Failed to delete task:", err);
+      alert("Failed to delete task. It might still be running.");
+    }
+  }
 
-        try {
-            await clearAllTasks()
-            setTasks([])
-            setSelectedIds([])
-            setExpandedId(null)
-        } catch (err) {
-            console.error('Failed to clear history:', err)
-            alert('Failed to clear history. Ensure no tasks are currently running.')
-        }
+  async function handleClearAll() {
+    if (
+      !window.confirm(
+        "CRITICAL: Are you sure you want to PURGE ALL RECORDS? This will wipe all scan history, findings, assets, and reports. This action is irreversible.",
+      )
+    ) {
+      return;
     }
 
-    async function handleBulkDelete() {
-        if (selectedIds.length === 0) return
-        if (!window.confirm(`Are you sure you want to delete ${selectedIds.length} selected scan records?`)) {
-            return
-        }
+    try {
+      await clearAllTasks();
+      setTasks([]);
+      setSelectedIds([]);
+      setExpandedId(null);
+    } catch (err) {
+      console.error("Failed to clear history:", err);
+      alert("Failed to clear history. Ensure no tasks are currently running.");
+    }
+  }
 
-        try {
-            await bulkDeleteTasks(selectedIds)
-            setTasks(prev => prev.filter(t => !selectedIds.includes(t.task_id)))
-            setSelectedIds([])
-        } catch (err) {
-            console.error('Bulk delete failed:', err)
-            alert('Failed to delete some tasks. Ensure they are not currently running.')
-        }
+  async function handleBulkDelete() {
+    if (selectedIds.length === 0) return;
+    if (
+      !window.confirm(
+        `Are you sure you want to delete ${selectedIds.length} selected scan records?`,
+      )
+    ) {
+      return;
     }
 
-    function toggleSelection(taskId: string, e: React.MouseEvent) {
-        e.stopPropagation()
-        setSelectedIds(prev => 
-            prev.includes(taskId) 
-            ? prev.filter(id => id !== taskId) 
-            : [...prev, taskId]
-        )
+    try {
+      await bulkDeleteTasks(selectedIds);
+      setTasks((prev) => prev.filter((t) => !selectedIds.includes(t.task_id)));
+      setSelectedIds([]);
+    } catch (err) {
+      console.error("Bulk delete failed:", err);
+      alert(
+        "Failed to delete some tasks. Ensure they are not currently running.",
+      );
     }
+  }
 
-    function toggleSelectAll() {
-        if (selectedIds.length === tasks.length) {
-            setSelectedIds([])
-        } else {
-            setSelectedIds(tasks.map(t => t.task_id))
-        }
+  function toggleSelection(taskId: string, e: React.MouseEvent) {
+    e.stopPropagation();
+    setSelectedIds((prev) =>
+      prev.includes(taskId)
+        ? prev.filter((id) => id !== taskId)
+        : [...prev, taskId],
+    );
+  }
+
+  function toggleSelectAll() {
+    if (selectedIds.length === tasks.length) {
+      setSelectedIds([]);
+    } else {
+      setSelectedIds(tasks.map((t) => t.task_id));
     }
+  }
 
-    function formatDuration(seconds?: number) {
-        if (!seconds) return null
-        if (seconds < 60) return `${Math.round(seconds)}s`
-        if (seconds < 3600) return `${Math.round(seconds / 60)}m`
-        return `${Math.round(seconds / 3600)}h`
-    }
+  function formatDuration(seconds?: number) {
+    if (!seconds) return null;
+    if (seconds < 60) return `${Math.round(seconds)}s`;
+    if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+    return `${Math.round(seconds / 3600)}h`;
+  }
 
-    return (
-        <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
-            
-            {/* Neo-Brutalist Header */}
-            <header className="relative flex flex-col md:flex-row justify-between items-start md:items-end gap-8 pb-12 border-b-4 border-silver-bright/10">
-                <div className="space-y-4">
-                  <div className="bg-rag-blue text-black px-4 py-1 text-xs font-black uppercase tracking-widest inline-block shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
-                    Operational_Registry_v10.1
-                  </div>
-                  <h1 className="text-6xl md:text-8xl font-black text-silver-bright uppercase tracking-tighter leading-none italic">
-                    Operational <span className="text-transparent stroke-white" style={{ WebkitTextStroke: '1px var(--accent-silver-bright)' }}>Registry</span>
-                  </h1>
-                  <p className="text-sm font-mono text-silver/40 uppercase tracking-widest italic flex items-center gap-4">
-                    Total_Registry_Keys: {total} // SYSTEM_STATUS: {loading ? 'SYNCING...' : 'SYNCED'}
-                    <span className={`w-2 h-2 rounded-full ${loading ? 'bg-rag-amber animate-pulse' : 'bg-rag-green'}`}></span>
+  return (
+    <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
+      {/* Neo-Brutalist Header */}
+      <header className="relative flex flex-col md:flex-row justify-between items-start md:items-end gap-8 pb-12 border-b-4 border-silver-bright/10">
+        <div className="space-y-4">
+          <div className="bg-rag-blue text-black px-4 py-1 text-xs font-black uppercase tracking-widest inline-block shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+            Operational_Registry_v10.1
+          </div>
+          <h1 className="text-6xl md:text-8xl font-black text-silver-bright uppercase tracking-tighter leading-none italic">
+            Operational{" "}
+            <span
+              className="text-transparent stroke-white"
+              style={{ WebkitTextStroke: "1px var(--accent-silver-bright)" }}
+            >
+              Registry
+            </span>
+          </h1>
+          <p className="text-sm font-mono text-silver/40 uppercase tracking-widest italic flex items-center gap-4">
+            Total_Registry_Keys: {total} // SYSTEM_STATUS:{" "}
+            {loading ? "SYNCING..." : "SYNCED"}
+            <span
+              className={`w-2 h-2 rounded-full ${loading ? "bg-rag-amber animate-pulse" : "bg-rag-green"}`}
+            ></span>
+          </p>
+        </div>
+
+        <div className="flex items-center gap-12 border-l-4 border-silver-bright/10 pl-12 hidden lg:flex">
+          <div className="text-right">
+            <span className="text-[10px] font-black text-silver/40 uppercase tracking-[0.3em] block mb-2 italic">
+              Integrity_Check
+            </span>
+            <span className="text-xs font-mono text-rag-green uppercase font-black">
+              OPSEC_CLEARANCE_L5
+            </span>
+          </div>
+        </div>
+      </header>
+
+      {/* Filtration Block */}
+      <section className="bg-charcoal border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] flex flex-col xl:flex-row justify-between items-center gap-12">
+        <div className="flex flex-wrap items-center gap-4">
+          <button
+            onClick={toggleSelectAll}
+            className={`px-6 py-3 text-[10px] font-black uppercase tracking-widest transition-all border-2 flex items-center gap-3 ${
+              selectedIds.length === tasks.length && tasks.length > 0
+                ? "bg-rag-blue text-black border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]"
+                : "bg-charcoal-dark text-silver/30 border-silver-bright/5 hover:border-silver-bright/20"
+            }`}
+          >
+            <span className="material-symbols-outlined text-sm">
+              {selectedIds.length === tasks.length && tasks.length > 0
+                ? "check_box"
+                : "check_box_outline_blank"}
+            </span>
+            Select_All
+          </button>
+          <div className="w-1 h-8 bg-black/40 mx-2 hidden md:block"></div>
+          {statusFilters.map((f) => (
+            <button
+              key={f.value}
+              onClick={() => handleFilterChange(f.value)}
+              className={`px-6 py-3 text-[10px] font-black uppercase tracking-widest transition-all border-2 flex items-center gap-2 ${
+                filter === f.value
+                  ? "bg-silver-bright text-black border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] -translate-x-0.5 -translate-y-0.5"
+                  : "bg-charcoal-dark text-silver/30 border-silver-bright/5 hover:border-silver-bright/20"
+              }`}
+            >
+              {f.label}
+              {filter === f.value && <span className="w-1 h-3 bg-black"></span>}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-6">
+          {tasks.length > 0 && (
+            <button
+              onClick={handleClearAll}
+              className="px-6 py-3 text-[10px] font-black uppercase tracking-widest transition-all border-2 bg-rag-red/10 text-rag-red border-rag-red/20 hover:bg-rag-red hover:text-black hover:border-black flex items-center gap-2 italic"
+            >
+              Purge_All_Records
+              <span className="material-symbols-outlined text-sm">
+                delete_forever
+              </span>
+            </button>
+          )}
+          <div className="flex items-center gap-4 text-[10px] font-mono text-silver/20 uppercase italic tracking-widest hidden sm:flex">
+            Isolation_Protocol_Active //{" "}
+            <span className="text-rag-blue">v4_stable</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Timeline Operations Feed */}
+      <section className="relative">
+        {/* Vertical Timeline Cable */}
+        <div className="absolute left-[39px] top-0 bottom-0 w-1 bg-silver-bright/5 hidden md:block"></div>
+
+        <AnimatePresence mode="popLayout">
+          {tasks.length > 0 ? (
+            <motion.div
+              variants={containerVariants}
+              initial="hidden"
+              animate="visible"
+              className="space-y-8"
+            >
+              {tasks.map((task) => {
+                const createDate = parseDateSafe(task.created_at);
+                const startDate = task.started_at
+                  ? parseDateSafe(task.started_at)
+                  : null;
+                const endDate = task.completed_at
+                  ? parseDateSafe(task.completed_at)
+                  : null;
+
+                return (
+                  <motion.div
+                    key={task.task_id}
+                    variants={itemVariants}
+                    layout
+                    className={`relative group md:pl-20 transition-all`}
+                  >
+                    {/* Timeline Node */}
+                    <div
+                      className={`absolute left-[31px] top-12 w-5 h-5 border-4 border-black z-10 hidden md:block transition-all duration-500 ${
+                        task.status === "completed"
+                          ? "bg-rag-green shadow-[0_0_15px_rgba(34,197,94,0.3)]"
+                          : task.status === "failed"
+                            ? "bg-rag-red"
+                            : task.status === "running"
+                              ? "bg-rag-amber animate-pulse"
+                              : "bg-silver/10"
+                      }`}
+                    ></div>
+
+                    <div
+                      className={`bg-charcoal border-4 border-black p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-[12px_12px_0px_0px_rgba(0,0,0,1)] transition-all cursor-pointer relative overflow-hidden group/card ${
+                        expandedId === task.task_id
+                          ? "border-rag-blue/40 shadow-[12px_12px_0px_0px_rgba(0,0,0,1)]"
+                          : ""
+                      }`}
+                      onClick={() =>
+                        setExpandedId(
+                          expandedId === task.task_id ? null : task.task_id,
+                        )
+                      }
+                    >
+                      <div className="flex flex-col xl:flex-row justify-between gap-8">
+                        <div className="flex-1 space-y-6">
+                          <div className="flex flex-wrap items-center gap-4">
+                            <div
+                              onClick={(e) => toggleSelection(task.task_id, e)}
+                              className={`w-10 h-10 border-4 border-black flex items-center justify-center transition-all ${
+                                selectedIds.includes(task.task_id)
+                                  ? "bg-rag-blue text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] -translate-x-1 -translate-y-1"
+                                  : "bg-charcoal-dark text-silver/10 hover:border-rag-blue/40"
+                              }`}
+                            >
+                              <span className="material-symbols-outlined text-base font-black">
+                                {selectedIds.includes(task.task_id)
+                                  ? "check"
+                                  : "add"}
+                              </span>
+                            </div>
+                            <span
+                              className={`px-2 py-0.5 text-[9px] font-black uppercase italic border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] ${
+                                task.status === "completed"
+                                  ? "bg-rag-green text-black"
+                                  : task.status === "failed"
+                                    ? "bg-rag-red text-black"
+                                    : "bg-charcoal-dark text-silver-bright/50"
+                              }`}
+                            >
+                              {task.status}
+                            </span>
+                            {task.status === "queued" &&
+                              task.queue_position && (
+                                <span className="text-[9px] font-mono text-rag-amber uppercase tracking-widest">
+                                  Queue #{task.queue_position}/
+                                  {task.pending_count}
+                                </span>
+                              )}
+                            <span className="text-[10px] font-mono text-silver/20 uppercase tracking-widest italic">
+                              OP_ID_{task.task_id.split("-")[0].toUpperCase()}
+                            </span>
+                          </div>
+
+                          <div className="space-y-2">
+                            <h3 className="text-3xl font-black text-silver-bright uppercase tracking-tighter italic leading-none group-hover/card:text-rag-blue transition-colors">
+                              {task.tool}
+                            </h3>
+                            <p className="text-xs font-mono text-silver/40 uppercase tracking-widest flex items-center gap-3">
+                              <span className="material-symbols-outlined text-sm">
+                                target
+                              </span>
+                              {task.target}
+                            </p>
+                          </div>
+                        </div>
+
+                        <div className="flex flex-row xl:flex-col items-center xl:items-end justify-between xl:justify-center gap-8 shrink-0">
+                          <div className="text-left xl:text-right">
+                            <p className="text-[8px] font-black uppercase text-silver/20 tracking-[0.3em] mb-1 italic">
+                              Historical_Execution
+                            </p>
+                            <p className="text-xs font-mono text-silver-bright/80 uppercase">
+                              {formatLocaleDate(createDate)} //{" "}
+                              {formatLocaleTime(createDate)}
+                            </p>
+                          </div>
+                          {task.duration_seconds && (
+                            <div className="bg-charcoal-dark border-2 border-black px-4 py-2 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]">
+                              <p className="text-[10px] font-black font-mono text-rag-blue leading-none">
+                                {formatDuration(
+                                  task.duration_seconds,
+                                )?.toUpperCase()}
+                              </p>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Expandable Details Block */}
+                      <AnimatePresence>
+                        {expandedId === task.task_id && (
+                          <motion.div
+                            initial={{ height: 0, opacity: 0 }}
+                            animate={{ height: "auto", opacity: 1 }}
+                            exit={{ height: 0, opacity: 0 }}
+                            className="overflow-hidden"
+                          >
+                            <div className="mt-12 pt-12 border-t-4 border-black grid grid-cols-1 md:grid-cols-3 gap-12 bg-charcoal-dark/20 -mx-8 -mb-8 p-8 border-dashed">
+                              <div className="space-y-4">
+                                <h5 className="text-[10px] font-black text-silver-bright uppercase tracking-[0.3em] italic flex items-center gap-3">
+                                  <span className="w-1.5 h-3 bg-rag-blue"></span>{" "}
+                                  Signal_Metadata
+                                </h5>
+                                <div className="space-y-2">
+                                  <p className="text-[10px] font-mono text-silver/40">
+                                    PLUGIN:{" "}
+                                    <span className="text-silver-bright uppercase">
+                                      {task.plugin_id}
+                                    </span>
+                                  </p>
+                                  <p className="text-[10px] font-mono text-silver/40">
+                                    SESSION:{" "}
+                                    <span className="text-silver-bright uppercase">
+                                      ENCRYPTED_VTX
+                                    </span>
+                                  </p>
+                                </div>
+                              </div>
+
+                              <div className="space-y-4">
+                                <h5 className="text-[10px] font-black text-silver-bright uppercase tracking-[0.3em] italic flex items-center gap-3">
+                                  <span className="w-1.5 h-3 bg-rag-amber"></span>{" "}
+                                  Time_Matrix
+                                </h5>
+                                <div className="grid grid-cols-2 gap-4">
+                                  <div className="space-y-1">
+                                    <span className="text-[8px] text-silver/20 uppercase font-black tracking-widest">
+                                      In_Lock
+                                    </span>
+                                    <span className="text-[10px] font-mono text-silver-bright block">
+                                      {startDate
+                                        ? formatLocaleTime(startDate)
+                                        : "PENDING"}
+                                    </span>
+                                  </div>
+                                  <div className="space-y-1">
+                                    <span className="text-[8px] text-silver/20 uppercase font-black tracking-widest">
+                                      Release
+                                    </span>
+                                    <span className="text-[10px] font-mono text-silver-bright block">
+                                      {endDate
+                                        ? formatLocaleTime(endDate)
+                                        : "N/A"}
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+
+                              <div className="flex items-center justify-end gap-6">
+                                {(task.status === "completed" ||
+                                  task.status === "failed" ||
+                                  task.status === "cancelled") && (
+                                  <button
+                                    className="bg-rag-red/20 text-rag-red border-2 border-rag-red/20 hover:bg-rag-red hover:text-black hover:border-black px-6 py-4 text-[10px] font-black uppercase tracking-widest transition-all flex items-center gap-3 italic"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleTaskDelete(task.task_id);
+                                    }}
+                                  >
+                                    Delete_Record
+                                    <span className="material-symbols-outlined text-sm">
+                                      delete
+                                    </span>
+                                  </button>
+                                )}
+                                {(task.status === "completed" ||
+                                  task.status === "failed") && (
+                                  <button
+                                    className="bg-rag-blue text-black px-8 py-4 text-[10px] font-black uppercase tracking-widest shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-3 group/btn italic"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleRescan(task);
+                                    }}
+                                  >
+                                    Rescan_Signal
+                                    <span className="material-symbols-outlined text-sm group-hover/btn:translate-x-1 transition-transform">
+                                      replay
+                                    </span>
+                                  </button>
+                                )}
+                                <button
+                                  className="bg-silver-bright text-black px-8 py-4 text-[10px] font-black uppercase tracking-widest shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-3 group/btn italic"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    navigate(routePath.task(task.task_id));
+                                  }}
+                                >
+                                  Open_Deep_Brief
+                                  <span className="material-symbols-outlined text-sm group-hover/btn:translate-x-1 transition-transform">
+                                    arrow_right_alt
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </motion.div>
+                        )}
+                      </AnimatePresence>
+                    </div>
+                  </motion.div>
+                );
+              })}
+            </motion.div>
+          ) : (
+            <div className="py-40 bg-charcoal/30 border-4 border-dashed border-silver-bright/5 text-center flex flex-col items-center gap-8">
+              <span className="material-symbols-outlined text-silver/5 text-9xl">
+                inventory_2
+              </span>
+              <div className="space-y-2">
+                <p className="text-xl font-black text-silver/20 uppercase tracking-[0.4em] italic">
+                  Archive Isolated
+                </p>
+                <p className="text-xs font-mono text-silver/10 uppercase tracking-widest">
+                  No historical signal streams available for current selection
+                </p>
+              </div>
+            </div>
+          )}
+        </AnimatePresence>
+        {total > PAGE_LIMIT && (
+          <Pagination
+            page={page}
+            total={total}
+            limit={PAGE_LIMIT}
+            loading={loading}
+            onPrev={() => setPage((p) => p - 1)}
+            onNext={() => setPage((p) => p + 1)}
+          />
+        )}
+      </section>
+
+      {/* Floating Bulk Action Bar */}
+      <AnimatePresence>
+        {selectedIds.length > 0 && (
+          <motion.div
+            initial={{ y: 100, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: 100, opacity: 0 }}
+            className="fixed bottom-12 left-1/2 -translate-x-1/2 z-50 w-full max-w-2xl px-6"
+          >
+            <div className="bg-black border-4 border-rag-blue p-6 shadow-[10px_10px_0px_0px_rgba(0,0,0,1)] flex items-center justify-between gap-8">
+              <div className="flex items-center gap-6">
+                <div className="bg-rag-blue text-black px-4 py-2 text-xl font-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+                  {selectedIds.length}
+                </div>
+                <div className="space-y-1">
+                  <p className="text-[10px] font-black text-rag-blue uppercase tracking-widest italic">
+                    Records_Selected_For_Pruning
+                  </p>
+                  <p className="text-[8px] font-mono text-silver/30 uppercase tracking-[0.2em]">
+                    Bulk_Action_Protocol_v4_Active
                   </p>
                 </div>
+              </div>
+              <div className="flex items-center gap-4">
+                <button
+                  onClick={() => setSelectedIds([])}
+                  className="px-6 py-3 text-[10px] font-black uppercase tracking-widest text-silver/40 hover:text-silver transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleBulkDelete}
+                  className="bg-rag-red text-black px-8 py-3 text-[10px] font-black uppercase tracking-widest shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-3 italic"
+                >
+                  Prune_Selected_Records
+                  <span className="material-symbols-outlined text-sm">
+                    delete_sweep
+                  </span>
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
-                <div className="flex items-center gap-12 border-l-4 border-silver-bright/10 pl-12 hidden lg:flex">
-                    <div className="text-right">
-                        <span className="text-[10px] font-black text-silver/40 uppercase tracking-[0.3em] block mb-2 italic">Integrity_Check</span>
-                        <span className="text-xs font-mono text-rag-green uppercase font-black">OPSEC_CLEARANCE_L5</span>
-                    </div>
-                </div>
-            </header>
-
-            {/* Filtration Block */}
-            <section className="bg-charcoal border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] flex flex-col xl:flex-row justify-between items-center gap-12">
-                <div className="flex flex-wrap items-center gap-4">
-                    <button
-                        onClick={toggleSelectAll}
-                        className={`px-6 py-3 text-[10px] font-black uppercase tracking-widest transition-all border-2 flex items-center gap-3 ${
-                            selectedIds.length === tasks.length && tasks.length > 0
-                            ? 'bg-rag-blue text-black border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]' 
-                            : 'bg-charcoal-dark text-silver/30 border-silver-bright/5 hover:border-silver-bright/20'
-                        }`}
-                    >
-                        <span className="material-symbols-outlined text-sm">
-                            {selectedIds.length === tasks.length && tasks.length > 0 ? 'check_box' : 'check_box_outline_blank'}
-                        </span>
-                        Select_All
-                    </button>
-                    <div className="w-1 h-8 bg-black/40 mx-2 hidden md:block"></div>
-                    {statusFilters.map(f => (
-                        <button
-                            key={f.value}
-                            onClick={() => handleFilterChange(f.value)}
-                            className={`px-6 py-3 text-[10px] font-black uppercase tracking-widest transition-all border-2 flex items-center gap-2 ${
-                                filter === f.value 
-                                ? 'bg-silver-bright text-black border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] -translate-x-0.5 -translate-y-0.5' 
-                                : 'bg-charcoal-dark text-silver/30 border-silver-bright/5 hover:border-silver-bright/20'
-                            }`}
-                        >
-                            {f.label}
-                            {filter === f.value && <span className="w-1 h-3 bg-black"></span>}
-                        </button>
-                    ))}
-                </div>
-                <div className="flex items-center gap-6">
-                    {tasks.length > 0 && (
-                        <button
-                            onClick={handleClearAll}
-                            className="px-6 py-3 text-[10px] font-black uppercase tracking-widest transition-all border-2 bg-rag-red/10 text-rag-red border-rag-red/20 hover:bg-rag-red hover:text-black hover:border-black flex items-center gap-2 italic"
-                        >
-                            Purge_All_Records
-                            <span className="material-symbols-outlined text-sm">delete_forever</span>
-                        </button>
-                    )}
-                    <div className="flex items-center gap-4 text-[10px] font-mono text-silver/20 uppercase italic tracking-widest hidden sm:flex">
-                    Isolation_Protocol_Active // <span className="text-rag-blue">v4_stable</span>
-                    </div>
-                </div>
-            </section>
-
-            {/* Timeline Operations Feed */}
-            <section className="relative">
-                {/* Vertical Timeline Cable */}
-                <div className="absolute left-[39px] top-0 bottom-0 w-1 bg-silver-bright/5 hidden md:block"></div>
-
-                <AnimatePresence mode='popLayout'>
-                    {tasks.length > 0 ? (
-                        <motion.div 
-                            variants={containerVariants}
-                            initial="hidden"
-                            animate="visible"
-                            className="space-y-8"
-                        >
-                            {tasks.map((task) => {
-                                const createDate = parseDateSafe(task.created_at);
-                                const startDate = task.started_at ? parseDateSafe(task.started_at) : null;
-                                const endDate = task.completed_at ? parseDateSafe(task.completed_at) : null;
-
-                                return (
-                                    <motion.div 
-                                        key={task.task_id}
-                                        variants={itemVariants}
-                                        layout
-                                        className={`relative group md:pl-20 transition-all`}
-                                    >
-                                        {/* Timeline Node */}
-                                        <div className={`absolute left-[31px] top-12 w-5 h-5 border-4 border-black z-10 hidden md:block transition-all duration-500 ${
-                                            task.status === 'completed' ? 'bg-rag-green shadow-[0_0_15px_rgba(34,197,94,0.3)]' :
-                                            task.status === 'failed' ? 'bg-rag-red' :
-                                            task.status === 'running' ? 'bg-rag-amber animate-pulse' : 'bg-silver/10'
-                                        }`}></div>
-
-                                        <div 
-                                            className={`bg-charcoal border-4 border-black p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-[12px_12px_0px_0px_rgba(0,0,0,1)] transition-all cursor-pointer relative overflow-hidden group/card ${
-                                                expandedId === task.task_id ? 'border-rag-blue/40 shadow-[12px_12px_0px_0px_rgba(0,0,0,1)]' : ''
-                                            }`}
-                                            onClick={() => setExpandedId(expandedId === task.task_id ? null : task.task_id)}
-                                        >
-                                            <div className="flex flex-col xl:flex-row justify-between gap-8">
-                                                <div className="flex-1 space-y-6">
-                                                    <div className="flex flex-wrap items-center gap-4">
-                                                        <div 
-                                                            onClick={(e) => toggleSelection(task.task_id, e)}
-                                                            className={`w-10 h-10 border-4 border-black flex items-center justify-center transition-all ${
-                                                                selectedIds.includes(task.task_id) 
-                                                                ? 'bg-rag-blue text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] -translate-x-1 -translate-y-1' 
-                                                                : 'bg-charcoal-dark text-silver/10 hover:border-rag-blue/40'
-                                                            }`}
-                                                        >
-                                                            <span className="material-symbols-outlined text-base font-black">
-                                                                {selectedIds.includes(task.task_id) ? 'check' : 'add'}
-                                                            </span>
-                                                        </div>
-                                                        <span className={`px-2 py-0.5 text-[9px] font-black uppercase italic border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] ${
-                                                            task.status === 'completed' ? 'bg-rag-green text-black' :
-                                                            task.status === 'failed' ? 'bg-rag-red text-black' :
-                                                            'bg-charcoal-dark text-silver-bright/50'
-                                                        }`}>
-                                                            {task.status}
-                                                        </span>
-                                                        {task.status === 'queued' && task.queue_position && (
-                                                            <span className="text-[9px] font-mono text-rag-amber uppercase tracking-widest">
-                                                                Queue #{task.queue_position}/{task.pending_count}
-                                                            </span>
-                                                        )}
-                                                        <span className="text-[10px] font-mono text-silver/20 uppercase tracking-widest italic">
-                                                            OP_ID_{task.task_id.split('-')[0].toUpperCase()}
-                                                        </span>
-                                                    </div>
-
-                                                    <div className="space-y-2">
-                                                        <h3 className="text-3xl font-black text-silver-bright uppercase tracking-tighter italic leading-none group-hover/card:text-rag-blue transition-colors">
-                                                            {task.tool}
-                                                        </h3>
-                                                        <p className="text-xs font-mono text-silver/40 uppercase tracking-widest flex items-center gap-3">
-                                                            <span className="material-symbols-outlined text-sm">target</span>
-                                                            {task.target}
-                                                        </p>
-                                                    </div>
-                                                </div>
-
-                                                <div className="flex flex-row xl:flex-col items-center xl:items-end justify-between xl:justify-center gap-8 shrink-0">
-                                                    <div className="text-left xl:text-right">
-                                                        <p className="text-[8px] font-black uppercase text-silver/20 tracking-[0.3em] mb-1 italic">Historical_Execution</p>
-                                                        <p className="text-xs font-mono text-silver-bright/80 uppercase">
-                                                            {formatLocaleDate(createDate)} // {formatLocaleTime(createDate)}
-                                                        </p>
-                                                    </div>
-                                                    {task.duration_seconds && (
-                                                        <div className="bg-charcoal-dark border-2 border-black px-4 py-2 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]">
-                                                            <p className="text-[10px] font-black font-mono text-rag-blue leading-none">{formatDuration(task.duration_seconds)?.toUpperCase()}</p>
-                                                        </div>
-                                                    )}
-                                                </div>
-                                            </div>
-
-                                            {/* Expandable Details Block */}
-                                            <AnimatePresence>
-                                                {expandedId === task.task_id && (
-                                                    <motion.div 
-                                                        initial={{ height: 0, opacity: 0 }}
-                                                        animate={{ height: 'auto', opacity: 1 }}
-                                                        exit={{ height: 0, opacity: 0 }}
-                                                        className="overflow-hidden"
-                                                    >
-                                                        <div className="mt-12 pt-12 border-t-4 border-black grid grid-cols-1 md:grid-cols-3 gap-12 bg-charcoal-dark/20 -mx-8 -mb-8 p-8 border-dashed">
-                                                            <div className="space-y-4">
-                                                                <h5 className="text-[10px] font-black text-silver-bright uppercase tracking-[0.3em] italic flex items-center gap-3">
-                                                                    <span className="w-1.5 h-3 bg-rag-blue"></span> Signal_Metadata
-                                                                </h5>
-                                                                <div className="space-y-2">
-                                                                    <p className="text-[10px] font-mono text-silver/40">PLUGIN: <span className="text-silver-bright uppercase">{task.plugin_id}</span></p>
-                                                                    <p className="text-[10px] font-mono text-silver/40">SESSION: <span className="text-silver-bright uppercase">ENCRYPTED_VTX</span></p>
-                                                                </div>
-                                                            </div>
-
-                                                            <div className="space-y-4">
-                                                                <h5 className="text-[10px] font-black text-silver-bright uppercase tracking-[0.3em] italic flex items-center gap-3">
-                                                                    <span className="w-1.5 h-3 bg-rag-amber"></span> Time_Matrix
-                                                                </h5>
-                                                                <div className="grid grid-cols-2 gap-4">
-                                                                    <div className="space-y-1">
-                                                                        <span className="text-[8px] text-silver/20 uppercase font-black tracking-widest">In_Lock</span>
-                                                                        <span className="text-[10px] font-mono text-silver-bright block">{startDate ? formatLocaleTime(startDate) : 'PENDING'}</span>
-                                                                    </div>
-                                                                    <div className="space-y-1">
-                                                                        <span className="text-[8px] text-silver/20 uppercase font-black tracking-widest">Release</span>
-                                                                        <span className="text-[10px] font-mono text-silver-bright block">{endDate ? formatLocaleTime(endDate) : 'N/A'}</span>
-                                                                    </div>
-                                                                </div>
-                                                            </div>
-
-                                                              <div className="flex items-center justify-end gap-6">
-                                                                {(task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled') && (
-                                                                    <button 
-                                                                        className="bg-rag-red/20 text-rag-red border-2 border-rag-red/20 hover:bg-rag-red hover:text-black hover:border-black px-6 py-4 text-[10px] font-black uppercase tracking-widest transition-all flex items-center gap-3 italic"
-                                                                        onClick={(e) => {
-                                                                            e.stopPropagation()
-                                                                            handleTaskDelete(task.task_id)
-                                                                        }}
-                                                                    >
-                                                                        Delete_Record
-                                                                        <span className="material-symbols-outlined text-sm">delete</span>
-                                                                    </button>
-                                                                )}
-                                                                {(task.status === 'completed' || task.status === 'failed') && (
-                                                                    <button 
-                                                                        className="bg-rag-blue text-black px-8 py-4 text-[10px] font-black uppercase tracking-widest shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-3 group/btn italic"
-                                                                        onClick={(e) => {
-                                                                            e.stopPropagation()
-                                                                            handleRescan(task)
-                                                                        }}
-                                                                    >
-                                                                        Rescan_Signal
-                                                                        <span className="material-symbols-outlined text-sm group-hover/btn:translate-x-1 transition-transform">replay</span>
-                                                                    </button>
-                                                                )}
-                                                                <button 
-                                                                    className="bg-silver-bright text-black px-8 py-4 text-[10px] font-black uppercase tracking-widest shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-3 group/btn italic"
-                                                                    onClick={(e) => {
-                                                                        e.stopPropagation()
-                                                                        navigate(routePath.task(task.task_id))
-                                                                    }}
-                                                                >
-                                                                    Open_Deep_Brief
-                                                                    <span className="material-symbols-outlined text-sm group-hover/btn:translate-x-1 transition-transform">arrow_right_alt</span>
-                                                                </button>
-                                                            </div>
-                                                        </div>
-                                                    </motion.div>
-                                                )}
-                                            </AnimatePresence>
-                                        </div>
-                                    </motion.div>
-                                );
-                            })}
-                        </motion.div>
-                    ) : (
-                        <div className="py-40 bg-charcoal/30 border-4 border-dashed border-silver-bright/5 text-center flex flex-col items-center gap-8">
-                            <span className="material-symbols-outlined text-silver/5 text-9xl">inventory_2</span>
-                            <div className="space-y-2">
-                                <p className="text-xl font-black text-silver/20 uppercase tracking-[0.4em] italic">Archive Isolated</p>
-                                <p className="text-xs font-mono text-silver/10 uppercase tracking-widest">No historical signal streams available for current selection</p>
-                            </div>
-                        </div>
-                    )}
-                </AnimatePresence>
-                {total > PAGE_LIMIT && (
-                    <Pagination
-                        page={page}
-                        total={total}
-                        limit={PAGE_LIMIT}
-                        loading={loading}
-                        onPrev={() => setPage(p => p - 1)}
-                        onNext={() => setPage(p => p + 1)}
-                    />
-                )}
-            </section>
-
-            {/* Floating Bulk Action Bar */}
-            <AnimatePresence>
-                {selectedIds.length > 0 && (
-                    <motion.div 
-                        initial={{ y: 100, opacity: 0 }}
-                        animate={{ y: 0, opacity: 1 }}
-                        exit={{ y: 100, opacity: 0 }}
-                        className="fixed bottom-12 left-1/2 -translate-x-1/2 z-50 w-full max-w-2xl px-6"
-                    >
-                        <div className="bg-black border-4 border-rag-blue p-6 shadow-[10px_10px_0px_0px_rgba(0,0,0,1)] flex items-center justify-between gap-8">
-                            <div className="flex items-center gap-6">
-                                <div className="bg-rag-blue text-black px-4 py-2 text-xl font-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">{selectedIds.length}</div>
-                                <div className="space-y-1">
-                                    <p className="text-[10px] font-black text-rag-blue uppercase tracking-widest italic">Records_Selected_For_Pruning</p>
-                                    <p className="text-[8px] font-mono text-silver/30 uppercase tracking-[0.2em]">Bulk_Action_Protocol_v4_Active</p>
-                                </div>
-                            </div>
-                            <div className="flex items-center gap-4">
-                                <button 
-                                    onClick={() => setSelectedIds([])}
-                                    className="px-6 py-3 text-[10px] font-black uppercase tracking-widest text-silver/40 hover:text-silver transition-colors"
-                                >
-                                    Cancel
-                                </button>
-                                <button 
-                                    onClick={handleBulkDelete}
-                                    className="bg-rag-red text-black px-8 py-3 text-[10px] font-black uppercase tracking-widest shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-3 italic"
-                                >
-                                    Prune_Selected_Records
-                                    <span className="material-symbols-outlined text-sm">delete_sweep</span>
-                                </button>
-                            </div>
-                        </div>
-                    </motion.div>
-                )}
-            </AnimatePresence>
-
-            {/* Restricted Footer */}
-            <footer className="pt-24 opacity-20 pointer-events-none select-none flex flex-col md:flex-row justify-between items-center gap-8 text-[9px] font-black uppercase tracking-[0.5em] italic">
-                <div className="flex items-center gap-4">
-                    <span className="w-8 h-8 border-4 border-silver/20 flex items-center justify-center font-serif text-lg">S</span>
-                    SECUSCAN ARCHIVE INTEGRITY PROTOCOL v10.1
-                </div>
-                <div className="flex gap-2">
-                    {[1,2,3,4,5,6,7,8,9,10,11,12].map(i => <div key={i} className="w-1.5 h-3 bg-silver/20"></div>)}
-                </div>
-            </footer>
+      {/* Restricted Footer */}
+      <footer className="pt-24 opacity-20 pointer-events-none select-none flex flex-col md:flex-row justify-between items-center gap-8 text-[9px] font-black uppercase tracking-[0.5em] italic">
+        <div className="flex items-center gap-4">
+          <span className="w-8 h-8 border-4 border-silver/20 flex items-center justify-center font-serif text-lg">
+            S
+          </span>
+          SECUSCAN ARCHIVE INTEGRITY PROTOCOL v10.1
         </div>
-    )
+        <div className="flex gap-2">
+          {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((i) => (
+            <div key={i} className="w-1.5 h-3 bg-silver/20"></div>
+          ))}
+        </div>
+      </footer>
+    </div>
+  );
 }


### PR DESCRIPTION
Closes #114
Added pagination controls to the Scans history page.

Changes:

New Pagination.tsx component with Prev/Next buttons and "Showing X–Y of Z" range text
Updated Scans.tsx to pass page and per_page params to the existing backend pagination API
Controls disabled at first/last page
Loading state preserved during page transitions
Filter state resets to page 1 on filter change
Total count in header now reflects full dataset, not just current page