### PR TITLE
fix(frontend): improve decorative icon accessibility

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -301,7 +301,7 @@ export default function Dashboard() {
               </div>
             </div>
             <div className="w-14 h-14 bg-charcoal-dark border-4 border-black flex items-center justify-center text-rag-blue shadow-inner group-hover:bg-rag-blue group-hover:text-black transition-all">
-              <span className="material-symbols-outlined text-2xl font-black">terminal</span>
+              <span className="material-symbols-outlined text-2xl font-black" aria-hidden="true">terminal</span>
             </div>
           </div>
 
@@ -332,7 +332,7 @@ export default function Dashboard() {
               animate={{ opacity: 1 }}
               className="mt-12 py-16 flex flex-col items-center justify-center bg-charcoal border border-rag-red/30 rounded-md max-w-3xl mx-auto shadow-lg">
               <div className="w-12 h-12 rounded-full bg-rag-red/10 flex items-center justify-center mb-4">
-                <span className="material-symbols-outlined text-rag-red text-2xl">warning</span>
+                <span className="material-symbols-outlined text-rag-red text-2xl" aria-hidden="true">warning</span>
               </div>
               <h3 className="text-rag-red text-lg font-bold tracking-widest uppercase mb-2">
                 System Offline
@@ -525,7 +525,7 @@ export default function Dashboard() {
                                     onClick={() => handleAbort(task.id)}
                                     className="text-[10px] font-bold text-silver/40 hover:text-rag-red uppercase tracking-widest transition-colors flex items-center gap-2"
                                   >
-                                    <span className="material-symbols-outlined text-[14px]">cancel</span>
+                                    <span className="material-symbols-outlined text-[14px]" aria-hidden="true">cancel</span>
                                     Abort
                                   </button>
                                 </>

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -349,7 +349,7 @@ export default function Findings() {
               </div>
             ) : null}
 
-            <span className={`material-symbols-outlined text-lg ${isSelected ? 'text-silver-bright' : 'text-silver/30'}`}>
+            <span className={`material-symbols-outlined text-lg ${isSelected ? 'text-silver-bright' : 'text-silver/30'}`} aria-hidden="true">
               east
             </span>
           </div>

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -113,7 +113,7 @@ export default function Reports() {
             className="bg-charcoal border-4 border-black p-4 text-silver-bright shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all"
             title="Refresh Archive"
           >
-            <ReportIcon icon={Refresh01Icon} className="block" />
+            <ReportIcon icon={Refresh01Icon} className="block" aria-hidden="true" />
           </button>
         </div>
       </header>
@@ -122,7 +122,7 @@ export default function Reports() {
       {loading && (
         <div className="flex items-center justify-center py-40 gap-6">
           <div className="animate-spin">
-            <ReportIcon icon={Refresh01Icon} size={48} className="text-silver/20" />
+            <ReportIcon icon={Refresh01Icon} size={48} className="text-silver/20" aria-hidden="true" />
           </div>
           <p className="text-[10px] font-black text-silver/20 uppercase tracking-[0.4em] italic animate-pulse">
             Retrieving Archive Data...
@@ -159,7 +159,7 @@ export default function Reports() {
               <div key={i} className={`${m.color} border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] flex flex-col justify-between h-40 group hover:-translate-y-1 transition-transform`}>
                 <div className="flex justify-between items-start">
                   <span className="text-[10px] font-black text-black uppercase tracking-[0.2em] italic">{m.label}</span>
-                  <ReportIcon icon={Archive02Icon} className="text-black/20 group-hover:text-black transition-colors" />
+                  <ReportIcon icon={Archive02Icon} className="text-black/20 group-hover:text-black transition-colors" aria-hidden="true" />
                 </div>
                 <div className="flex items-baseline gap-2">
                   <span className="text-5xl font-black text-black font-mono leading-none tracking-tighter">{m.val}</span>
@@ -187,7 +187,7 @@ export default function Reports() {
                         }`}
                       >
                         {t} BRIEFINGS
-                        {selectedType === t && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
+                        {selectedType === t && <ReportIcon icon={Radar02Icon} size={16} className="text-black" aria-hidden="true" />}
                       </button>
                     ))}
                   </div>
@@ -195,7 +195,7 @@ export default function Reports() {
 
                 <div className="p-8 border-4 border-black border-dashed space-y-4 bg-charcoal-dark/50">
                   <div className="flex items-center gap-3">
-                    <ReportIcon icon={KnightShieldIcon} className="text-rag-green" />
+                    <ReportIcon icon={KnightShieldIcon} className="text-rag-green" aria-hidden="true" />
                     <h4 className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic leading-none">Integrity_Secure</h4>
                   </div>
                   <p className="text-[10px] text-silver/40 font-black uppercase tracking-widest leading-loose italic">
@@ -241,7 +241,7 @@ export default function Reports() {
                           }`}>
                             {report.type}_TYPE
                           </span>
-                          <ReportIcon icon={File01Icon} size={24} className="text-silver/10 group-hover:text-silver-bright transition-colors" />
+                          <ReportIcon icon={File01Icon} size={24} className="text-silver/10 group-hover:text-silver-bright transition-colors" aria-hidden="true" />
                         </div>
 
                         <div>
@@ -275,9 +275,9 @@ export default function Reports() {
                             <button
                               onClick={() => navigate(`/task/${report.task_id}`)}
                               className="bg-charcoal-dark border-4 border-black p-3 text-silver/20 group-hover:text-silver-bright group-hover:bg-black transition-all"
-                              title="View Briefing"
+                              title="View Briefing" aria-label="View briefing"
                             >
-                              <ReportIcon icon={ScanEyeIcon} size={18} />
+                              <ReportIcon icon={ScanEyeIcon} size={18} aria-hidden="true"/>
                             </button>
                             {exportFormats.map((format) => (
                               <button
@@ -303,7 +303,7 @@ export default function Reports() {
                         <div className="text-silver-bright">
                           <ReportIcon
                             icon={report.type === 'executive' ? Analytics02Icon : report.type === 'compliance' ? UserShield02Icon : ShieldUserIcon}
-                            size={200}
+                            size={200} aria-hidden="true"
                           />
                         </div>
                       </div>
@@ -312,7 +312,7 @@ export default function Reports() {
 
                   {filteredReports.length === 0 && (
                     <div className="col-span-2 py-40 border-4 border-dashed border-black/5 text-center flex flex-col items-center gap-8 bg-charcoal/30">
-                      <ReportIcon icon={Archive02Icon} size={120} className="text-silver/5" />
+                      <ReportIcon icon={Archive02Icon} size={120} className="text-silver/5" aria-hidden="true" />
                       <div className="space-y-2">
                         <p className="text-xl font-black text-silver/20 uppercase tracking-[0.4em] italic">Archive Isolated</p>
                         <p className="text-xs font-mono text-silver/10 uppercase tracking-widest leading-relaxed">System buffer awaiting briefing generation protocols</p>

--- a/frontend/src/pages/Toolkit.tsx
+++ b/frontend/src/pages/Toolkit.tsx
@@ -288,7 +288,8 @@ export default function Scanner() {
 
         <div className="flex items-center gap-6 flex-wrap">
           <div className="relative group">
-            <span className="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-silver/20 group-focus-within:text-rag-red transition-colors text-sm">search</span>
+            <span className="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-silver/20 group-focus-within:text-rag-red transition-colors text-sm"
+            aria-hidden="true">search</span>
             <input
               type="text"
               aria-label="Search scanner catalog"
@@ -472,7 +473,7 @@ export default function Scanner() {
               filteredTools.length > 0 &&
               Array.from({ length: Math.max(0, 4 - (filteredTools.length % 4 || 4)) }).map((_, index) => (
                 <div key={index} className="bg-charcoal/30 border-4 border-black/5 border-dashed flex items-center justify-center opacity-10 p-10">
-                  <span className="material-symbols-outlined text-4xl">add_box</span>
+                  <span className="material-symbols-outlined text-4xl" aria-hidden="true">add_box</span>
                 </div>
               ))}
           </motion.div>
@@ -481,7 +482,7 @@ export default function Scanner() {
 
       <footer className="pt-24 opacity-20 hover:opacity-100 transition-opacity duration-700 pointer-events-none md:pointer-events-auto">
         <div className="p-12 border-4 border-black border-dashed flex flex-col md:flex-row items-center gap-10 bg-charcoal/50">
-          <span className="material-symbols-outlined text-rag-red text-6xl">gavel</span>
+          <span className="material-symbols-outlined text-rag-red text-6xl" aria-hidden="true">gavel</span>
           <div className="space-y-4">
             <p className="text-xs font-black text-rag-amber uppercase tracking-[0.4em] italic leading-relaxed">
               UNAUTHORIZED_DEPLOYMENT_IS_MONITORED


### PR DESCRIPTION
## Description
Improved accessibility for decorative icons across multiple frontend pages by adding aria-hidden="true" where appropriate. Also ensured meaningful interactive controls retain accessible names.

## Related Issues
Closes #82 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
-Ran frontend production build using: npm run build
-Verified the application builds successfully.
-Confirmed there are no visible UI changes after the accessibility updates.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
