### PR TITLE
feat: show active filter summary strip on Findings page #104

### DIFF
--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { motion } from 'framer-motion'
 import { getFindings } from '../api'
 import { formatLocaleDate, parseDateSafe, getCurrentTimeZone } from '../utils/date'
-
 type Finding = {
   id: string
   severity: string
@@ -267,6 +266,29 @@ export default function Findings() {
     [enrichedFindings, filteredFindings, countsBySeverity],
   )
 
+  // Derives a flat list of active filter chips from non-default filter state.
+  const activeFilters = useMemo(() => {
+    const chips: { key: string; label: string }[] = []
+    if (searchQuery.trim())      chips.push({ key: 'search',  label: `Search: "${searchQuery.trim()}"` })
+    if (filterTarget !== 'all')  chips.push({ key: 'target',  label: `Target: ${filterTarget}` })
+    if (filterScanner !== 'all') chips.push({ key: 'scanner', label: `Scanner: ${filterScanner}` })
+    if (sortMode !== 'severity') chips.push({ key: 'sort',    label: `Sort: ${sortMode}` })
+    if (dateFrom)                chips.push({ key: 'from',    label: `From: ${dateFrom}` })
+    if (dateTo)                  chips.push({ key: 'to',      label: `To: ${dateTo}` })
+    return chips
+  }, [searchQuery, filterTarget, filterScanner, sortMode, dateFrom, dateTo])
+
+
+  function resetAllFilters() {
+    setFilterSeverity('all')
+    setFilterTarget('all')
+    setFilterScanner('all')
+    setSortMode('severity')
+    setDateFrom('')
+    setDateTo('')
+    setSearchQuery('')
+  }
+
   function updateFindingStatus(id: string, status: FindingStatus) {
     setReviewState((current) => ({ ...current, [id]: status }))
   }
@@ -520,15 +542,7 @@ export default function Findings() {
 
               <button
                 type="button"
-                onClick={() => {
-                  setFilterSeverity('all')
-                  setFilterTarget('all')
-                  setFilterScanner('all')
-                  setSortMode('severity')
-                  setDateFrom('')
-                  setDateTo('')
-                  setSearchQuery('')
-                }}
+                onClick={resetAllFilters}
                 className="h-11 w-full border border-silver-bright/20 bg-charcoal-dark px-4 text-[10px] font-black uppercase tracking-[0.18em] text-silver/65 transition-all hover:border-rag-red hover:text-silver-bright xl:w-auto xl:min-w-[180px]"
               >
                 Reset Filters
@@ -536,6 +550,27 @@ export default function Findings() {
             </div>
           </div>
         </section>
+
+        {/* ── Active filter summary strip ────────────────────────────────────────
+            Hidden when all filters are at their default values.    */}
+        {activeFilters.length > 0 && (
+          <div
+            aria-label="active filters"
+            className="flex flex-wrap items-center gap-2 border border-silver-bright/10 bg-charcoal/60 px-4 py-3"
+          >
+            <span className="mr-1 text-[10px] font-black uppercase tracking-[0.2em] text-silver/40">
+              Active Filters
+            </span>
+            {activeFilters.map(({ key, label }) => (
+              <span
+                key={key}
+                className="border border-rag-red/30 bg-rag-red/10 px-2 py-1 text-[9px] font-mono uppercase tracking-[0.15em] text-rag-red"
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+        )}
 
         <div className="grid gap-8 xl:grid-cols-[minmax(0,1.2fr)_420px]">
           <motion.section variants={sectionVariants} initial="hidden" animate="visible" className="space-y-5">
@@ -707,3 +742,4 @@ export default function Findings() {
     </div>
   )
 }
+

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -742,4 +742,3 @@ export default function Findings() {
     </div>
   )
 }
-

--- a/frontend/testing/unit/pages/Findings.test.tsx
+++ b/frontend/testing/unit/pages/Findings.test.tsx
@@ -433,3 +433,46 @@ describe('Findings — empty state', () => {
     expect(await screen.findByText(/No Findings Match/i)).toBeInTheDocument()
   })
 })
+
+// ── Active filter summary ─────────────────────────────────────────────────────
+
+describe('Findings — active filter summary', () => {
+  beforeEach(() => {
+    vi.mocked(getFindings).mockResolvedValue({ findings: allFindings })
+  })
+
+  it('is hidden when no filters are active', async () => {
+    renderFindings()
+    await waitForLoad()
+    expect(screen.queryByLabelText('active filters')).not.toBeInTheDocument()
+  })
+
+  it('shows target + scanner chips when both filters are applied', async () => {
+    const user = userEvent.setup()
+    renderFindings()
+    await waitForLoad()
+
+    await user.selectOptions(screen.getByDisplayValue(/All Targets/i), 'api.example.com')
+    await user.selectOptions(screen.getByDisplayValue(/All Scanners/i), 'sqlmap')
+
+    const strip = await screen.findByLabelText('active filters')
+    expect(strip).toBeInTheDocument()
+    expect(within(strip).getByText(/target: api\.example\.com/i)).toBeInTheDocument()
+    expect(within(strip).getByText(/scanner: sqlmap/i)).toBeInTheDocument()
+  })
+
+  it('shows date range chips when both dates are set', async () => {
+    renderFindings()
+    await waitForLoad()
+
+    const fromInput = screen.getByText('From Date').parentElement!.querySelector('input')!
+    const toInput   = screen.getByText('To Date').parentElement!.querySelector('input')!
+
+    fireEvent.change(fromInput, { target: { value: '2026-05-14' } })
+    fireEvent.change(toInput,   { target: { value: '2026-05-15' } })
+
+    const strip = await screen.findByLabelText('active filters')
+    expect(within(strip).getByText(/from: 2026-05-14/i)).toBeInTheDocument()
+    expect(within(strip).getByText(/to: 2026-05-15/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Description
Adds a compact active filter summary strip to the Findings page. When any filter is non-default (search, target, scanner, sort, date range), a row of red-tinted chips appears between the filter controls and the findings list showing the current filter state at a glance. The strip is hidden when all filters are at their default values and updates instantly as filters change. The existing Reset Filters button clears all filters and the strip together.

## Related Issues
Closes #104 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Automated tests - 3 new tests added in Findings.test.tsx under describe('Findings -active filter summary'):

1.Strip is hidden when no filters are active
2.Strip shows correct chips for target + scanner combination
3.Strip shows correct chips for date from + to combination
All 75 tests pass (npm test).
Browser testing by manually verifying in the browser using dev seed data (5 findings across all severity levels).
<img width="1568" height="669" alt="image" src="https://github.com/user-attachments/assets/6982c0d8-3b7e-46bb-9c7a-4f00a03decd4" />

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
