### PR TITLE
Test: Add fallback unit tests for formatLocaleDate and formatLocaleTime #78

### DIFF
--- a/frontend/testing/unit/utils/date.test.ts
+++ b/frontend/testing/unit/utils/date.test.ts
@@ -60,6 +60,14 @@ import {
       test("returns N/A for invalid input", () => {
         expect(formatLocaleDate("bad-date")).toBe("N/A");
       });
+
+      test("returns N/A for null input", () => {
+        expect(formatLocaleDate(null)).toBe("N/A");
+      });
+
+      test("returns N/A for undefinied input", () =>{
+        expect(formatLocaleDate(undefined)).toBe("N/A");
+      });
     });
   
     describe("formatLocaleTime", () => {
@@ -70,6 +78,14 @@ import {
   
       test("returns N/A for invalid input", () => {
         expect(formatLocaleTime("bad-date")).toBe("N/A");
+      });
+
+      test("returns N/A for null input", () => {
+        expect (formatLocaleTime(null)).toBe("N/A");
+      });
+
+      test("returns N/A for undefinied input", () =>{
+        expect(formatLocaleTime(undefined)).toBe("N/A");
       });
     });
   

--- a/frontend/testing/unit/utils/date.test.ts
+++ b/frontend/testing/unit/utils/date.test.ts
@@ -65,7 +65,7 @@ import {
         expect(formatLocaleDate(null)).toBe("N/A");
       });
 
-      test("returns N/A for undefinied input", () =>{
+      test("returns N/A for undefined input", () => {
         expect(formatLocaleDate(undefined)).toBe("N/A");
       });
     });
@@ -81,10 +81,10 @@ import {
       });
 
       test("returns N/A for null input", () => {
-        expect (formatLocaleTime(null)).toBe("N/A");
+        expect(formatLocaleTime(null)).toBe("N/A");
       });
 
-      test("returns N/A for undefinied input", () =>{
+      test("returns N/A for undefined input", () => {
         expect(formatLocaleTime(undefined)).toBe("N/A");
       });
     });


### PR DESCRIPTION
## Description
Added fallback unit tests for formatLocaleDate and formatLocaleTime (issue #78) to safely handle "undefined" and "null" user inputs. Ensures that the system  won't crash and will cleanly fall back to returning "N/A" if empty values leak through.

## Related Issues
Closes #78 

## Type of Change
- [ **x** ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran the local Vitest testing framework inside the frontend folder. 
Verified that the test suite inside `testing/unit/utils/date.test.ts` successfully expanded from 15 passing tests to 19 passing tests, proving the new fallback paths work under simulation.

## Checklist
- [ **x** ] My code follows the code style of this project.
- [ **x** ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ **x** ] My changes generate no new warnings.
