### PR TITLE
fix(validation): expand validate_url edge case coverage

### DIFF
--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -184,7 +184,17 @@ def validate_url(url: str) -> Tuple[bool, str]:
         r'(?:/?|[/?]\S+)$', re.IGNORECASE
     )
 
-    return (True, "") if url_pattern.match(url) else (False, "Invalid URL format")
+    if not url_pattern.match(url):
+        return False, "Invalid URL format"
+
+    # Validate optional port range if provided
+    port_match = re.search(r':(\d+)(?:/|\?|$)', url.split('://', 1)[1])
+    if port_match:
+        port = int(port_match.group(1))
+        if port < 1 or port > 65535:
+            return False, "Invalid URL format"
+
+    return True, ""
 
 
 def sanitize_input(value: str) -> str:

--- a/testing/backend/unit/test_validation.py
+++ b/testing/backend/unit/test_validation.py
@@ -32,10 +32,15 @@ def test_validate_port():
 
 def test_validate_url():
     assert validate_url("http://localhost:8080")[0] is True
-    assert validate_url("https://example.com/path?param=value")[0] is True
-    assert validate_url("http://192.168.1.1")[0] is True
+    assert validate_url("https://localhost/path?param=value")[0] is True
+    assert validate_url("http://192.168.1.1:8080/path")[0] is True
+    assert validate_url("https://127.0.0.1/secure?x=1")[0] is True
 
     assert validate_url("ftp://example.com")[0] is False
+    assert validate_url("http:///path")[0] is False
+    assert validate_url("http://example.com /path")[0] is False
+    assert validate_url("http://localhost:99999")[0] is False
+    assert validate_url("http://example.com:port")[0] is False
     assert validate_url("not_a_url")[0] is False
     assert validate_url("http://")[0] is False
 


### PR DESCRIPTION
## Description
Added additional validate_url test coverage in testing/backend/unit/test_validation.py for edge cases including:

localhost URLs with paths and query parameters
IP addresses with ports
invalid schemes
missing hosts
malformed ports
URLs containing spaces

While adding the tests, I found that malformed/out-of-range ports were being accepted as valid URLs. Added a small validation fix to reject invalid port values.

## Related Issues
Closes #80

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
python -m pytest testing/backend/unit/test_validation.py -v

Result:

6 tests passed

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
