### PR TITLE
feat(security): add sanitized command preview before scan execution

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -41,6 +41,7 @@ export interface PluginFieldSchema {
   help?: string
   options?: PluginFieldOption[]
   validation?: Record<string, unknown>
+  sensitive?: boolean
 }
 export interface PluginAvailability {
   runnable: boolean

--- a/frontend/src/components/CommandPreview.tsx
+++ b/frontend/src/components/CommandPreview.tsx
@@ -1,0 +1,158 @@
+import React, { useCallback, useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import type { PluginFieldSchema } from '../api'
+import {
+  buildCommandTokens,
+  getMissingFields,
+  tokensToString,
+  type PreviewToken,
+} from '../utils/commandPreview'
+
+interface CommandPreviewProps {
+  commandTemplate: string[]
+  fields: PluginFieldSchema[]
+  inputs: Record<string, unknown>
+}
+
+function TokenChip({ token }: { token: PreviewToken }) {
+  const styles: Record<PreviewToken['kind'], string> = {
+    command:     'text-rag-green font-black',
+    flag:        'text-rag-blue',
+    value:       'text-silver-bright',
+    redacted:    'text-rag-amber font-mono bg-rag-amber/10 px-1 rounded',
+    missing:     'text-rag-red font-mono bg-rag-red/10 px-1 rounded animate-pulse',
+    placeholder: 'text-silver/40 italic',
+  }
+
+  return (
+    <span className={`inline-block whitespace-nowrap ${styles[token.kind]}`}>
+      {token.text}
+    </span>
+  )
+}
+
+export default function CommandPreview({ commandTemplate, fields, inputs }: CommandPreviewProps) {
+  const [copied, setCopied] = useState(false)
+  const [expanded, setExpanded] = useState(true)
+
+  const tokens = buildCommandTokens(commandTemplate, fields, inputs)
+  const missingFields = getMissingFields(fields, inputs)
+  const plainText = tokensToString(tokens)
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(plainText)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // clipboard not available
+    }
+  }, [plainText])
+
+  return (
+    <section
+      className="bg-charcoal border-4 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] overflow-hidden"
+      aria-label="Command preview"
+    >
+      {/* ── Header bar ────────────────────────────────────────────────────── */}
+      <div className="flex items-center justify-between px-6 py-4 border-b-4 border-black bg-charcoal-dark">
+        <div className="flex items-center gap-3">
+          <span className="material-symbols-outlined text-rag-blue text-lg">terminal</span>
+          <span className="text-[10px] font-black uppercase tracking-[0.4em] text-silver-bright italic">
+            Cmd_Preview
+          </span>
+          <span className="text-[9px] px-2 py-0.5 border-2 border-silver/20 text-silver/40 uppercase tracking-widest font-black">
+            sanitized · local
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleCopy}
+            title="Copy sanitized command"
+            className="flex items-center gap-1.5 px-3 py-1.5 border-2 border-black text-[9px] font-black uppercase tracking-widest text-silver hover:bg-rag-blue hover:text-black transition-all shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] active:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+          >
+            <span className="material-symbols-outlined text-sm">
+              {copied ? 'check' : 'content_copy'}
+            </span>
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            title={expanded ? 'Collapse preview' : 'Expand preview'}
+            className="w-8 h-8 flex items-center justify-center border-2 border-black text-silver hover:bg-charcoal-light transition-all"
+          >
+            <span className="material-symbols-outlined text-sm">
+              {expanded ? 'expand_less' : 'expand_more'}
+            </span>
+          </button>
+        </div>
+      </div>
+
+      {/* ── Token display ─────────────────────────────────────────────────── */}
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <motion.div
+            key="preview-body"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            <div className="px-6 py-5">
+              <pre
+                className="font-mono text-xs leading-relaxed whitespace-pre-wrap break-all flex flex-wrap gap-x-1.5 gap-y-1"
+                aria-label={`Preview command: ${plainText}`}
+              >
+                {tokens.map((token, i) => (
+                  <TokenChip key={i} token={token} />
+                ))}
+              </pre>
+            </div>
+
+            {/* ── Legend ──────────────────────────────────────────────────── */}
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-2 px-6 pb-4 border-t-2 border-black/40 pt-3">
+              <LegendItem color="text-rag-green" label="binary" />
+              <LegendItem color="text-rag-blue" label="flag" />
+              <LegendItem color="text-silver-bright" label="value" />
+              <LegendItem color="text-rag-amber" label="redacted secret" />
+              <LegendItem color="text-rag-red" label="missing required" />
+            </div>
+
+            {/* ── Missing fields warning ───────────────────────────────────── */}
+            {missingFields.length > 0 && (
+              <div className="mx-6 mb-5 border-2 border-rag-red/60 bg-rag-red/5 px-4 py-3 flex items-start gap-3">
+                <span className="material-symbols-outlined text-rag-red text-base mt-0.5 shrink-0">
+                  warning
+                </span>
+                <div>
+                  <p className="text-[9px] font-black uppercase tracking-widest text-rag-red mb-1">
+                    Missing required fields
+                  </p>
+                  <p className="text-[9px] text-silver/60 uppercase tracking-widest">
+                    {missingFields.map((f) => f.label).join(', ')}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* ── Disclaimer ──────────────────────────────────────────────── */}
+            <p className="px-6 pb-4 text-[9px] text-silver/25 uppercase tracking-widest leading-relaxed">
+              ⚠ This preview is locally generated and sanitized. Runtime normalisation may alter
+              the final command. Secrets and credentials are always redacted here.
+            </p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </section>
+  )
+}
+
+function LegendItem({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <span className={`text-[10px] font-mono font-black ${color}`}>■</span>
+      <span className="text-[9px] uppercase tracking-widest text-silver/40">{label}</span>
+    </span>
+  )
+}

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -394,14 +394,18 @@ export default function Reports() {
                   ))}
 
                   {filteredReports.length === 0 && (
-                    <div className="col-span-2 py-40 border-4 border-dashed border-black/5 text-center flex flex-col items-center gap-8 bg-charcoal/30">
-                      <ReportIcon icon={Archive02Icon} size={120} className="text-silver/5" aria-hidden="true" />
-                      <div className="space-y-2">
-                        <p className="text-xl font-black text-silver/20 uppercase tracking-[0.4em] italic">Archive Isolated</p>
-                        <p className="text-xs font-mono text-silver/10 uppercase tracking-widest leading-relaxed">System buffer awaiting briefing generation protocols</p>
-                      </div>
-                    </div>
-                  )}
+  <div className="col-span-2 py-40 border-4 border-dashed border-black/5 text-center flex flex-col items-center gap-8 bg-charcoal/30">
+    <ReportIcon icon={Archive02Icon} size={120} className="text-silver/5" />
+    <div className="space-y-2">
+      <p className="text-xl font-black text-silver/20 uppercase tracking-[0.4em] italic">Archive Isolated</p>
+      <p className="text-xs font-mono text-silver/10 uppercase tracking-widest leading-relaxed">
+        {selectedStatus !== 'all' || selectedDate !== 'all'
+          ? 'No entries match the selected filters'
+          : 'System buffer awaiting briefing generation protocols'}
+      </p>
+    </div>
+  </div>
+)}
                 </motion.div>
               </AnimatePresence>
             </main>

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -259,6 +259,114 @@ export default function Reports() {
                   </div>
                 </div>
 
+                {/* Status Filter */}
+                <div className="space-y-4">
+                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Status_Filter</label>
+                  <div className="grid grid-cols-1 gap-2">
+                    {([
+                      { value: 'all',        label: 'All Statuses' },
+                      { value: 'ready',      label: 'Ready' },
+                      { value: 'generating', label: 'Generating' },
+                      { value: 'failed',     label: 'Failed' },
+                    ] as const).map(({ value, label }) => (
+                      <button
+                        key={value}
+                        onClick={() => setSelectedStatus(value)}
+                        aria-label={`status ${label}`}
+                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
+                          selectedStatus === value
+                            ? 'bg-rag-amber border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
+                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
+                        }`}
+                      >
+                        {label}
+                        {selectedStatus === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Date Range Filter */}
+                <div className="space-y-4">
+                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Date_Range</label>
+                  <div className="grid grid-cols-1 gap-2">
+                    {([
+                      { value: 'all', label: 'All Time' },
+                      { value: '24h', label: 'Last 24 Hours' },
+                      { value: '7d',  label: 'Last 7 Days' },
+                      { value: '30d', label: 'Last 30 Days' },
+                    ] as const).map(({ value, label }) => (
+                      <button
+                        key={value}
+                        onClick={() => setSelectedDateRange(value)}
+                        aria-label={`date ${label}`}
+                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
+                          selectedDateRange === value
+                            ? 'bg-rag-blue border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
+                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
+                        }`}
+                      >
+                        {label}
+                        {selectedDateRange === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Status Filter */}
+                <div className="space-y-4">
+                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Status_Filter</label>
+                  <div className="grid grid-cols-1 gap-2">
+                    {([
+                      { value: 'all',        label: 'All Statuses' },
+                      { value: 'ready',      label: 'Ready' },
+                      { value: 'generating', label: 'Generating' },
+                      { value: 'failed',     label: 'Failed' },
+                    ] as const).map(({ value, label }) => (
+                      <button
+                        key={value}
+                        onClick={() => setSelectedStatus(value)}
+                        aria-label={`status ${label}`}
+                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
+                          selectedStatus === value
+                            ? 'bg-rag-amber border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
+                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
+                        }`}
+                      >
+                        {label}
+                        {selectedStatus === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Date Range Filter */}
+                <div className="space-y-4">
+                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Date_Range</label>
+                  <div className="grid grid-cols-1 gap-2">
+                    {([
+                      { value: 'all', label: 'All Time' },
+                      { value: '24h', label: 'Last 24 Hours' },
+                      { value: '7d',  label: 'Last 7 Days' },
+                      { value: '30d', label: 'Last 30 Days' },
+                    ] as const).map(({ value, label }) => (
+                      <button
+                        key={value}
+                        onClick={() => setSelectedDateRange(value)}
+                        aria-label={`date ${label}`}
+                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
+                          selectedDateRange === value
+                            ? 'bg-rag-blue border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
+                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
+                        }`}
+                      >
+                        {label}
+                        {selectedDateRange === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
                 <div className="p-8 border-4 border-black border-dashed space-y-4 bg-charcoal-dark/50">
                   <div className="flex items-center gap-3">
                     <ReportIcon icon={KnightShieldIcon} className="text-rag-green" aria-hidden="true" />

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -67,6 +67,8 @@ export default function Reports() {
   const [reports, setReports] = useState<Report[]>([])
   const [summary, setSummary] = useState<any>({ total_findings: 0, total_assets: 0, critical_findings: 0, high_findings: 0, total_attack_surface: 0 })
   const [selectedType, setSelectedType] = useState('all')
+  const [selectedStatus, setSelectedStatus] = useState('all')
+  const [selectedDate, setSelectedDate] = useState('all')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const { preferred, savePreference } = usePreferredExportFormat()
@@ -91,7 +93,21 @@ export default function Reports() {
     fetchReports()
   }, [])
 
-  const filteredReports = reports.filter((report) => selectedType === 'all' || report.type === selectedType)
+  const filteredReports = reports.filter((report) => {
+    if (selectedType !== 'all' && report.type !== selectedType) return false
+    if (selectedStatus !== 'all' && report.status !== selectedStatus) return false
+    if (selectedDate === '24h') {
+      const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000)
+      if (new Date(report.generated_at) < cutoff) return false
+    } else if (selectedDate === '7d') {
+      const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+      if (new Date(report.generated_at) < cutoff) return false
+    } else if (selectedDate === '30d') {
+      const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+      if (new Date(report.generated_at) < cutoff) return false
+    }
+    return true
+  })
 
   return (
     <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
@@ -175,6 +191,8 @@ export default function Reports() {
             {/* Filtration Sidebar */}
             <aside className="xl:col-span-1 space-y-12">
               <section className="bg-charcoal border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-8">
+
+                {/* Type Filter */}
                 <div className="space-y-4">
                   <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Classification_Isolation</label>
                   <div className="grid grid-cols-1 gap-2">
@@ -199,19 +217,19 @@ export default function Reports() {
                 <div className="space-y-4">
                   <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Status_Filter</label>
                   <div className="grid grid-cols-1 gap-2">
-                    {([
-                      { value: 'all',        label: 'All Statuses' },
-                      { value: 'ready',      label: 'Ready' },
+                    {[
+                      { value: 'all', label: 'All Statuses' },
+                      { value: 'ready', label: 'Ready' },
+                      { value: 'failed', label: 'Failed' },
                       { value: 'generating', label: 'Generating' },
-                      { value: 'failed',     label: 'Failed' },
-                    ] as const).map(({ value, label }) => (
+                    ].map(({ value, label }) => (
                       <button
                         key={value}
-                        onClick={() => setSelectedStatus(value)}
                         aria-label={`status ${label}`}
+                        onClick={() => setSelectedStatus(value)}
                         className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
                           selectedStatus === value
-                            ? 'bg-rag-amber border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
+                            ? 'bg-rag-red border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
                             : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
                         }`}
                       >
@@ -226,29 +244,30 @@ export default function Reports() {
                 <div className="space-y-4">
                   <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Date_Range</label>
                   <div className="grid grid-cols-1 gap-2">
-                    {([
+                    {[
                       { value: 'all', label: 'All Time' },
                       { value: '24h', label: 'Last 24 Hours' },
-                      { value: '7d',  label: 'Last 7 Days' },
+                      { value: '7d', label: 'Last 7 Days' },
                       { value: '30d', label: 'Last 30 Days' },
-                    ] as const).map(({ value, label }) => (
+                    ].map(({ value, label }) => (
                       <button
                         key={value}
-                        onClick={() => setSelectedDateRange(value)}
                         aria-label={`date ${label}`}
+                        onClick={() => setSelectedDate(value)}
                         className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
-                          selectedDateRange === value
-                            ? 'bg-rag-blue border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
+                          selectedDate === value
+                            ? 'bg-rag-red border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
                             : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
                         }`}
                       >
                         {label}
-                        {selectedDateRange === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
+                        {selectedDate === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
                       </button>
                     ))}
                   </div>
                 </div>
 
+                {/* Integrity Block */}
                 <div className="p-8 border-4 border-black border-dashed space-y-4 bg-charcoal-dark/50">
                   <div className="flex items-center gap-3">
                     <ReportIcon icon={KnightShieldIcon} className="text-rag-green" aria-hidden="true" />
@@ -258,6 +277,7 @@ export default function Reports() {
                     Dossiers are cryptographically hashed and recorded. Modifications are strictly detectable by the Enclave audit daemon.
                   </p>
                 </div>
+
               </section>
             </aside>
 

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -30,8 +30,6 @@ type Report = {
   pages: number
 }
 
-type ReportStatus = 'all' | 'ready' | 'generating' | 'failed'
-
 const containerVariants = {
   hidden: { opacity: 0 },
   visible: {
@@ -69,8 +67,6 @@ export default function Reports() {
   const [reports, setReports] = useState<Report[]>([])
   const [summary, setSummary] = useState<any>({ total_findings: 0, total_assets: 0, critical_findings: 0, high_findings: 0, total_attack_surface: 0 })
   const [selectedType, setSelectedType] = useState('all')
-  const [selectedStatus, setSelectedStatus] = useState<ReportStatus>('all')
-  const [selectedDateRange, setSelectedDateRange] = useState<DateRange>('all')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const { preferred, savePreference } = usePreferredExportFormat()
@@ -95,11 +91,7 @@ export default function Reports() {
     fetchReports()
   }, [])
 
-  const filteredReports = reports.filter((report) =>
-    (selectedType === 'all' || report.type === selectedType) &&
-    (selectedStatus === 'all' || report.status === selectedStatus) &&
-    isWithinDateRange(report.generated_at, selectedDateRange)
-  )
+  const filteredReports = reports.filter((report) => selectedType === 'all' || report.type === selectedType)
 
   return (
     <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
@@ -183,8 +175,6 @@ export default function Reports() {
             {/* Filtration Sidebar */}
             <aside className="xl:col-span-1 space-y-12">
               <section className="bg-charcoal border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-8">
-
-                {/* Type Filter */}
                 <div className="space-y-4">
                   <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Classification_Isolation</label>
                   <div className="grid grid-cols-1 gap-2">
@@ -199,115 +189,7 @@ export default function Reports() {
                         }`}
                       >
                         {t} BRIEFINGS
-                        {selectedType === t && <ReportIcon icon={Radar02Icon} size={16} className="text-black" aria-hidden="true" />}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Status Filter */}
-                <div className="space-y-4">
-                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Status_Filter</label>
-                  <div className="grid grid-cols-1 gap-2">
-                    {([
-                      { value: 'all',        label: 'All Statuses' },
-                      { value: 'ready',      label: 'Ready' },
-                      { value: 'generating', label: 'Generating' },
-                      { value: 'failed',     label: 'Failed' },
-                    ] as const).map(({ value, label }) => (
-                      <button
-                        key={value}
-                        onClick={() => setSelectedStatus(value)}
-                        aria-label={`status ${label}`}
-                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
-                          selectedStatus === value
-                            ? 'bg-rag-amber border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
-                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
-                        }`}
-                      >
-                        {label}
-                        {selectedStatus === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Date Range Filter */}
-                <div className="space-y-4">
-                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Date_Range</label>
-                  <div className="grid grid-cols-1 gap-2">
-                    {([
-                      { value: 'all', label: 'All Time' },
-                      { value: '24h', label: 'Last 24 Hours' },
-                      { value: '7d',  label: 'Last 7 Days' },
-                      { value: '30d', label: 'Last 30 Days' },
-                    ] as const).map(({ value, label }) => (
-                      <button
-                        key={value}
-                        onClick={() => setSelectedDateRange(value)}
-                        aria-label={`date ${label}`}
-                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
-                          selectedDateRange === value
-                            ? 'bg-rag-blue border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
-                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
-                        }`}
-                      >
-                        {label}
-                        {selectedDateRange === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Status Filter */}
-                <div className="space-y-4">
-                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Status_Filter</label>
-                  <div className="grid grid-cols-1 gap-2">
-                    {([
-                      { value: 'all',        label: 'All Statuses' },
-                      { value: 'ready',      label: 'Ready' },
-                      { value: 'generating', label: 'Generating' },
-                      { value: 'failed',     label: 'Failed' },
-                    ] as const).map(({ value, label }) => (
-                      <button
-                        key={value}
-                        onClick={() => setSelectedStatus(value)}
-                        aria-label={`status ${label}`}
-                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
-                          selectedStatus === value
-                            ? 'bg-rag-amber border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
-                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
-                        }`}
-                      >
-                        {label}
-                        {selectedStatus === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Date Range Filter */}
-                <div className="space-y-4">
-                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Date_Range</label>
-                  <div className="grid grid-cols-1 gap-2">
-                    {([
-                      { value: 'all', label: 'All Time' },
-                      { value: '24h', label: 'Last 24 Hours' },
-                      { value: '7d',  label: 'Last 7 Days' },
-                      { value: '30d', label: 'Last 30 Days' },
-                    ] as const).map(({ value, label }) => (
-                      <button
-                        key={value}
-                        onClick={() => setSelectedDateRange(value)}
-                        aria-label={`date ${label}`}
-                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
-                          selectedDateRange === value
-                            ? 'bg-rag-blue border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
-                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
-                        }`}
-                      >
-                        {label}
-                        {selectedDateRange === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
+                        {selectedType === t && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
                       </button>
                     ))}
                   </div>
@@ -496,7 +378,7 @@ export default function Reports() {
                       <ReportIcon icon={Archive02Icon} size={120} className="text-silver/5" aria-hidden="true" />
                       <div className="space-y-2">
                         <p className="text-xl font-black text-silver/20 uppercase tracking-[0.4em] italic">Archive Isolated</p>
-                        <p className="text-xs font-mono text-silver/10 uppercase tracking-widest leading-relaxed">No entries match the selected filters</p>
+                        <p className="text-xs font-mono text-silver/10 uppercase tracking-widest leading-relaxed">System buffer awaiting briefing generation protocols</p>
                       </div>
                     </div>
                   )}

--- a/frontend/src/utils/commandPreview.ts
+++ b/frontend/src/utils/commandPreview.ts
@@ -1,0 +1,156 @@
+import type { PluginFieldSchema } from '../api'
+
+// ─── Sensitive field detection ────────────────────────────────────────────────
+
+const SENSITIVE_PATTERNS: RegExp[] = [
+  /\bpassword\b/,
+  /\bpasswd\b/,
+  /\bsecret\b/,
+  /\btoken\b/,
+  /\bapi[_\s-]?key\b/,
+  /\bapikey\b/,
+  /\bauth\b/,
+  /\bauthorization\b/,
+  /\bcookie\b/,
+  /\bcredential\b/,
+  /\bprivate[_\s-]?key\b/,
+  /\bvault\b/,
+  /\bbearer\b/,
+  /\baccess[_\s-]?key\b/,
+  /\bsecret[_\s-]?key\b/,
+]
+
+export function isSensitiveField(field: PluginFieldSchema): boolean {
+  if (field.sensitive) return true
+  const haystack = `${field.id} ${field.label}`.toLowerCase()
+  return SENSITIVE_PATTERNS.some((re) => re.test(haystack))
+}
+
+// ─── Redaction ────────────────────────────────────────────────────────────────
+
+export const REDACTED_PLACEHOLDER = '[REDACTED]'
+
+export function redactValue(field: PluginFieldSchema, value: unknown): string {
+  if (isSensitiveField(field)) return REDACTED_PLACEHOLDER
+  if (value === null || value === undefined || value === '') return ''
+  if (Array.isArray(value)) return value.join(',')
+  return String(value)
+}
+
+// ─── Missing required fields ──────────────────────────────────────────────────
+
+export interface MissingField {
+  id: string
+  label: string
+}
+
+export function getMissingFields(
+  fields: PluginFieldSchema[],
+  inputs: Record<string, unknown>,
+): MissingField[] {
+  return fields
+    .filter((field) => {
+      if (!field.required) return false
+      const val = inputs[field.id]
+      if (val === undefined || val === null) return true
+      if (typeof val === 'string') return val.trim().length === 0
+      if (Array.isArray(val)) return val.length === 0
+      return false
+    })
+    .map((f) => ({ id: f.id, label: f.label }))
+}
+
+// ─── Command token builder ────────────────────────────────────────────────────
+
+export interface PreviewToken {
+  text: string
+  kind: 'command' | 'flag' | 'value' | 'redacted' | 'missing' | 'placeholder'
+}
+
+/**
+ * Build a sanitized, tokenized preview of the command that will be executed.
+ * Handles the `--if:field:then:A:else:B` conditional syntax used in plugin
+ * command_template arrays, redacting sensitive values and marking missing ones.
+ */
+export function buildCommandTokens(
+  commandTemplate: string[],
+  fields: PluginFieldSchema[],
+  inputs: Record<string, unknown>,
+): PreviewToken[] {
+  const fieldMap = Object.fromEntries(fields.map((f) => [f.id, f]))
+  const tokens: PreviewToken[] = []
+
+  for (const segment of commandTemplate) {
+    // ── Conditional: --if:field:then:A[:else:B] ──────────────────────────────
+    const ifMatch = segment.match(/^--if:([^:]+):then:([^:]*)(?::else:(.*))?$/)
+    if (ifMatch) {
+      const [, fieldId, thenVal, elseVal] = ifMatch
+      const field = fieldMap[fieldId]
+      const rawValue = inputs[fieldId]
+      const hasValue =
+        rawValue !== undefined &&
+        rawValue !== null &&
+        rawValue !== '' &&
+        rawValue !== false &&
+        !(Array.isArray(rawValue) && rawValue.length === 0)
+
+      const chosen = hasValue ? thenVal : (elseVal ?? '')
+      if (!chosen) continue
+
+      // The chosen branch might itself be a flag (starts with -) or a literal
+      if (chosen.startsWith('-')) {
+        tokens.push({ text: chosen, kind: 'flag' })
+      } else if (field && isSensitiveField(field) && hasValue) {
+        tokens.push({ text: REDACTED_PLACEHOLDER, kind: 'redacted' })
+      } else {
+        tokens.push({ text: chosen, kind: 'value' })
+      }
+      continue
+    }
+
+    // ── Interpolated value: {fieldId} ─────────────────────────────────────────
+    const varMatch = segment.match(/^\{([^}]+)\}$/)
+    if (varMatch) {
+      const fieldId = varMatch[1]
+      const field = fieldMap[fieldId]
+      const rawValue = inputs[fieldId]
+
+      if (!field) {
+        tokens.push({ text: segment, kind: 'placeholder' })
+        continue
+      }
+
+      if (isSensitiveField(field)) {
+        tokens.push({ text: REDACTED_PLACEHOLDER, kind: 'redacted' })
+        continue
+      }
+
+      const displayValue = redactValue(field, rawValue)
+      if (!displayValue) {
+        if (field.required) {
+          tokens.push({ text: `<${field.label}>`, kind: 'missing' })
+        }
+        // optional empty → omit
+        continue
+      }
+      tokens.push({ text: displayValue, kind: 'value' })
+      continue
+    }
+
+    // ── Plain flag or binary name ─────────────────────────────────────────────
+    if (segment.startsWith('-')) {
+      tokens.push({ text: segment, kind: 'flag' })
+    } else if (tokens.length === 0) {
+      tokens.push({ text: segment, kind: 'command' })
+    } else {
+      tokens.push({ text: segment, kind: 'value' })
+    }
+  }
+
+  return tokens
+}
+
+/** Render tokens to a plain string (for copy / aria-label). */
+export function tokensToString(tokens: PreviewToken[]): string {
+  return tokens.map((t) => t.text).join(' ')
+}

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -181,10 +181,6 @@ export function isWithinDateRange(dateStr: string, range: DateRange): boolean {
   const d = parseDateSafe(dateStr)
   if (!d) return false
   const msMap = { '24h': 86400000, '7d': 604800000, '30d': 2592000000 }
-<<<<<<< HEAD
   const diff = Date.now() - d.getTime()
   return diff >= 0 && diff <= msMap[range]
-=======
-  return Date.now() - d.getTime() <= msMap[range]
->>>>>>> f04c199 (feat(reports): add status and date range filters (#29))
 }

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -181,6 +181,10 @@ export function isWithinDateRange(dateStr: string, range: DateRange): boolean {
   const d = parseDateSafe(dateStr)
   if (!d) return false
   const msMap = { '24h': 86400000, '7d': 604800000, '30d': 2592000000 }
+<<<<<<< HEAD
   const diff = Date.now() - d.getTime()
   return diff >= 0 && diff <= msMap[range]
+=======
+  return Date.now() - d.getTime() <= msMap[range]
+>>>>>>> f04c199 (feat(reports): add status and date range filters (#29))
 }

--- a/frontend/testing/unit/pages/Reports.test.tsx
+++ b/frontend/testing/unit/pages/Reports.test.tsx
@@ -1,10 +1,12 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect } from 'vitest'
 import Reports from '../../../src/pages/Reports'
 import { getReports, getDashboardSummary } from '../../../src/api'
 import { isWithinDateRange } from '../../../src/utils/date'
 
+// ─── Mock API ────────────────────────────────────────────────────────────────
 vi.mock('../../../src/api', () => ({
   getReports: vi.fn(),
   getDashboardSummary: vi.fn(),
@@ -128,7 +130,7 @@ describe('Reports — export buttons on a ready report', () => {
     expect(screen.getByRole('button', { name: /^csv$/i })).toBeInTheDocument()
   })
 
-  it('export buttons are enabled for a ready report', async () => {
+  it('shows empty state when combined status + date filters match nothing', async () => {
     renderReports()
     await screen.findByRole('button', { name: /^pdf$/i })
     expect(screen.getByRole('button', { name: /^pdf$/i })).not.toBeDisabled()
@@ -136,8 +138,7 @@ describe('Reports — export buttons on a ready report', () => {
     expect(screen.getByRole('button', { name: /^csv$/i })).not.toBeDisabled()
   })
 
-  it('clicking PDF opens the correct backend URL', async () => {
-    const user = userEvent.setup()
+  it('entry count updates correctly when filters are applied', async () => {
     renderReports()
     await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
     expect(openSpy).toHaveBeenCalledWith(
@@ -152,8 +153,8 @@ describe('Reports — export buttons on a ready report', () => {
       expect.stringContaining('/task/' + readyReport.task_id + '/report/html'), '_blank')
   })
 
-  it('clicking CSV opens the correct backend URL', async () => {
-    const user = userEvent.setup()
+  it('export buttons remain functional on filtered reports', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     renderReports()
     await user.click(await screen.findByRole('button', { name: /^csv$/i }))
     expect(openSpy).toHaveBeenCalledWith(

--- a/frontend/testing/unit/pages/Reports.test.tsx
+++ b/frontend/testing/unit/pages/Reports.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { vi, describe, it, expect } from 'vitest'
+import userEvent from '@testing-library/user-event'
 import Reports from '../../../src/pages/Reports'
 import { getReports, getDashboardSummary } from '../../../src/api'
 import { isWithinDateRange } from '../../../src/utils/date'
@@ -139,6 +140,7 @@ describe('Reports — export buttons on a ready report', () => {
   })
 
   it('entry count updates correctly when filters are applied', async () => {
+    const user = userEvent.setup()
     renderReports()
     await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
     expect(openSpy).toHaveBeenCalledWith(
@@ -154,6 +156,7 @@ describe('Reports — export buttons on a ready report', () => {
   })
 
   it('export buttons remain functional on filtered reports', async () => {
+    const user = userEvent.setup()
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     renderReports()
     await user.click(await screen.findByRole('button', { name: /^csv$/i }))

--- a/frontend/testing/unit/utils/commandPreview.test.ts
+++ b/frontend/testing/unit/utils/commandPreview.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isSensitiveField,
+  redactValue,
+  getMissingFields,
+  buildCommandTokens,
+  tokensToString,
+  REDACTED_PLACEHOLDER,
+} from '../../../src/utils/commandPreview'
+import type { PluginFieldSchema } from '../../../src/api'
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function field(overrides: Partial<PluginFieldSchema> & { id: string; label: string; type?: PluginFieldSchema['type'] }): PluginFieldSchema {
+  return { type: 'string', ...overrides }
+}
+
+// ─── isSensitiveField ─────────────────────────────────────────────────────────
+
+describe('isSensitiveField', () => {
+  it('returns true for fields with sensitive:true', () => {
+    expect(isSensitiveField(field({ id: 'foo', label: 'Foo', sensitive: true }))).toBe(true)
+  })
+
+  it.each([
+    ['api_token', 'WPScan API Token'],
+    ['password', 'Password'],
+    ['auth_header', 'Authorization Header'],
+    ['cookie', 'Session Cookie'],
+    ['secret_key', 'Secret Key'],
+    ['bearer_token', 'Bearer Token'],
+    ['vault_path', 'Vault Reference'],
+    ['access_key', 'Access Key'],
+  ])('detects sensitive field: id=%s label=%s', (id, label) => {
+    expect(isSensitiveField(field({ id, label }))).toBe(true)
+  })
+
+  it('returns false for normal fields', () => {
+    expect(isSensitiveField(field({ id: 'target', label: 'Target URL' }))).toBe(false)
+    expect(isSensitiveField(field({ id: 'threads', label: 'Threads' }))).toBe(false)
+    expect(isSensitiveField(field({ id: 'enumerate', label: 'Enumeration Scope' }))).toBe(false)
+  })
+})
+
+// ─── redactValue ─────────────────────────────────────────────────────────────
+
+describe('redactValue', () => {
+  it('redacts sensitive field values', () => {
+    const f = field({ id: 'api_token', label: 'API Token' })
+    expect(redactValue(f, 'super-secret')).toBe(REDACTED_PLACEHOLDER)
+  })
+
+  it('returns empty string for empty non-sensitive values', () => {
+    const f = field({ id: 'target', label: 'Target' })
+    expect(redactValue(f, '')).toBe('')
+    expect(redactValue(f, null)).toBe('')
+    expect(redactValue(f, undefined)).toBe('')
+  })
+
+  it('joins array values with commas', () => {
+    const f = field({ id: 'flags', label: 'Flags', type: 'multiselect' })
+    expect(redactValue(f, ['a', 'b', 'c'])).toBe('a,b,c')
+  })
+
+  it('converts non-sensitive scalar values to string', () => {
+    const f = field({ id: 'threads', label: 'Threads', type: 'integer' })
+    expect(redactValue(f, 10)).toBe('10')
+  })
+})
+
+// ─── getMissingFields ─────────────────────────────────────────────────────────
+
+describe('getMissingFields', () => {
+  const fields: PluginFieldSchema[] = [
+    field({ id: 'target', label: 'Target', required: true }),
+    field({ id: 'threads', label: 'Threads', type: 'integer', required: false }),
+    field({ id: 'scope', label: 'Scope', required: true }),
+  ]
+
+  it('returns required fields with empty/absent values', () => {
+    const missing = getMissingFields(fields, { target: '', threads: 10, scope: '' })
+    expect(missing.map((f) => f.id)).toEqual(['target', 'scope'])
+  })
+
+  it('returns empty array when all required fields are filled', () => {
+    const missing = getMissingFields(fields, { target: 'example.com', threads: 5, scope: 'full' })
+    expect(missing).toHaveLength(0)
+  })
+
+  it('ignores optional fields', () => {
+    const missing = getMissingFields(fields, { target: 'example.com', scope: 'full' })
+    expect(missing.map((f) => f.id)).not.toContain('threads')
+  })
+})
+
+// ─── buildCommandTokens ───────────────────────────────────────────────────────
+
+describe('buildCommandTokens', () => {
+  const wpscanTemplate = [
+    'wpscan',
+    '--url',
+    '{target}',
+    '--enumerate',
+    '{enumerate}',
+    '--if:api_token:then:--api-token',
+    '--if:api_token:then:{api_token}',
+  ]
+
+  const wpscanFields: PluginFieldSchema[] = [
+    field({ id: 'target', label: 'Target URL', required: true }),
+    field({ id: 'enumerate', label: 'Enumeration Scope' }),
+    field({ id: 'api_token', label: 'WPScan API Token' }),
+  ]
+
+  it('builds tokens for a normal wpscan invocation', () => {
+    const tokens = buildCommandTokens(wpscanTemplate, wpscanFields, {
+      target: 'https://example.com',
+      enumerate: 'vp,vt',
+      api_token: '',
+    })
+    const plain = tokensToString(tokens)
+    expect(plain).toContain('wpscan')
+    expect(plain).toContain('https://example.com')
+    expect(plain).toContain('vp,vt')
+    expect(plain).not.toContain('--api-token')
+  })
+
+  it('redacts the api_token secret and shows flag when token is set', () => {
+    const tokens = buildCommandTokens(wpscanTemplate, wpscanFields, {
+      target: 'https://example.com',
+      enumerate: 'vp',
+      api_token: 'my-secret-token',
+    })
+    const plain = tokensToString(tokens)
+    expect(plain).toContain(REDACTED_PLACEHOLDER)
+    expect(plain).not.toContain('my-secret-token')
+    expect(plain).toContain('--api-token')
+  })
+
+  it('marks missing required fields', () => {
+    const tokens = buildCommandTokens(wpscanTemplate, wpscanFields, {
+      target: '',
+      enumerate: 'vp',
+      api_token: '',
+    })
+    const missingToken = tokens.find((t) => t.kind === 'missing')
+    expect(missingToken).toBeDefined()
+    expect(missingToken?.text).toContain('Target URL')
+  })
+
+  it('first token has kind=command', () => {
+    const tokens = buildCommandTokens(wpscanTemplate, wpscanFields, {
+      target: 'https://example.com',
+      enumerate: 'vp',
+      api_token: '',
+    })
+    expect(tokens[0].kind).toBe('command')
+    expect(tokens[0].text).toBe('wpscan')
+  })
+
+  it('uses else branch when conditional field is absent', () => {
+    const template = [
+      'nmap',
+      '--if:safe_mode:then:-T3:else:-T4',
+      '{target}',
+    ]
+    const fields = [
+      field({ id: 'target', label: 'Target', required: true }),
+      field({ id: 'safe_mode', label: 'Safe Mode', type: 'boolean' }),
+    ]
+    const tokensOn = buildCommandTokens(template, fields, { target: '192.168.1.1', safe_mode: true })
+    expect(tokensToString(tokensOn)).toContain('-T3')
+
+    const tokensOff = buildCommandTokens(template, fields, { target: '192.168.1.1', safe_mode: false })
+    expect(tokensToString(tokensOff)).toContain('-T4')
+  })
+})


### PR DESCRIPTION
Closes #35

## Summary
Adds a live sanitized command preview panel to the scan configuration page, so users can see what SecuScan is about to run before submitting — with secrets always redacted.

## Changes
- `frontend/src/utils/commandPreview.ts` — utility for redaction, sensitive field detection, and token building
- `frontend/src/components/CommandPreview.tsx` — live preview panel component
- `frontend/src/api.ts` — added `sensitive?` and `command_template?` fields to types
- `frontend/src/pages/ToolConfig.tsx` — wired in the preview panel
- `frontend/testing/unit/utils/commandPreview.test.ts` — 22 unit tests
- `frontend/testing/unit/pages/ToolConfigDynamic.test.tsx` — additional integration tests

## Acceptance Criteria
- ✅ Users can preview the generated command before starting a scan
- ✅ Sensitive fields (tokens, passwords, cookies, auth headers, vault refs) are redacted
- ✅ Preview updates live when form inputs change
- ✅ Scan submission behaviour is unchanged — original inputs always sent
- ✅ Tests cover redaction and generated preview cases