### PR TITLE
docs(plugins): add contributor examples for checksum refresh workflow

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -142,6 +142,35 @@ After refreshing, run the backend tests to confirm the plugin loads correctly:
 cd backend && python -m pytest
 ```
 
+### Example 1 — Refresh a single plugin after editing its files
+
+Run this after editing `plugins/nmap/metadata.json` or `plugins/nmap/parser.py`:
+
+```bash
+python scripts/refresh_plugin_checksum.py --plugin nmap
+```
+
+When the checksum is already up to date, the script reports the plugin as
+`[OK]` and exits cleanly with no files modified.
+
+When the checksum is outdated, the script prints the old and new digest values,
+writes the updated checksum back into `metadata.json`, and confirms the update.
+
+### Example 2 — Preview all plugins without writing anything (dry run)
+
+Run this to check which plugins are out of date before committing:
+
+```bash
+python scripts/refresh_plugin_checksum.py --all --dry-run
+```
+
+In dry-run mode no files are modified. Each plugin reports either `[OK]` if
+its checksum is current, or `[UPDATE]` showing what would change. A clean
+state means every plugin reports `[OK]` and the final line shows zero failures.
+
+If any `[UPDATE]` lines appear, run the same command without `--dry-run` to
+apply the changes before committing.
+
 ## Plugin Validation
 
 Validate a single plugin without loading all plugins:


### PR DESCRIPTION
## Description
Contributors editing plugin files had no clear guidance on when to run `scripts/refresh_plugin_checksum.py` or what a successful run looks like. This PR adds two contributor-facing examples to the existing Checksum Maintenance section in `PLUGINS.md` — one for refreshing a single plugin and one explaining dry-run mode — using plain English descriptions instead of raw terminal output dumps.

## Related Issues
'Closes #75'

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
Manual verification done:
- Confirmed `scripts/refresh_plugin_checksum.py` exists and supports `--plugin`, `--all`, and `--dry-run` flags
- Verified the example commands match the actual script CLI exactly
- Confirmed output descriptions match the script's `[OK]` and `[UPDATE]` print statements
- Reviewed that no plugin `metadata.json` files were modified
- Confirmed changes are scoped to `PLUGINS.md` only

## Checklist
- [ ] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
