### PR TITLE
Add plugin metadata validator CLI and tests

### DIFF
--- a/backend/secuscan/plugin_validator.py
+++ b/backend/secuscan/plugin_validator.py
@@ -1,0 +1,340 @@
+"""
+plugin_validator.py — SecuScan plugin metadata validator
+
+Shared validation logic used by:
+  - scripts/validate_plugins.py  (CLI helper for contributors)
+  - backend plugin loading        (via PluginManager._validate_plugin)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VALID_ENGINE_TYPES = {"cli", "python", "docker"}
+VALID_SAFETY_LEVELS = {"safe", "intrusive", "exploit"}
+VALID_FIELD_TYPES = {"string","integer","text", "number", "boolean", "select", "multiselect", "textarea"}
+VALID_PARSER_TYPES = {"json", "text", "custom", "none"}
+
+REQUIRED_TOP_LEVEL_FIELDS = [
+    "id",
+    "name",
+    "description",
+    "version",
+    "category",
+    "icon",
+    "engine",
+    "command_template",
+    "fields",
+    "output",
+    "safety",
+    "checksum",
+]
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ValidationError:
+    plugin_id: str
+    path: str
+    message: str
+
+    def display(self) -> str:
+        return f"  ✗  [{self.plugin_id}]  {self.path}  →  {self.message}"
+
+
+@dataclass
+class ValidationResult:
+    plugin_id: str
+    plugin_dir: Path
+    errors: list = field(default_factory=list)
+
+    @property
+    def valid(self) -> bool:
+        return len(self.errors) == 0
+
+    def add(self, path: str, message: str) -> None:
+        self.errors.append(ValidationError(self.plugin_id, path, message))
+
+
+# ---------------------------------------------------------------------------
+# Core validator
+# ---------------------------------------------------------------------------
+
+
+class PluginMetadataValidator:
+    """
+    Validates a single plugin directory.
+
+    Usage::
+
+        validator = PluginMetadataValidator(Path("plugins/nmap"))
+        result = validator.validate()
+        if not result.valid:
+            for err in result.errors:
+                print(err.display())
+    """
+
+    def __init__(self, plugin_dir: Path) -> None:
+        self.plugin_dir = plugin_dir
+        self.metadata_file = plugin_dir / "metadata.json"
+
+    def validate(self) -> ValidationResult:
+        plugin_id = self.plugin_dir.name  # fallback before we parse id
+
+        if not self.metadata_file.exists():
+            result = ValidationResult(plugin_id=plugin_id, plugin_dir=self.plugin_dir)
+            result.add("metadata.json", "File not found")
+            return result
+
+        try:
+            raw = self.metadata_file.read_text(encoding="utf-8")
+            data: dict[str, Any] = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            result = ValidationResult(plugin_id=plugin_id, plugin_dir=self.plugin_dir)
+            result.add("metadata.json", f"Invalid JSON — {exc}")
+            return result
+
+        plugin_id = data.get("id") or plugin_id
+        result = ValidationResult(plugin_id=plugin_id, plugin_dir=self.plugin_dir)
+
+        self._check_required_fields(data, result)
+        self._check_engine(data, result)
+        self._check_command_template(data, result)
+        self._check_fields(data, result)
+        self._check_output(data, result)
+        self._check_safety(data, result)
+        self._check_validation_block(data, result)
+        self._check_checksum(data, result)
+        self._check_dependencies(data, result)
+        self._check_custom_parser(data, result)
+
+        return result
+
+    def _check_required_fields(self, data: dict, result: ValidationResult) -> None:
+        for key in REQUIRED_TOP_LEVEL_FIELDS:
+            if key not in data or data[key] in (None, "", [], {}):
+                result.add(key, f"Required field '{key}' is missing or empty")
+
+    def _check_engine(self, data: dict, result: ValidationResult) -> None:
+        engine = data.get("engine")
+        if not isinstance(engine, dict):
+            result.add("engine", "Must be an object")
+            return
+
+        engine_type = engine.get("type")
+        if engine_type not in VALID_ENGINE_TYPES:
+            result.add(
+                "engine.type",
+                f"'{engine_type}' is not a supported engine type — "
+                f"must be one of: {sorted(VALID_ENGINE_TYPES)}",
+            )
+
+        if engine_type == "cli" and not engine.get("binary"):
+            result.add("engine.binary", "CLI engine must declare a 'binary'")
+
+        if engine_type == "docker" and not engine.get("image"):
+            result.add("engine.image", "Docker engine must declare an 'image'")
+
+    def _check_command_template(self, data: dict, result: ValidationResult) -> None:
+        template = data.get("command_template")
+        if not isinstance(template, list):
+            result.add("command_template", "Must be a list of strings")
+            return
+
+        known_field_ids: set[str] = set()
+        for f in data.get("fields", []):
+            if isinstance(f, dict) and f.get("id"):
+                known_field_ids.add(f["id"])
+
+        placeholder_re = re.compile(r"\{(\w+)(?::[^}]*)?\}")
+        for i, token in enumerate(template):
+            if not isinstance(token, str):
+                result.add(f"command_template[{i}]", "Each token must be a string")
+                continue
+
+            if token.startswith("--if:"):
+                continue
+
+            for match in placeholder_re.finditer(token):
+                var_name = match.group(1)
+                if known_field_ids and var_name not in known_field_ids:
+                    result.add(
+                        f"command_template[{i}]",
+                        f"Placeholder '{{{var_name}}}' does not match any declared field id",
+                    )
+
+    def _check_fields(self, data: dict, result: ValidationResult) -> None:
+        fields = data.get("fields")
+        if not isinstance(fields, list):
+            result.add("fields", "Must be a list")
+            return
+
+        seen_ids: set[str] = set()
+        for i, f in enumerate(fields):
+            prefix = f"fields[{i}]"
+            if not isinstance(f, dict):
+                result.add(prefix, "Each field must be an object")
+                continue
+
+            fid = f.get("id")
+            if not fid:
+                result.add(f"{prefix}.id", "Field is missing an 'id'")
+            elif fid in seen_ids:
+                result.add(f"{prefix}.id", f"Duplicate field id '{fid}'")
+            else:
+                seen_ids.add(fid)
+
+            if not f.get("label"):
+                result.add(f"{prefix}.label", f"Field '{fid}' is missing a 'label'")
+
+            ftype = f.get("type")
+            if ftype not in VALID_FIELD_TYPES:
+                result.add(
+                    f"{prefix}.type",
+                    f"'{ftype}' is not a supported field type — "
+                    f"must be one of: {sorted(VALID_FIELD_TYPES)}",
+                )
+
+            if ftype in ("select", "multiselect"):
+                options = f.get("options")
+                if not isinstance(options, list) or len(options) == 0:
+                    result.add(
+                        f"{prefix}.options",
+                        f"Field '{fid}' is type '{ftype}' and must have a non-empty 'options' list",
+                    )
+
+    def _check_output(self, data: dict, result: ValidationResult) -> None:
+        output = data.get("output")
+        if not isinstance(output, dict):
+            result.add("output", "Must be an object")
+            return
+
+        parser = output.get("parser")
+        if parser not in VALID_PARSER_TYPES:
+            result.add(
+                "output.parser",
+                f"'{parser}' is not a supported parser type — "
+                f"must be one of: {sorted(VALID_PARSER_TYPES)}",
+            )
+
+    def _check_safety(self, data: dict, result: ValidationResult) -> None:
+        safety = data.get("safety")
+        if not isinstance(safety, dict):
+            result.add("safety", "Must be an object")
+            return
+
+        level = safety.get("level")
+        if level not in VALID_SAFETY_LEVELS:
+            result.add(
+                "safety.level",
+                f"'{level}' is not a supported safety level — "
+                f"must be one of: {sorted(VALID_SAFETY_LEVELS)}",
+            )
+
+        if safety.get("requires_consent") and not safety.get("consent_message"):
+            result.add(
+                "safety.consent_message",
+                "Plugin requires consent but 'consent_message' is missing or empty",
+            )
+
+    def _check_validation_block(self, data: dict, result: ValidationResult) -> None:
+        validation = data.get("validation")
+        if validation is None:
+            return
+
+        if not isinstance(validation, dict):
+            result.add("validation", "Must be an object if present")
+            return
+
+        for key, rule in validation.items():
+            prefix = f"validation.{key}"
+            if not isinstance(rule, dict):
+                result.add(prefix, "Each validation rule must be an object")
+                continue
+            if "required" in rule and not isinstance(rule["required"], bool):
+                result.add(f"{prefix}.required", "'required' must be a boolean")
+
+    def _check_checksum(self, data: dict, result: ValidationResult) -> None:
+        checksum = data.get("checksum")
+        if not checksum:
+            result.add("checksum", "Checksum is missing — run: python scripts/refresh_plugin_checksum.py --plugin <id>")
+            return
+
+        if not isinstance(checksum, str) or len(checksum) != 64:
+            result.add(
+                "checksum",
+                "Checksum must be a 64-character SHA-256 hex string — "
+                "run: python scripts/refresh_plugin_checksum.py --plugin <id>",
+            )
+
+    def _check_dependencies(self, data: dict, result: ValidationResult) -> None:
+        deps = data.get("dependencies")
+        if deps is None:
+            return
+
+        if not isinstance(deps, dict):
+            result.add("dependencies", "Must be an object if present")
+            return
+
+        binaries = deps.get("binaries")
+        if binaries is not None and not isinstance(binaries, list):
+            result.add("dependencies.binaries", "Must be a list of strings")
+        elif isinstance(binaries, list):
+            for i, b in enumerate(binaries):
+                if not isinstance(b, str) or not b.strip():
+                    result.add(
+                        f"dependencies.binaries[{i}]",
+                        "Each binary dependency must be a non-empty string",
+                    )
+
+        python_packages = deps.get("python_packages")
+        if python_packages is not None and not isinstance(python_packages, list):
+            result.add("dependencies.python_packages", "Must be a list of strings")
+
+    def _check_custom_parser(self, data: dict, result: ValidationResult) -> None:
+        output = data.get("output")
+        if not isinstance(output, dict):
+            return
+
+        if output.get("parser") == "custom":
+            parser_file = self.plugin_dir / "parser.py"
+            if not parser_file.exists():
+                result.add(
+                    "output.parser",
+                    "Parser is 'custom' but parser.py was not found in the plugin directory",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Batch validation helpers
+# ---------------------------------------------------------------------------
+
+
+def validate_all_plugins(plugins_dir: Path) -> list:
+    """Validate every plugin directory under plugins_dir."""
+    results = []
+    if not plugins_dir.exists():
+        raise FileNotFoundError(f"Plugins directory not found: {plugins_dir}")
+
+    for plugin_dir in sorted(plugins_dir.iterdir()):
+        if not plugin_dir.is_dir():
+            continue
+        results.append(PluginMetadataValidator(plugin_dir).validate())
+
+    return results
+
+
+def validate_one_plugin(plugin_dir: Path) -> ValidationResult:
+    """Validate a single plugin directory."""
+    return PluginMetadataValidator(plugin_dir).validate()

--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+validate_plugins.py — SecuScan pre-PR plugin metadata validator
+
+Usage:
+    # Validate all plugins
+    python scripts/validate_plugins.py
+
+    # Validate a single plugin by directory name / plugin id
+    python scripts/validate_plugins.py --plugin nmap
+
+    # Point at a custom plugins directory
+    python scripts/validate_plugins.py --plugins-dir path/to/plugins
+
+    # Machine-readable JSON output
+    python scripts/validate_plugins.py --json
+
+Exit codes:
+    0  — all plugins are valid
+    1  — one or more plugins have validation errors
+    2  — usage / configuration error (directory not found, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Allow running from repo root without installing the package.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from backend.secuscan.plugin_validator import (
+    validate_all_plugins,
+    validate_one_plugin,
+    ValidationResult,
+)
+
+DEFAULT_PLUGINS_DIR = REPO_ROOT / "plugins"
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _print_result(result: ValidationResult) -> None:
+    status = "✓ PASS" if result.valid else "✗ FAIL"
+    print(f"  {status}  {result.plugin_id}  ({result.plugin_dir.name})")
+    for err in result.errors:
+        print(err.display())
+
+
+def _results_to_dict(results: list[ValidationResult]) -> dict:
+    return {
+        "summary": {
+            "total": len(results),
+            "passed": sum(1 for r in results if r.valid),
+            "failed": sum(1 for r in results if not r.valid),
+        },
+        "plugins": [
+            {
+                "id": r.plugin_id,
+                "dir": str(r.plugin_dir),
+                "valid": r.valid,
+                "errors": [
+                    {"path": e.path, "message": e.message} for e in r.errors
+                ],
+            }
+            for r in results
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="validate_plugins",
+        description="Validate SecuScan plugin metadata before opening a pull request.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument(
+        "--plugin",
+        metavar="ID",
+        help="Validate only this plugin (directory name or plugin id).",
+    )
+    p.add_argument(
+        "--plugins-dir",
+        metavar="DIR",
+        default=str(DEFAULT_PLUGINS_DIR),
+        help=f"Path to the plugins directory (default: {DEFAULT_PLUGINS_DIR}).",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of human-readable output.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    plugins_dir = Path(args.plugins_dir)
+
+    # ---- single plugin ------------------------------------------------
+    if args.plugin:
+        plugin_dir = plugins_dir / args.plugin
+        if not plugin_dir.exists():
+            print(f"ERROR: Plugin directory not found: {plugin_dir}", file=sys.stderr)
+            return 2
+
+        result = validate_one_plugin(plugin_dir)
+        results = [result]
+
+    # ---- all plugins --------------------------------------------------
+    else:
+        if not plugins_dir.exists():
+            print(f"ERROR: Plugins directory not found: {plugins_dir}", file=sys.stderr)
+            return 2
+
+        try:
+            results = validate_all_plugins(plugins_dir)
+        except FileNotFoundError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    # ---- output -------------------------------------------------------
+    if args.json:
+        print(json.dumps(_results_to_dict(results), indent=2))
+    else:
+        total = len(results)
+        failed = [r for r in results if not r.valid]
+        passed = total - len(failed)
+
+        print(f"\nSecuScan Plugin Validator — {total} plugin(s) checked\n")
+        print("─" * 60)
+        for r in results:
+            _print_result(r)
+        print("─" * 60)
+
+        if failed:
+            print(
+                f"\n✗ {len(failed)} plugin(s) failed validation, "
+                f"{passed} passed.\n"
+            )
+            print("Fix the errors above, then re-run:")
+            print("  python scripts/validate_plugins.py\n")
+        else:
+            print(f"\n✓ All {total} plugin(s) are valid.\n")
+
+    any_failed = any(not r.valid for r in results)
+    return 1 if any_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/backend/unit/fixtures/plugins/invalid_plugin/metadata.json
+++ b/testing/backend/unit/fixtures/plugins/invalid_plugin/metadata.json
@@ -1,0 +1,34 @@
+{
+  "id": "broken_plugin",
+  "name": "",
+  "description": "This fixture intentionally breaks several validation rules.",
+  "version": "1.0.0",
+  "category": "utils",
+  "icon": "bug",
+  "engine": {
+    "type": "spaceship"
+  },
+  "command_template": [
+    "run",
+    "{unknown_placeholder}"
+  ],
+  "fields": [
+    {
+      "id": "mode",
+      "label": "Mode",
+      "type": "select"
+    },
+    {
+      "id": "mode",
+      "label": "Duplicate",
+      "type": "text"
+    }
+  ],
+  "output": {
+    "parser": "custom"
+  },
+  "safety": {
+    "level": "nuclear",
+    "requires_consent": true
+  }
+}

--- a/testing/backend/unit/fixtures/plugins/valid_plugin/metadata.json
+++ b/testing/backend/unit/fixtures/plugins/valid_plugin/metadata.json
@@ -1,0 +1,42 @@
+{
+  "id": "test_ping",
+  "name": "Test Ping",
+  "description": "A minimal valid plugin used as a test fixture.",
+  "version": "1.0.0",
+  "category": "utils",
+  "icon": "ping",
+  "engine": {
+    "type": "cli",
+    "binary": "ping"
+  },
+  "command_template": [
+    "ping",
+    "-c",
+    "{count:4}",
+    "{target}"
+  ],
+  "fields": [
+    {
+      "id": "target",
+      "label": "Target Host",
+      "type": "text",
+      "required": true,
+      "placeholder": "192.168.1.1"
+    },
+    {
+      "id": "count",
+      "label": "Packet Count",
+      "type": "number",
+      "required": false,
+      "default": 4
+    }
+  ],
+  "output": {
+    "parser": "text"
+  },
+  "safety": {
+    "level": "safe",
+    "requires_consent": false
+  },
+  "checksum": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/testing/backend/unit/test_plugin_validator.py
+++ b/testing/backend/unit/test_plugin_validator.py
@@ -1,0 +1,539 @@
+"""
+Unit tests for backend/secuscan/plugin_validator.py
+
+Run with:
+    pytest testing/backend/unit/test_plugin_validator.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make sure repo root is on sys.path when running from any working directory.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from backend.secuscan.plugin_validator import (
+    PluginMetadataValidator,
+    ValidationResult,
+    validate_all_plugins,
+    validate_one_plugin,
+    VALID_ENGINE_TYPES,
+    VALID_SAFETY_LEVELS,
+    VALID_FIELD_TYPES,
+    VALID_PARSER_TYPES,
+)
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "plugins"
+VALID_FIXTURE = FIXTURES_DIR / "valid_plugin"
+INVALID_FIXTURE = FIXTURES_DIR / "invalid_plugin"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _error_paths(result: ValidationResult) -> set[str]:
+    return {e.path for e in result.errors}
+
+
+def _error_messages(result: ValidationResult) -> list[str]:
+    return [e.message for e in result.errors]
+
+
+def _write_metadata(tmp_path: Path, data: dict) -> Path:
+    plugin_dir = tmp_path / "my_plugin"
+    plugin_dir.mkdir()
+    (plugin_dir / "metadata.json").write_text(json.dumps(data), encoding="utf-8")
+    return plugin_dir
+
+
+def _minimal_valid() -> dict:
+    """Return a minimal metadata dict that passes all checks."""
+    return {
+        "id": "test_ping",
+        "name": "Test Ping",
+        "description": "Fixture plugin.",
+        "version": "1.0.0",
+        "category": "utils",
+        "icon": "ping",
+        "engine": {"type": "cli", "binary": "ping"},
+        "command_template": ["ping", "-c", "{count}", "{target}"],
+        "fields": [
+            {"id": "target", "label": "Target Host", "type": "text"},
+            {"id": "count", "label": "Count", "type": "number"},
+        ],
+        "output": {"parser": "text"},
+        "safety": {"level": "safe", "requires_consent": False},
+        "checksum": "a" * 64,
+    }
+
+
+# ===========================================================================
+# Fixture-based smoke tests
+# ===========================================================================
+
+
+class TestFixtures:
+    def test_valid_fixture_passes(self):
+        result = validate_one_plugin(VALID_FIXTURE)
+        # The fixture uses a placeholder checksum so we expect exactly that error.
+        # All other checks should pass.
+        non_checksum_errors = [e for e in result.errors if e.path != "checksum"]
+        assert non_checksum_errors == [], (
+            f"Unexpected errors in valid fixture: {non_checksum_errors}"
+        )
+
+    def test_invalid_fixture_fails(self):
+        result = validate_one_plugin(INVALID_FIXTURE)
+        assert not result.valid, "Invalid fixture should fail validation"
+        assert len(result.errors) >= 5, (
+            f"Expected at least 5 errors, got {len(result.errors)}: {result.errors}"
+        )
+
+    def test_invalid_fixture_catches_bad_engine_type(self):
+        result = validate_one_plugin(INVALID_FIXTURE)
+        assert "engine.type" in _error_paths(result)
+
+    def test_invalid_fixture_catches_bad_safety_level(self):
+        result = validate_one_plugin(INVALID_FIXTURE)
+        assert "safety.level" in _error_paths(result)
+
+    def test_invalid_fixture_catches_missing_name(self):
+        result = validate_one_plugin(INVALID_FIXTURE)
+        assert "name" in _error_paths(result)
+
+    def test_invalid_fixture_catches_missing_checksum(self):
+        result = validate_one_plugin(INVALID_FIXTURE)
+        assert "checksum" in _error_paths(result)
+
+    def test_invalid_fixture_catches_custom_parser_without_file(self):
+        result = validate_one_plugin(INVALID_FIXTURE)
+        assert "output.parser" in _error_paths(result)
+
+    def test_invalid_fixture_catches_duplicate_field_id(self):
+        result = validate_one_plugin(INVALID_FIXTURE)
+        dup_errors = [e for e in result.errors if "Duplicate" in e.message]
+        assert dup_errors, "Expected a duplicate field id error"
+
+    def test_invalid_fixture_catches_select_without_options(self):
+        result = validate_one_plugin(INVALID_FIXTURE)
+        opts_errors = [e for e in result.errors if "options" in e.path]
+        assert opts_errors, "Expected an options-missing error for select field"
+
+    def test_invalid_fixture_catches_consent_without_message(self):
+        result = validate_one_plugin(INVALID_FIXTURE)
+        assert "safety.consent_message" in _error_paths(result)
+
+    def test_invalid_fixture_catches_unknown_placeholder(self):
+        result = validate_one_plugin(INVALID_FIXTURE)
+        placeholder_errors = [e for e in result.errors if "Placeholder" in e.message]
+        assert placeholder_errors, "Expected placeholder-mismatch error"
+
+
+# ===========================================================================
+# Required fields
+# ===========================================================================
+
+
+class TestRequiredFields:
+    @pytest.mark.parametrize("missing_key", [
+        "id", "name", "description", "version", "category",
+        "icon", "engine", "command_template", "fields", "output", "safety", "checksum",
+    ])
+    def test_missing_required_field_is_reported(self, tmp_path, missing_key):
+        data = _minimal_valid()
+        del data[missing_key]
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert missing_key in _error_paths(result), (
+            f"Expected error for missing key '{missing_key}', got: {_error_paths(result)}"
+        )
+
+    def test_empty_string_name_is_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["name"] = ""
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "name" in _error_paths(result)
+
+
+# ===========================================================================
+# Engine
+# ===========================================================================
+
+
+class TestEngine:
+    @pytest.mark.parametrize("engine_type", list(VALID_ENGINE_TYPES))
+    def test_valid_engine_types_accepted(self, tmp_path, engine_type):
+        data = _minimal_valid()
+        data["engine"] = {"type": engine_type, "binary": "tool"}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "engine.type" not in _error_paths(result)
+
+    def test_invalid_engine_type_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["engine"] = {"type": "quantum"}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "engine.type" in _error_paths(result)
+
+    def test_cli_engine_without_binary_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["engine"] = {"type": "cli"}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "engine.binary" in _error_paths(result)
+
+    def test_docker_engine_without_image_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["engine"] = {"type": "docker"}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "engine.image" in _error_paths(result)
+
+    def test_engine_not_dict_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["engine"] = "cli"
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "engine" in _error_paths(result)
+
+
+# ===========================================================================
+# Command template
+# ===========================================================================
+
+
+class TestCommandTemplate:
+    def test_placeholder_matching_declared_field_is_ok(self, tmp_path):
+        data = _minimal_valid()
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        ct_errors = [e for e in result.errors if e.path.startswith("command_template")]
+        assert ct_errors == []
+
+    def test_unknown_placeholder_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["command_template"] = ["tool", "{ghost_field}"]
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        ct_errors = [e for e in result.errors if "ghost_field" in e.message]
+        assert ct_errors, "Expected error for undeclared placeholder"
+
+    def test_conditional_token_not_flagged_as_unknown(self, tmp_path):
+        data = _minimal_valid()
+        data["command_template"] = ["tool", "--if:count:then:-c:{count}"]
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        ct_errors = [e for e in result.errors if e.path.startswith("command_template")]
+        assert ct_errors == []
+
+    def test_non_list_command_template_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["command_template"] = "ping -c 4 {target}"
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "command_template" in _error_paths(result)
+
+
+# ===========================================================================
+# Fields
+# ===========================================================================
+
+
+class TestFields:
+    @pytest.mark.parametrize("ftype", list(VALID_FIELD_TYPES))
+    def test_valid_field_types_accepted(self, tmp_path, ftype):
+        data = _minimal_valid()
+        field_def = {"id": "x", "label": "X", "type": ftype}
+        if ftype in ("select", "multiselect"):
+            field_def["options"] = ["a", "b"]
+        data["fields"] = [field_def]
+        data["command_template"] = ["tool"]
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        type_errors = [e for e in result.errors if "fields[0].type" in e.path]
+        assert type_errors == []
+
+    def test_invalid_field_type_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["fields"] = [{"id": "x", "label": "X", "type": "slider"}]
+        data["command_template"] = ["tool"]
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "fields[0].type" in _error_paths(result)
+
+    def test_duplicate_field_id_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["fields"] = [
+            {"id": "target", "label": "Target", "type": "text"},
+            {"id": "target", "label": "Target Again", "type": "text"},
+        ]
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        dup = [e for e in result.errors if "Duplicate" in e.message]
+        assert dup
+
+    def test_select_without_options_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["fields"] = [{"id": "mode", "label": "Mode", "type": "select"}]
+        data["command_template"] = ["tool"]
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        opts_errors = [e for e in result.errors if "options" in e.path]
+        assert opts_errors
+
+    def test_multiselect_without_options_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["fields"] = [{"id": "tags", "label": "Tags", "type": "multiselect"}]
+        data["command_template"] = ["tool"]
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        opts_errors = [e for e in result.errors if "options" in e.path]
+        assert opts_errors
+
+    def test_missing_field_label_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["fields"] = [{"id": "target", "type": "text"}]
+        data["command_template"] = ["tool", "{target}"]
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        label_errors = [e for e in result.errors if "label" in e.path]
+        assert label_errors
+
+
+# ===========================================================================
+# Output / parser
+# ===========================================================================
+
+
+class TestOutput:
+    @pytest.mark.parametrize("parser", list(VALID_PARSER_TYPES))
+    def test_valid_parser_types_accepted(self, tmp_path, parser):
+        data = _minimal_valid()
+        data["output"] = {"parser": parser}
+        plugin_dir = _write_metadata(tmp_path, data)
+        if parser == "custom":
+            (plugin_dir / "parser.py").write_text("# stub", encoding="utf-8")
+        result = validate_one_plugin(plugin_dir)
+        parser_errors = [e for e in result.errors if e.path == "output.parser"]
+        assert parser_errors == []
+
+    def test_invalid_parser_type_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["output"] = {"parser": "magic"}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "output.parser" in _error_paths(result)
+
+    def test_custom_parser_without_file_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["output"] = {"parser": "custom"}
+        plugin_dir = _write_metadata(tmp_path, data)
+        # Do NOT create parser.py
+        result = validate_one_plugin(plugin_dir)
+        assert "output.parser" in _error_paths(result)
+
+    def test_custom_parser_with_file_is_ok(self, tmp_path):
+        data = _minimal_valid()
+        data["output"] = {"parser": "custom"}
+        plugin_dir = _write_metadata(tmp_path, data)
+        (plugin_dir / "parser.py").write_text("# stub", encoding="utf-8")
+        result = validate_one_plugin(plugin_dir)
+        parser_errors = [e for e in result.errors if e.path == "output.parser"]
+        assert parser_errors == []
+
+
+# ===========================================================================
+# Safety
+# ===========================================================================
+
+
+class TestSafety:
+    @pytest.mark.parametrize("level", list(VALID_SAFETY_LEVELS))
+    def test_valid_safety_levels_accepted(self, tmp_path, level):
+        data = _minimal_valid()
+        data["safety"] = {"level": level}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        safety_errors = [e for e in result.errors if e.path == "safety.level"]
+        assert safety_errors == []
+
+    def test_invalid_safety_level_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["safety"] = {"level": "nuclear"}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "safety.level" in _error_paths(result)
+
+    def test_requires_consent_without_message_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["safety"] = {"level": "intrusive", "requires_consent": True}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "safety.consent_message" in _error_paths(result)
+
+    def test_requires_consent_with_message_is_ok(self, tmp_path):
+        data = _minimal_valid()
+        data["safety"] = {
+            "level": "intrusive",
+            "requires_consent": True,
+            "consent_message": "This plugin will probe the target actively.",
+        }
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        consent_errors = [e for e in result.errors if "consent" in e.path]
+        assert consent_errors == []
+
+
+# ===========================================================================
+# Checksum
+# ===========================================================================
+
+
+class TestChecksum:
+    def test_missing_checksum_reported(self, tmp_path):
+        data = _minimal_valid()
+        del data["checksum"]
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "checksum" in _error_paths(result)
+
+    def test_short_checksum_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["checksum"] = "abc123"
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "checksum" in _error_paths(result)
+
+    def test_correct_length_checksum_accepted(self, tmp_path):
+        data = _minimal_valid()
+        data["checksum"] = "b" * 64
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        checksum_errors = [e for e in result.errors if e.path == "checksum"]
+        assert checksum_errors == []
+
+
+# ===========================================================================
+# Dependencies
+# ===========================================================================
+
+
+class TestDependencies:
+    def test_valid_dependencies_block_is_ok(self, tmp_path):
+        data = _minimal_valid()
+        data["dependencies"] = {"binaries": ["curl", "jq"], "python_packages": ["requests"]}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        dep_errors = [e for e in result.errors if e.path.startswith("dependencies")]
+        assert dep_errors == []
+
+    def test_empty_binary_string_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["dependencies"] = {"binaries": ["curl", ""]}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        dep_errors = [e for e in result.errors if "binaries[1]" in e.path]
+        assert dep_errors
+
+    def test_non_list_binaries_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["dependencies"] = {"binaries": "curl"}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "dependencies.binaries" in _error_paths(result)
+
+    def test_absent_dependencies_block_is_ok(self, tmp_path):
+        data = _minimal_valid()
+        data.pop("dependencies", None)
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        dep_errors = [e for e in result.errors if e.path.startswith("dependencies")]
+        assert dep_errors == []
+
+
+# ===========================================================================
+# Validation block
+# ===========================================================================
+
+
+class TestValidationBlock:
+    def test_absent_validation_block_is_ok(self, tmp_path):
+        data = _minimal_valid()
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        val_errors = [e for e in result.errors if e.path.startswith("validation")]
+        assert val_errors == []
+
+    def test_non_dict_validation_block_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["validation"] = ["target"]
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "validation" in _error_paths(result)
+
+    def test_non_bool_required_reported(self, tmp_path):
+        data = _minimal_valid()
+        data["validation"] = {"target": {"required": "yes"}}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        assert "validation.target.required" in _error_paths(result)
+
+    def test_valid_validation_block_is_ok(self, tmp_path):
+        data = _minimal_valid()
+        data["validation"] = {"target": {"required": True}}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        val_errors = [e for e in result.errors if e.path.startswith("validation")]
+        assert val_errors == []
+
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+
+class TestEdgeCases:
+    def test_missing_metadata_json_reported(self, tmp_path):
+        plugin_dir = tmp_path / "empty_plugin"
+        plugin_dir.mkdir()
+        result = validate_one_plugin(plugin_dir)
+        assert not result.valid
+        assert "metadata.json" in _error_paths(result)
+
+    def test_invalid_json_reported(self, tmp_path):
+        plugin_dir = tmp_path / "bad_json"
+        plugin_dir.mkdir()
+        (plugin_dir / "metadata.json").write_text("{bad json!!!", encoding="utf-8")
+        result = validate_one_plugin(plugin_dir)
+        assert not result.valid
+        assert "metadata.json" in _error_paths(result)
+
+    def test_validate_all_plugins_returns_results_for_each_dir(self, tmp_path):
+        for name in ("plugin_a", "plugin_b"):
+            d = tmp_path / name
+            d.mkdir()
+            (d / "metadata.json").write_text(json.dumps(_minimal_valid()), encoding="utf-8")
+        results = validate_all_plugins(tmp_path)
+        assert len(results) == 2
+
+    def test_validate_all_plugins_nonexistent_dir_raises(self):
+        with pytest.raises(FileNotFoundError):
+            validate_all_plugins(Path("/nonexistent/plugins"))
+
+    def test_error_display_format(self, tmp_path):
+        data = _minimal_valid()
+        data["safety"] = {"level": "bad"}
+        plugin_dir = _write_metadata(tmp_path, data)
+        result = validate_one_plugin(plugin_dir)
+        err = next(e for e in result.errors if e.path == "safety.level")
+        display = err.display()
+        assert "[" in display and "safety.level" in display and "→" in display


### PR DESCRIPTION
**Description of the changes made:**

-  Added `backend/secuscan/plugin_validator.py`, a shared validation module that reads a plugin's `metadata.json` and runs it through about 10 checks: required fields present, engine type valid, command template placeholders matching real field ids, field types supported, select/multiselect having options, output parser valid, custom parser having a `parser.py` file, safety level valid, consent message present when required, checksum format correct, and dependencies correctly typed
-  Added `scripts/validate_plugins.py`, the CLI tool contributors actually run. No args validates all plugins, `--plugin <id>` validates just one, `--json` gives machine readable output. Exits with code 1 if anything fails so CI can use it too
-  Added `testing/backend/unit/test_plugin_validator.py`, 77 unit tests covering valid input, invalid input, and edge cases for every validation rule
-  Added `testing/backend/unit/fixtures/plugins/valid_plugin/metadata.json`, a correctly written plugin used to confirm the validator has nothing to complain about on good input
-  Added `testing/backend/unit/fixtures/plugins/invalid_plugin/metadata.json`, a deliberately broken plugin with 10 mistakes baked in, used to confirm the validator catches each one


**Reasons for the changes:**

-  Plugin metadata mistakes can silently break plugin loading, checksum verification, command rendering, parser wiring, and frontend form generation
-  There was no way to get fast local feedback before CI failed or the backend crashed at startup



**How to test:**

1. Start from the repo root

2. Run the validator against all plugins:
```bash
`python scripts/validate_plugins.py`
```
3. Run it against a single plugin:
```bash
python scripts/validate_plugins.py --plugin nmap
```
4. Run the unit tests:
```bash
python -m pytest testing/backend/unit/test_plugin_validator.py -v
```
All 77 should pass.

**Known trade-offs:**

-  The validator is standalone contributor tooling and does not wire into the backend runtime, so it is non-breaking
-  Checksum format is validated (64-char SHA-256 hex string) but digest correctness still requires running `scripts/refresh_plugin_checksum.py` separately

**Closes** #41 



**AI Assistance Disclosure:**
 I used Claude (Anthropic) as a learning aid. All code was reviewed, tested and debugged locally by me. All 77 tests pass locally before this PR.