### PR TITLE
feat(validation): standardize plugin field validation metadata

### DIFF
--- a/docs/plugin-validation.md
+++ b/docs/plugin-validation.md
@@ -1,0 +1,153 @@
+# Plugin Field Validation
+
+This document describes the validation contract for plugin field metadata in SecuScan.
+
+Plugin authors define fields in their plugin's schema. Each field can have an optional `validation` object that controls how the frontend form validates user input before a scan is started.
+
+---
+
+## Supported validation keys
+
+| Key               | Type     | Description                                                  |
+|-------------------|----------|--------------------------------------------------------------|
+| `pattern`         | `string` | A regex string the trimmed value must match                  |
+| `message`         | `string` | Custom error message shown when validation fails             |
+| `min`             | `number` | Minimum value (integer fields only)                          |
+| `max`             | `number` | Maximum value (integer fields only)                          |
+| `validation_type` | `string` | Named preset — see table below. Takes priority over `pattern`|
+
+---
+
+## Named `validation_type` presets
+
+Use these for common cases instead of writing your own regex:
+
+| `validation_type` | Accepts                                  | Example               |
+|-------------------|------------------------------------------|-----------------------|
+| `url`             | HTTP or HTTPS URLs                       | `https://example.com` |
+| `hostname`        | Hostnames with optional subdomains       | `sub.example.com`     |
+| `domain`          | Domain names without a scheme            | `example.com`         |
+| `ipv4`            | IPv4 addresses (0–255 per octet)         | `192.168.1.1`         |
+| `port`            | Integer port numbers (1–65535)           | `8080`                |
+| `cidr`            | IPv4 CIDR notation                       | `192.168.1.0/24`      |
+
+If both `validation_type` and `pattern` are set, `validation_type` takes priority.
+
+---
+
+## Examples
+
+### URL field
+
+```json
+{
+  "id": "target_url",
+  "label": "Target URL",
+  "type": "string",
+  "required": true,
+  "placeholder": "https://example.com",
+  "help": "Full URL of the target including scheme.",
+  "validation": {
+    "validation_type": "url",
+    "message": "Enter a valid URL starting with http:// or https://"
+  }
+}
+```
+
+### Hostname field
+
+```json
+{
+  "id": "target_host",
+  "label": "Target Hostname",
+  "type": "string",
+  "required": true,
+  "placeholder": "example.com",
+  "help": "Hostname or subdomain to scan. Do not include http://.",
+  "validation": {
+    "validation_type": "hostname"
+  }
+}
+```
+
+### IPv4 field
+
+```json
+{
+  "id": "target_ip",
+  "label": "Target IP",
+  "type": "string",
+  "required": true,
+  "placeholder": "192.168.1.1",
+  "validation": {
+    "validation_type": "ipv4",
+    "message": "Enter a valid IPv4 address"
+  }
+}
+```
+
+### Port field (integer with range)
+
+```json
+{
+  "id": "port",
+  "label": "Port",
+  "type": "integer",
+  "required": false,
+  "placeholder": "80",
+  "validation": {
+    "min": 1,
+    "max": 65535,
+    "message": "Port must be between 1 and 65535"
+  }
+}
+```
+
+### CIDR block field
+
+```json
+{
+  "id": "subnet",
+  "label": "Target Subnet",
+  "type": "string",
+  "required": false,
+  "placeholder": "192.168.1.0/24",
+  "validation": {
+    "validation_type": "cidr"
+  }
+}
+```
+
+### Custom regex (backwards compatible)
+
+Existing plugins using a raw `pattern` continue to work without changes:
+
+```json
+{
+  "id": "api_key",
+  "label": "API Key",
+  "type": "string",
+  "required": true,
+  "validation": {
+    "pattern": "^[A-Za-z0-9]{32,64}$",
+    "message": "API key must be 32–64 alphanumeric characters"
+  }
+}
+```
+
+---
+
+## Frontend behaviour
+
+- **Required fields**: show an error if the value is empty, null, or whitespace.
+- **Pattern / validation_type**: checked on non-empty string values only — an empty optional field is never flagged.
+- **Integer min/max**: checked when the field has type `integer` and a value has been entered.
+- **aria-invalid**: set to `true` on the input element when a validation error is present.
+- **Inline error message**: shown directly below the field with `role="alert"`.
+- **Scan button**: disabled while any field has a validation error.
+
+---
+
+## Backwards compatibility
+
+Plugins that already define `validation.pattern` (without `validation_type`) continue to work exactly as before. No migration is required.

--- a/frontend/src/pages/ToolConfig.tsx
+++ b/frontend/src/pages/ToolConfig.tsx
@@ -11,6 +11,7 @@ import {
 } from '../api'
 import { useToast } from '../components/ToastContext'
 import { routePath, routes } from '../routes'
+import { getValidationError } from '../utils/validation'
 
 type InputState = Record<string, unknown>
 
@@ -27,59 +28,6 @@ function buildDefaultInputs(fields: PluginFieldSchema[]): InputState {
   const defaults: InputState = {}
   for (const field of fields) defaults[field.id] = defaultValueForField(field)
   return defaults
-}
-
-function isRequiredFieldValid(field: PluginFieldSchema, value: unknown): boolean {
-  if (!field.required) return true
-  if (value === undefined || value === null) return false
-  if (typeof value === 'string') return value.trim().length > 0
-  if (Array.isArray(value)) return value.length > 0
-  return true
-}
-
-function asFiniteNumber(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isFinite(value)) return value
-  if (typeof value === 'string' && value.trim()) {
-    const parsed = Number(value)
-    return Number.isFinite(parsed) ? parsed : null
-  }
-  return null
-}
-
-function getFieldValidationError(field: PluginFieldSchema, value: unknown): string | null {
-  if (!isRequiredFieldValid(field, value)) {
-    return `${field.label} is required`
-  }
-
-  const validation = field.validation || {}
-  const message = typeof validation.message === 'string' ? validation.message : null
-
-  if (typeof value === 'string' && value.trim()) {
-    const pattern = typeof validation.pattern === 'string' ? validation.pattern : null
-    if (pattern) {
-      try {
-        if (!new RegExp(pattern).test(value.trim())) {
-          return message || `${field.label} is not valid`
-        }
-      } catch {
-        return null
-      }
-    }
-  }
-
-  if (field.type === 'integer' && value !== '' && value !== undefined && value !== null) {
-    const numericValue = asFiniteNumber(value)
-    if (numericValue === null || !Number.isInteger(numericValue)) {
-      return message || `${field.label} must be a whole number`
-    }
-
-    const min = asFiniteNumber(validation.min)
-    const max = asFiniteNumber(validation.max)
-    if (min !== null && numericValue < min) return message || `${field.label} must be at least ${min}`
-    if (max !== null && numericValue > max) return message || `${field.label} must be no more than ${max}`
-  }
-
-  return null
 }
 
 function resolvePresetInputs(
@@ -162,15 +110,18 @@ export default function ToolConfig() {
   }, [toolId, navigate, addToast])
 
   const presetNames = useMemo(() => Object.keys(schema?.presets || {}), [schema])
+
   const validationErrors = useMemo<Record<string, string>>(() => {
     if (!schema) return {}
     return schema.fields.reduce<Record<string, string>>((errors, field) => {
-      const error = getFieldValidationError(field, inputs[field.id])
+      const error = getValidationError(field, inputs[field.id])
       if (error) errors[field.id] = error
       return errors
     }, {})
   }, [schema, inputs])
+
   const invalidFieldCount = Object.keys(validationErrors).length
+  const hasValidationErrors = invalidFieldCount > 0
   const safetyLevel = String(schema?.safety?.level || 'safe')
 
   const handleFieldChange = (field: PluginFieldSchema, value: unknown) => {
@@ -185,7 +136,7 @@ export default function ToolConfig() {
 
   const handleStartScan = async () => {
     if (!plugin || !schema || submitting) return
-    if (invalidFieldCount > 0) {
+    if (hasValidationErrors) {
       addToast('Fix highlighted scan parameters before starting the scan.', 'error')
       return
     }
@@ -279,7 +230,8 @@ export default function ToolConfig() {
             Task launch remains available, but execution may fail until dependencies are installed.
           </p>
         </section>
-     )}
+      )}
+
       <main className="grid grid-cols-1 xl:grid-cols-4 gap-12 pt-4">
         <div className="xl:col-span-3 space-y-10">
           {presetNames.length > 0 && (
@@ -310,41 +262,56 @@ export default function ToolConfig() {
               {schema.fields.map((field) => {
                 const value = inputs[field.id]
                 const validationError = validationErrors[field.id]
+                const isInvalid = Boolean(validationError)
+                const inputBorderClass = isInvalid
+                  ? 'border-rag-red focus:border-rag-red'
+                  : 'border-black focus:border-rag-blue'
+                const fieldId = `field-${field.id}`
+                const errorId = `error-${field.id}`
 
                 return (
                   <motion.div key={field.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-3">
                     <div className="flex items-center justify-between gap-6">
-                      <label className="text-[10px] font-black uppercase tracking-[0.3em] text-silver-bright italic">
+                      <label
+                        htmlFor={fieldId}
+                        className="text-[10px] font-black uppercase tracking-[0.3em] text-silver-bright italic"
+                      >
                         {field.label}
-                        {field.required && <span className="text-rag-red ml-2">*</span>}
+                        {field.required && <span className="text-rag-red ml-2" aria-hidden="true">*</span>}
                       </label>
-                      {validationError && <span className="text-[9px] uppercase tracking-widest text-rag-red font-black">invalid</span>}
+                      {isInvalid && (
+                        <span className="text-[9px] uppercase tracking-widest text-rag-red font-black" aria-live="polite">
+                          invalid
+                        </span>
+                      )}
                     </div>
 
                     {field.type === 'text' ? (
                       <textarea
+                        id={fieldId}
                         value={String(value ?? '')}
                         onChange={(event) => handleFieldChange(field, event.target.value)}
                         placeholder={field.placeholder || ''}
-                        aria-invalid={!!validationError}
-                        className={`w-full min-h-[120px] bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none transition-all ${
-                          validationError ? 'border-rag-red' : 'border-black focus:border-rag-blue'
-                        }`}
+                        aria-invalid={isInvalid}
+                        aria-describedby={isInvalid ? errorId : field.help ? `help-${field.id}` : undefined}
+                        className={`w-full min-h-[120px] bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none ${inputBorderClass}`}
                       />
                     ) : field.type === 'integer' ? (
                       <input
+                        id={fieldId}
                         type="number"
                         value={value === '' ? '' : String(value ?? '')}
                         onChange={(event) => handleFieldChange(field, coerceInteger(event.target.value))}
                         placeholder={field.placeholder || ''}
-                        aria-invalid={!!validationError}
-                        className={`w-full bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none transition-all ${
-                          validationError ? 'border-rag-red' : 'border-black focus:border-rag-blue'
-                        }`}
+                        aria-invalid={isInvalid}
+                        aria-describedby={isInvalid ? errorId : field.help ? `help-${field.id}` : undefined}
+                        className={`w-full bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none ${inputBorderClass}`}
                       />
                     ) : field.type === 'boolean' ? (
                       <button
+                        id={fieldId}
                         onClick={() => handleFieldChange(field, !Boolean(value))}
+                        aria-pressed={Boolean(value)}
                         className={`w-full flex items-center justify-between p-4 border-4 border-black transition-all ${
                           value ? 'bg-rag-green text-black' : 'bg-charcoal-dark text-silver-bright'
                         }`}
@@ -354,12 +321,12 @@ export default function ToolConfig() {
                       </button>
                     ) : field.type === 'select' ? (
                       <select
+                        id={fieldId}
                         value={String(value ?? '')}
                         onChange={(event) => handleFieldChange(field, event.target.value)}
-                        aria-invalid={!!validationError}
-                        className={`w-full bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none transition-all ${
-                          validationError ? 'border-rag-red' : 'border-black focus:border-rag-blue'
-                        }`}
+                        aria-invalid={isInvalid}
+                        aria-describedby={isInvalid ? errorId : field.help ? `help-${field.id}` : undefined}
+                        className={`w-full bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none ${inputBorderClass}`}
                       >
                         <option value="">Select option</option>
                         {(field.options || []).map((option) => (
@@ -369,12 +336,17 @@ export default function ToolConfig() {
                         ))}
                       </select>
                     ) : field.type === 'multiselect' ? (
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                      <div
+                        role="group"
+                        aria-labelledby={`label-${field.id}`}
+                        className="grid grid-cols-1 md:grid-cols-2 gap-3"
+                      >
                         {(field.options || []).map((option) => {
                           const selected = Array.isArray(value) && value.includes(option.value)
                           return (
                             <button
                               key={option.value}
+                              aria-pressed={selected}
                               onClick={() => {
                                 const current = Array.isArray(value) ? [...value] : []
                                 const next = selected
@@ -393,25 +365,32 @@ export default function ToolConfig() {
                       </div>
                     ) : (
                       <input
+                        id={fieldId}
                         type="text"
                         value={String(value ?? '')}
                         onChange={(event) => handleFieldChange(field, event.target.value)}
                         placeholder={field.placeholder || ''}
-                        aria-invalid={!!validationError}
-                        className={`w-full bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none transition-all ${
-                          validationError ? 'border-rag-red' : 'border-black focus:border-rag-blue'
-                        }`}
+                        aria-invalid={isInvalid}
+                        aria-describedby={isInvalid ? errorId : field.help ? `help-${field.id}` : undefined}
+                        className={`w-full bg-charcoal-dark border-4 p-4 text-sm text-silver-bright focus:outline-none ${inputBorderClass}`}
                       />
                     )}
 
-                    {field.help && <p className="text-[10px] text-silver/40 uppercase tracking-widest">{field.help}</p>}
-                    {validationError && <p className="text-[10px] text-rag-red uppercase tracking-widest">{validationError}</p>}
+                    {field.help && !isInvalid && (
+                      <p id={`help-${field.id}`} className="text-[10px] text-silver/40 uppercase tracking-widest">
+                        {field.help}
+                      </p>
+                    )}
+                    {isInvalid && (
+                      <p id={errorId} role="alert" className="text-[10px] text-rag-red uppercase tracking-widest font-black">
+                        {validationError}
+                      </p>
+                    )}
                   </motion.div>
                 )
               })}
             </div>
           </section>
-
         </div>
 
         <aside className="xl:col-span-1">
@@ -435,14 +414,22 @@ export default function ToolConfig() {
             )}
             <button
               onClick={handleStartScan}
-              disabled={submitting || invalidFieldCount > 0}
-              className="w-full py-4 bg-rag-red border-4 border-black text-black text-[10px] font-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-1 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              disabled={submitting || hasValidationErrors}
+              aria-disabled={submitting || hasValidationErrors}
+              className="w-full py-4 bg-rag-red border-4 border-black text-black text-[10px] font-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-1 transition-all disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:shadow-none disabled:hover:translate-y-0"
             >
-              {submitting ? 'QUEUEING...' : invalidFieldCount > 0 ? 'FIX_PARAMETERS' : 'INITIATE_SCAN'}
+              {submitting ? 'QUEUEING...' : 'INITIATE_SCAN'}
             </button>
-            <p className="text-[10px] text-silver/30 uppercase tracking-widest">
-              Parameter issues: {invalidFieldCount}
-            </p>
+            {hasValidationErrors && (
+              <p role="status" className="text-[10px] text-rag-red uppercase tracking-widest font-black">
+                {invalidFieldCount} field{invalidFieldCount > 1 ? 's' : ''} need{invalidFieldCount === 1 ? 's' : ''} attention
+              </p>
+            )}
+            {!hasValidationErrors && (
+              <p className="text-[10px] text-rag-green uppercase tracking-widest font-black">
+                All fields valid
+              </p>
+            )}
           </section>
         </aside>
       </main>

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -1,0 +1,147 @@
+/**
+ * Plugin field validation utility.
+ *
+ * Defines the shared validation contract used by plugin metadata,
+ * the frontend form generator (ToolConfig), and plugin authors.
+ *
+ * Supported validation keys on a field's `validation` object:
+ *   - pattern       {string}  — a regex string the value must match
+ *   - message       {string}  — custom error message shown on failure
+ *   - min           {number}  — minimum value for integer fields
+ *   - max           {number}  — maximum value for integer fields
+ *   - validation_type {string} — optional named preset: 'url' | 'hostname' | 'domain' | 'ipv4' | 'port' | 'cidr'
+ *
+ * Named validation_type presets (override pattern/message if set):
+ *   - url      valid HTTP/HTTPS URL
+ *   - hostname  valid hostname (letters, digits, hyphens, dots)
+ *   - domain    valid domain name (at least one dot, no scheme)
+ *   - ipv4      valid IPv4 address (0-255 per octet)
+ *   - port      integer 1–65535
+ *   - cidr      IPv4 CIDR notation e.g. 192.168.1.0/24
+ *
+ * Backwards compatible: existing plugins using only `validation.pattern`
+ * continue to work without any changes.
+ */
+
+export type ValidationTypeName = 'url' | 'hostname' | 'domain' | 'ipv4' | 'port' | 'cidr'
+
+export interface FieldValidation {
+  pattern?: string
+  message?: string
+  min?: number
+  max?: number
+  validation_type?: ValidationTypeName
+}
+
+interface ValidationPreset {
+  pattern: RegExp
+  message: string
+}
+
+const VALIDATION_PRESETS: Record<ValidationTypeName, ValidationPreset> = {
+  url: {
+    pattern: /^https?:\/\/[^\s/$.?#].[^\s]*$/i,
+    message: 'Must be a valid URL starting with http:// or https://',
+  },
+  hostname: {
+    pattern: /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/,
+    message: 'Must be a valid hostname (e.g. example.com or sub.example.com)',
+  },
+  domain: {
+    pattern: /^(?!https?:\/\/)(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/,
+    message: 'Must be a valid domain name without a scheme (e.g. example.com)',
+  },
+  ipv4: {
+    pattern: /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/,
+    message: 'Must be a valid IPv4 address (e.g. 192.168.1.1)',
+  },
+  port: {
+    pattern: /^(6553[0-5]|655[0-2]\d|65[0-4]\d{2}|6[0-4]\d{3}|[1-5]\d{4}|[1-9]\d{0,3}|[1-9])$/,
+    message: 'Must be a valid port number between 1 and 65535',
+  },
+  cidr: {
+    pattern: /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)){3}\/(3[0-2]|[12]\d|[0-9])$/,
+    message: 'Must be a valid CIDR block (e.g. 192.168.1.0/24)',
+  },
+}
+
+/**
+ * Returns a validation error message for a field value, or null if valid.
+ *
+ * Handles:
+ *   - required field check
+ *   - validation_type named presets (url, hostname, domain, ipv4, port, cidr)
+ *   - custom regex pattern
+ *   - integer min/max range
+ */
+export function getValidationError(
+  field: {
+    id: string
+    label: string
+    type: string
+    required?: boolean
+    validation?: Record<string, unknown>
+  },
+  value: unknown,
+): string | null {
+  // Required check
+  if (field.required) {
+    if (value === undefined || value === null) return `${field.label} is required`
+    if (typeof value === 'string' && value.trim().length === 0) return `${field.label} is required`
+    if (Array.isArray(value) && value.length === 0) return `${field.label} is required`
+  }
+
+  const validation = (field.validation ?? {}) as FieldValidation
+  const customMessage = validation.message ?? null
+
+  // String-based validation (text / string fields)
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const trimmed = value.trim()
+
+    // Named preset takes priority over raw pattern
+    const typeName = validation.validation_type
+    if (typeName && VALIDATION_PRESETS[typeName]) {
+      const preset = VALIDATION_PRESETS[typeName]
+      if (!preset.pattern.test(trimmed)) {
+        return customMessage ?? preset.message
+      }
+      return null
+    }
+
+    // Raw pattern fallback
+    const rawPattern = validation.pattern
+    if (typeof rawPattern === 'string') {
+      try {
+        if (!new RegExp(rawPattern).test(trimmed)) {
+          return customMessage ?? `${field.label} is not valid`
+        }
+      } catch {
+        // Malformed regex — skip silently
+      }
+    }
+  }
+
+  // Integer range validation
+  if (field.type === 'integer' && value !== '' && value !== undefined && value !== null) {
+    const num = typeof value === 'number' ? value : Number(value)
+    if (!Number.isFinite(num) || !Number.isInteger(num)) {
+      return customMessage ?? `${field.label} must be a whole number`
+    }
+    const min = typeof validation.min === 'number' ? validation.min : null
+    const max = typeof validation.max === 'number' ? validation.max : null
+    if (min !== null && num < min) return customMessage ?? `${field.label} must be at least ${min}`
+    if (max !== null && num > max) return customMessage ?? `${field.label} must be no more than ${max}`
+  }
+
+  return null
+}
+
+/**
+ * Returns true if all required fields are valid and no validation errors exist.
+ */
+export function isFormValid(
+  fields: Array<{ id: string; label: string; type: string; required?: boolean; validation?: Record<string, unknown> }>,
+  inputs: Record<string, unknown>,
+): boolean {
+  return fields.every((field) => getValidationError(field, inputs[field.id]) === null)
+}

--- a/frontend/testing/unit/pages/ToolConfigDynamic.test.tsx
+++ b/frontend/testing/unit/pages/ToolConfigDynamic.test.tsx
@@ -203,14 +203,14 @@ describe('ToolConfig dynamic schema flow', () => {
     const targetInput = screen.getByPlaceholderText('https://secuscan.in')
 
     // Initially FIX_PARAMETERS because target is required and empty
-    expect(screen.getByText(/FIX_PARAMETERS/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /FIX_PARAMETERS/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /INITIATE_SCAN/i })).toBeDisabled()
+    expect(screen.getByText(/1 field.*attention/i)).toBeInTheDocument()
 
     // Type invalid data
     await user.type(targetInput, 'not-a-url')
     expect(screen.getByText(/Must be a valid URL/i)).toBeInTheDocument()
     expect(targetInput).toHaveAttribute('aria-invalid', 'true')
-    expect(screen.getByRole('button', { name: /FIX_PARAMETERS/i })).toBeDisabled()
+    expect(screen.getByText(/1 field.*attention/i)).toBeInTheDocument()
 
     // Clear and type valid data
     await user.clear(targetInput)

--- a/frontend/testing/unit/utils/validation.test.ts
+++ b/frontend/testing/unit/utils/validation.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest'
+import { getValidationError, isFormValid } from '../../../src/utils/validation'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function field(overrides: Partial<{
+  id: string
+  label: string
+  type: string
+  required: boolean
+  validation: Record<string, unknown>
+}> = {}) {
+  return {
+    id: 'target',
+    label: 'Target',
+    type: 'string',
+    required: false,
+    validation: {},
+    ...overrides,
+  }
+}
+
+// ─── Required field ───────────────────────────────────────────────────────────
+
+describe('getValidationError – required fields', () => {
+  it('returns error for empty required string', () => {
+    expect(getValidationError(field({ required: true }), '')).toBeTruthy()
+  })
+
+  it('returns error for whitespace-only required string', () => {
+    expect(getValidationError(field({ required: true }), '   ')).toBeTruthy()
+  })
+
+  it('returns error for null required field', () => {
+    expect(getValidationError(field({ required: true }), null)).toBeTruthy()
+  })
+
+  it('returns error for empty array required multiselect', () => {
+    expect(getValidationError(field({ required: true }), [])).toBeTruthy()
+  })
+
+  it('returns null for valid required string', () => {
+    expect(getValidationError(field({ required: true }), 'example.com')).toBeNull()
+  })
+
+  it('returns null for non-required empty field', () => {
+    expect(getValidationError(field({ required: false }), '')).toBeNull()
+  })
+})
+
+// ─── validation_type presets ──────────────────────────────────────────────────
+
+describe('getValidationError – validation_type: url', () => {
+  const f = field({ validation: { validation_type: 'url' } })
+
+  it('accepts valid http URL', () => {
+    expect(getValidationError(f, 'http://example.com')).toBeNull()
+  })
+
+  it('accepts valid https URL', () => {
+    expect(getValidationError(f, 'https://sub.example.com/path?q=1')).toBeNull()
+  })
+
+  it('rejects bare domain', () => {
+    expect(getValidationError(f, 'example.com')).toBeTruthy()
+  })
+
+  it('rejects ftp URL', () => {
+    expect(getValidationError(f, 'ftp://example.com')).toBeTruthy()
+  })
+})
+
+describe('getValidationError – validation_type: hostname', () => {
+  const f = field({ validation: { validation_type: 'hostname' } })
+
+  it('accepts simple hostname', () => {
+    expect(getValidationError(f, 'example.com')).toBeNull()
+  })
+
+  it('accepts subdomain', () => {
+    expect(getValidationError(f, 'sub.example.com')).toBeNull()
+  })
+
+  it('rejects hostname with scheme', () => {
+    expect(getValidationError(f, 'https://example.com')).toBeTruthy()
+  })
+
+  it('rejects hostname with spaces', () => {
+    expect(getValidationError(f, 'exam ple.com')).toBeTruthy()
+  })
+})
+
+describe('getValidationError – validation_type: domain', () => {
+  const f = field({ validation: { validation_type: 'domain' } })
+
+  it('accepts valid domain', () => {
+    expect(getValidationError(f, 'example.com')).toBeNull()
+  })
+
+  it('rejects domain with http scheme', () => {
+    expect(getValidationError(f, 'http://example.com')).toBeTruthy()
+  })
+
+  it('rejects bare word without dot', () => {
+    expect(getValidationError(f, 'localhost')).toBeTruthy()
+  })
+})
+
+describe('getValidationError – validation_type: ipv4', () => {
+  const f = field({ validation: { validation_type: 'ipv4' } })
+
+  it('accepts valid IPv4', () => {
+    expect(getValidationError(f, '192.168.1.1')).toBeNull()
+  })
+
+  it('accepts 0.0.0.0', () => {
+    expect(getValidationError(f, '0.0.0.0')).toBeNull()
+  })
+
+  it('rejects octet > 255', () => {
+    expect(getValidationError(f, '256.0.0.1')).toBeTruthy()
+  })
+
+  it('rejects partial IP', () => {
+    expect(getValidationError(f, '192.168.1')).toBeTruthy()
+  })
+})
+
+describe('getValidationError – validation_type: port', () => {
+  const f = field({ validation: { validation_type: 'port' } })
+
+  it('accepts port 80', () => {
+    expect(getValidationError(f, '80')).toBeNull()
+  })
+
+  it('accepts port 65535', () => {
+    expect(getValidationError(f, '65535')).toBeNull()
+  })
+
+  it('rejects port 0', () => {
+    expect(getValidationError(f, '0')).toBeTruthy()
+  })
+
+  it('rejects port 65536', () => {
+    expect(getValidationError(f, '65536')).toBeTruthy()
+  })
+})
+
+describe('getValidationError – validation_type: cidr', () => {
+  const f = field({ validation: { validation_type: 'cidr' } })
+
+  it('accepts valid CIDR', () => {
+    expect(getValidationError(f, '192.168.1.0/24')).toBeNull()
+  })
+
+  it('accepts /32', () => {
+    expect(getValidationError(f, '10.0.0.1/32')).toBeNull()
+  })
+
+  it('rejects CIDR with prefix > 32', () => {
+    expect(getValidationError(f, '10.0.0.0/33')).toBeTruthy()
+  })
+
+  it('rejects plain IP without prefix', () => {
+    expect(getValidationError(f, '10.0.0.1')).toBeTruthy()
+  })
+})
+
+// ─── Raw pattern validation ───────────────────────────────────────────────────
+
+describe('getValidationError – raw pattern (backwards compat)', () => {
+  const f = field({ validation: { pattern: '^[a-z]+$' } })
+
+  it('accepts value matching pattern', () => {
+    expect(getValidationError(f, 'abc')).toBeNull()
+  })
+
+  it('rejects value not matching pattern', () => {
+    expect(getValidationError(f, 'ABC123')).toBeTruthy()
+  })
+
+  it('uses custom message when provided', () => {
+    const fWithMsg = field({ validation: { pattern: '^[a-z]+$', message: 'lowercase only' } })
+    expect(getValidationError(fWithMsg, 'ABC')).toBe('lowercase only')
+  })
+
+  it('does not crash on malformed regex', () => {
+    const fBad = field({ validation: { pattern: '[invalid(' } })
+    expect(() => getValidationError(fBad, 'abc')).not.toThrow()
+  })
+})
+
+// ─── Integer min/max ──────────────────────────────────────────────────────────
+
+describe('getValidationError – integer min/max', () => {
+  const f = field({ type: 'integer', validation: { min: 1, max: 100 } })
+
+  it('accepts value within range', () => {
+    expect(getValidationError(f, 50)).toBeNull()
+  })
+
+  it('accepts boundary min', () => {
+    expect(getValidationError(f, 1)).toBeNull()
+  })
+
+  it('accepts boundary max', () => {
+    expect(getValidationError(f, 100)).toBeNull()
+  })
+
+  it('rejects value below min', () => {
+    expect(getValidationError(f, 0)).toBeTruthy()
+  })
+
+  it('rejects value above max', () => {
+    expect(getValidationError(f, 101)).toBeTruthy()
+  })
+
+  it('rejects non-integer float', () => {
+    expect(getValidationError(f, 1.5)).toBeTruthy()
+  })
+
+  it('skips check for empty string (not yet entered)', () => {
+    expect(getValidationError(f, '')).toBeNull()
+  })
+})
+
+// ─── isFormValid ──────────────────────────────────────────────────────────────
+
+describe('isFormValid', () => {
+  const fields = [
+    field({ id: 'target', label: 'Target', required: true, validation: { validation_type: 'url' } }),
+    field({ id: 'threads', label: 'Threads', type: 'integer', required: false, validation: { min: 1, max: 50 } }),
+  ]
+
+  it('returns true when all fields are valid', () => {
+    expect(isFormValid(fields, { target: 'https://example.com', threads: 5 })).toBe(true)
+  })
+
+  it('returns false when required field is empty', () => {
+    expect(isFormValid(fields, { target: '', threads: 5 })).toBe(false)
+  })
+
+  it('returns false when a field fails pattern validation', () => {
+    expect(isFormValid(fields, { target: 'not-a-url', threads: 5 })).toBe(false)
+  })
+
+  it('returns false when integer is out of range', () => {
+    expect(isFormValid(fields, { target: 'https://example.com', threads: 999 })).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #28

## Changes
- Added `frontend/src/utils/validation.ts` with `getValidationError()` and `isFormValid()`
- Updated `frontend/src/pages/ToolConfig.tsx` to use the new validation utility
- Added `frontend/testing/unit/utils/validation.test.ts` with 44 tests
- Added `docs/plugin-validation.md` documenting the validation contract

## Test plan
cd frontend && npx vitest run