### PR TITLE
feat: add request-size and field-length limits for task start inputs

### DIFF
--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -66,7 +66,12 @@ class Settings(BaseSettings):
     sandbox_timeout: int = 600  # seconds
     sandbox_cpu_quota: float = 0.5
     sandbox_memory_mb: int = 512
-    
+
+    # Task-start payload limits (tunable via env vars)
+    task_start_max_body_bytes: int = 64_000       # 64 KB total JSON body
+    task_start_max_field_length: int = 1_000      # max chars per string input value
+    task_start_max_array_length: int = 50         # max items in any list/multiselect input
+
     # Logging
     log_level: str = "INFO"
     log_file: str = str(PROJECT_ROOT / "logs" / "secuscan.log")

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -2,7 +2,7 @@
 API routes for SecuScan backend
 """
 
-from fastapi import APIRouter, HTTPException, BackgroundTasks, Response
+from fastapi import APIRouter, HTTPException, BackgroundTasks, Response, Request
 from fastapi.responses import JSONResponse
 from typing import Any, Optional, List, Dict, Callable
 import json
@@ -72,7 +72,7 @@ from .database import get_db
 from .plugins import get_plugin_manager, init_plugins
 from .executor import executor
 from .ratelimit import rate_limiter, concurrent_limiter
-from .validation import validate_target
+from .validation import validate_target, validate_task_start_payload
 from .reporting import reporting
 from .vault import VaultCrypto
 from .workflows import scheduler
@@ -193,11 +193,18 @@ async def get_all_presets():
 @router.post("/task/start")
 async def start_task(
     request: TaskCreateRequest,
-    background_tasks: BackgroundTasks
+    background_tasks: BackgroundTasks,
+    raw_request: Request,
 ):
     """
-    Start a new scan task
+    Start a new scan task.
     """
+    # ── Payload size / field-length guard ─────────────────────────────────
+    raw_body = await raw_request.body()
+    ok, status_code, error_msg = validate_task_start_payload(raw_body, request.inputs)
+    if not ok:
+        raise HTTPException(status_code=status_code, detail=error_msg)
+
     # Validate consent
     if settings.require_consent and not request.consent_granted:
         logger.warning(f"Task start failed: Consent not granted. Request: {request}")

--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -4,7 +4,7 @@ Input validation and security checks
 
 import re
 import ipaddress
-from typing import Tuple
+from typing import Any, Dict, Tuple
 from fnmatch import fnmatch
 
 from .config import settings
@@ -230,3 +230,82 @@ def match_pattern(value: str, pattern: str) -> bool:
         True if value matches pattern
     """
     return fnmatch(value, pattern)
+
+
+# ---------------------------------------------------------------------------
+# Task-start payload size/length validation
+# ---------------------------------------------------------------------------
+
+def validate_task_start_payload(raw_body: bytes, inputs: Dict[str, Any]) -> Tuple[bool, int, str]:
+    """
+    Enforce size and field-length limits on POST /task/start payloads.
+
+    Checks are run in order:
+      1. Total body size  → HTTP 413
+      2. inputs dict type → HTTP 400
+      3. Per-field string length and array length → HTTP 400
+
+    Error messages never echo back input values to avoid leaking sensitive
+    or oversized data into logs/responses.
+
+    Args:
+        raw_body: Raw request bytes (for total-size check).
+        inputs:   The parsed ``inputs`` dict from the request body.
+
+    Returns:
+        (ok, status_code, error_message)
+        ok is True and status_code is 0 when all checks pass.
+    """
+    # 1. Total body size
+    if len(raw_body) > settings.task_start_max_body_bytes:
+        return (
+            False,
+            413,
+            f"Request body exceeds the maximum allowed size of "
+            f"{settings.task_start_max_body_bytes} bytes.",
+        )
+
+    # 2. inputs must be a dict
+    if not isinstance(inputs, dict):
+        return False, 400, "'inputs' must be a JSON object."
+
+    # 3. Per-field checks
+    for key, value in inputs.items():
+        ok, status, msg = _check_field(key, value)
+        if not ok:
+            return ok, status, msg
+
+    return True, 0, ""
+
+
+def _check_field(key: str, value: Any) -> Tuple[bool, int, str]:
+    """Check a single input field value (string or list)."""
+    if isinstance(value, str):
+        if len(value) > settings.task_start_max_field_length:
+            # Do NOT include the value itself — it may be huge or sensitive.
+            return (
+                False,
+                400,
+                f"Input field '{key}' exceeds the maximum allowed length of "
+                f"{settings.task_start_max_field_length} characters.",
+            )
+
+    elif isinstance(value, list):
+        if len(value) > settings.task_start_max_array_length:
+            return (
+                False,
+                400,
+                f"Input field '{key}' contains too many items "
+                f"(max {settings.task_start_max_array_length}).",
+            )
+        for idx, item in enumerate(value):
+            if isinstance(item, str) and len(item) > settings.task_start_max_field_length:
+                return (
+                    False,
+                    400,
+                    f"Item at index {idx} in input field '{key}' exceeds the "
+                    f"maximum allowed length of "
+                    f"{settings.task_start_max_field_length} characters.",
+                )
+
+    return True, 0, ""

--- a/testing/backend/unit/test_task_start_validation.py
+++ b/testing/backend/unit/test_task_start_validation.py
@@ -1,0 +1,36 @@
+import json, pytest
+from unittest.mock import patch, MagicMock
+
+MOCK_SETTINGS = MagicMock()
+MOCK_SETTINGS.task_start_max_body_bytes = 64_000
+MOCK_SETTINGS.task_start_max_field_length = 1_000
+MOCK_SETTINGS.task_start_max_array_length = 50
+
+with patch("backend.secuscan.validation.settings", MOCK_SETTINGS):
+    from backend.secuscan.validation import validate_task_start_payload
+
+MAX_BYTES = MOCK_SETTINGS.task_start_max_body_bytes
+MAX_FIELD = MOCK_SETTINGS.task_start_max_field_length
+MAX_ARRAY = MOCK_SETTINGS.task_start_max_array_length
+
+def _encode(p): return json.dumps(p).encode()
+
+def test_normal_payload_passes():
+    p = {"plugin_id":"nmap","inputs":{"target":"192.168.1.1"}}
+    ok,code,msg = validate_task_start_payload(_encode(p),p["inputs"])
+    assert ok and code==0
+
+def test_oversized_body_returns_413():
+    p = {"plugin_id":"nmap","inputs":{"x":"a"*(MAX_BYTES+1)}}
+    ok,code,msg = validate_task_start_payload(_encode(p),p["inputs"])
+    assert not ok and code==413
+
+def test_oversized_string_field_returns_400():
+    p = {"plugin_id":"nmap","inputs":{"target":"a"*(MAX_FIELD+1)}}
+    ok,code,msg = validate_task_start_payload(_encode(p),p["inputs"])
+    assert not ok and code==400
+
+def test_oversized_array_returns_400():
+    p = {"plugin_id":"nmap","inputs":{"ports":["80"]*(MAX_ARRAY+1)}}
+    ok,code,msg = validate_task_start_payload(_encode(p),p["inputs"])
+    assert not ok and code==400


### PR DESCRIPTION
Closes #31

## Changes
- Added payload size limits to `config.py` (tunable via env vars)
- Added `validate_task_start_payload()` to `validation.py`
- Enforced limits in `POST /task/start` in `routes.py`
- Added unit tests in `testing/backend/unit/test_task_start_validation.py`

## Test plan
cd backend && pytest testing/backend/unit/test_task_start_validation.py