### PR TITLE
feat(reports): add status and date range filters to Reports page

### DIFF
--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -16,7 +16,7 @@ import {
 } from '@hugeicons/core-free-icons'
 import { getDashboardSummary, getReports, API_BASE } from '../api'
 import { formatDateLong, isWithinDateRange, type DateRange } from '../utils/date'
-import { usePreferredExportFormat } from '../hooks/usePreferredExportFormat'  
+import { usePreferredExportFormat } from '../hooks/usePreferredExportFormat'
 
 type Report = {
   id: string

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -15,8 +15,8 @@ import {
   UserShield02Icon,
 } from '@hugeicons/core-free-icons'
 import { getDashboardSummary, getReports, API_BASE } from '../api'
-import { formatDateLong } from '../utils/date'
-import { usePreferredExportFormat } from '../hooks/usePreferredExportFormat'
+import { formatDateLong, isWithinDateRange, type DateRange } from '../utils/date'
+import { usePreferredExportFormat } from '../hooks/usePreferredExportFormat'  
 
 type Report = {
   id: string
@@ -29,6 +29,8 @@ type Report = {
   assets: number
   pages: number
 }
+
+type ReportStatus = 'all' | 'ready' | 'generating' | 'failed'
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -67,6 +69,8 @@ export default function Reports() {
   const [reports, setReports] = useState<Report[]>([])
   const [summary, setSummary] = useState<any>({ total_findings: 0, total_assets: 0, critical_findings: 0, high_findings: 0, total_attack_surface: 0 })
   const [selectedType, setSelectedType] = useState('all')
+  const [selectedStatus, setSelectedStatus] = useState<ReportStatus>('all')
+  const [selectedDateRange, setSelectedDateRange] = useState<DateRange>('all')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const { preferred, savePreference } = usePreferredExportFormat()
@@ -91,7 +95,11 @@ export default function Reports() {
     fetchReports()
   }, [])
 
-  const filteredReports = reports.filter((report) => selectedType === 'all' || report.type === selectedType)
+  const filteredReports = reports.filter((report) =>
+    (selectedType === 'all' || report.type === selectedType) &&
+    (selectedStatus === 'all' || report.status === selectedStatus) &&
+    isWithinDateRange(report.generated_at, selectedDateRange)
+  )
 
   return (
     <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
@@ -175,6 +183,8 @@ export default function Reports() {
             {/* Filtration Sidebar */}
             <aside className="xl:col-span-1 space-y-12">
               <section className="bg-charcoal border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-8">
+
+                {/* Type Filter */}
                 <div className="space-y-4">
                   <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Classification_Isolation</label>
                   <div className="grid grid-cols-1 gap-2">
@@ -190,6 +200,60 @@ export default function Reports() {
                       >
                         {t} BRIEFINGS
                         {selectedType === t && <ReportIcon icon={Radar02Icon} size={16} className="text-black" aria-hidden="true" />}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Status Filter */}
+                <div className="space-y-4">
+                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Status_Filter</label>
+                  <div className="grid grid-cols-1 gap-2">
+                    {([
+                      { value: 'all',        label: 'All Statuses' },
+                      { value: 'ready',      label: 'Ready' },
+                      { value: 'generating', label: 'Generating' },
+                      { value: 'failed',     label: 'Failed' },
+                    ] as const).map(({ value, label }) => (
+                      <button
+                        key={value}
+                        onClick={() => setSelectedStatus(value)}
+                        aria-label={`status ${label}`}
+                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
+                          selectedStatus === value
+                            ? 'bg-rag-amber border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
+                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
+                        }`}
+                      >
+                        {label}
+                        {selectedStatus === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Date Range Filter */}
+                <div className="space-y-4">
+                  <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] italic">Date_Range</label>
+                  <div className="grid grid-cols-1 gap-2">
+                    {([
+                      { value: 'all', label: 'All Time' },
+                      { value: '24h', label: 'Last 24 Hours' },
+                      { value: '7d',  label: 'Last 7 Days' },
+                      { value: '30d', label: 'Last 30 Days' },
+                    ] as const).map(({ value, label }) => (
+                      <button
+                        key={value}
+                        onClick={() => setSelectedDateRange(value)}
+                        aria-label={`date ${label}`}
+                        className={`px-6 py-4 text-left text-[10px] font-black uppercase tracking-widest border-4 transition-all flex justify-between items-center ${
+                          selectedDateRange === value
+                            ? 'bg-rag-blue border-black text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]'
+                            : 'bg-charcoal-dark border-black text-silver/40 hover:border-silver-bright/20'
+                        }`}
+                      >
+                        {label}
+                        {selectedDateRange === value && <ReportIcon icon={Radar02Icon} size={16} className="text-black" />}
                       </button>
                     ))}
                   </div>
@@ -324,7 +388,7 @@ export default function Reports() {
                       <ReportIcon icon={Archive02Icon} size={120} className="text-silver/5" aria-hidden="true" />
                       <div className="space-y-2">
                         <p className="text-xl font-black text-silver/20 uppercase tracking-[0.4em] italic">Archive Isolated</p>
-                        <p className="text-xs font-mono text-silver/10 uppercase tracking-widest leading-relaxed">System buffer awaiting briefing generation protocols</p>
+                        <p className="text-xs font-mono text-silver/10 uppercase tracking-widest leading-relaxed">No entries match the selected filters</p>
                       </div>
                     </div>
                   )}

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -174,3 +174,13 @@ export function formatLocaleTime(dateStr: string | Date | null | undefined, opti
         ...options
     });
 }
+export type DateRange = 'all' | '24h' | '7d' | '30d'
+
+export function isWithinDateRange(dateStr: string, range: DateRange): boolean {
+  if (range === 'all') return true
+  const d = parseDateSafe(dateStr)
+  if (!d) return false
+  const msMap = { '24h': 86400000, '7d': 604800000, '30d': 2592000000 }
+  const diff = Date.now() - d.getTime()
+  return diff >= 0 && diff <= msMap[range]
+}

--- a/frontend/testing/unit/pages/Reports.test.tsx
+++ b/frontend/testing/unit/pages/Reports.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import Reports from '../../../src/pages/Reports'
 import { getReports, getDashboardSummary } from '../../../src/api'
+import { isWithinDateRange } from '../../../src/utils/date'
 
 vi.mock('../../../src/api', () => ({
   getReports: vi.fn(),
@@ -10,94 +11,62 @@ vi.mock('../../../src/api', () => ({
   API_BASE: 'http://127.0.0.1:8000',
 }))
 
-// Stops "window.open is not a function" errors in the test environment
 const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
-// ── Shared fixtures ───────────────────────────────────────────────────────────
+// Fixed base time so date-range tests are deterministic
+const BASE_NOW = new Date('2026-05-14T12:00:00Z').getTime()
 
 const readyReport = {
-  id: 'report-1',
-  task_id: 'task-abc-123',
-  name: 'Security Scan — example.com',
-  type: 'technical',
-  generated_at: '2026-05-14T10:00:00Z',
-  status: 'ready',
-  findings: 7,
-  assets: 3,
-  pages: 12,
+  id: 'report-1', task_id: 'task-abc-123',
+  name: 'Security Scan — example.com', type: 'technical',
+  generated_at: '2026-05-14T10:00:00Z', status: 'ready',
+  findings: 7, assets: 3, pages: 12,
 }
-
 const generatingReport = {
-  id: 'report-2',
-  task_id: 'task-def-456',
-  name: 'Security Scan — staging.example.com',
-  type: 'executive',
-  generated_at: '2026-05-14T11:00:00Z',
-  status: 'generating',
-  findings: 0,
-  assets: 0,
-  pages: 0,
+  id: 'report-2', task_id: 'task-def-456',
+  name: 'Security Scan — staging.example.com', type: 'executive',
+  generated_at: '2026-05-12T12:00:00Z', status: 'generating',
+  findings: 0, assets: 0, pages: 0,
 }
-
 const failedReport = {
-  id: 'report-3',
-  task_id: 'task-ghi-789',
-  name: 'Security Scan — api.example.com',
-  type: 'compliance',
-  generated_at: '2026-05-14T12:00:00Z',
-  status: 'failed',
-  findings: 0,
-  assets: 0,
-  pages: 0,
+  id: 'report-3', task_id: 'task-ghi-789',
+  name: 'Security Scan — api.example.com', type: 'compliance',
+  generated_at: '2026-05-04T12:00:00Z', status: 'failed',
+  findings: 0, assets: 0, pages: 0,
 }
-
 const emptySummary = {
-  total_findings: 0,
-  total_assets: 0,
-  critical_findings: 0,
-  high_findings: 0,
-  total_attack_surface: 0,
+  total_findings: 0, total_assets: 0, critical_findings: 0,
+  high_findings: 0, total_attack_surface: 0,
 }
-
-// ── Helper ────────────────────────────────────────────────────────────────────
 
 function renderReports() {
-  return render(
-    <MemoryRouter>
-      <Reports />
-    </MemoryRouter>,
-  )
+  return render(<MemoryRouter><Reports /></MemoryRouter>)
 }
 
-// ── Loading state ─────────────────────────────────────────────────────────────
+// ── Loading state ─────────────────────────────────────────────────────────────────────────────
 
 describe('Reports — loading state', () => {
-
   it('shows loading spinner while fetching', () => {
-    // Never resolves so the loading state stays visible
     vi.mocked(getReports).mockReturnValue(new Promise(() => {}))
     vi.mocked(getDashboardSummary).mockReturnValue(new Promise(() => {}))
-
     renderReports()
-
     expect(screen.getByText(/Retrieving Archive Data/i)).toBeInTheDocument()
   })
 })
 
-// ── Error state ───────────────────────────────────────────────────────────────
+// ── Error state ───────────────────────────────────────────────────────────────────────────────
 
 describe('Reports — error state', () => {
   beforeEach(() => {
     vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
     vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
-    vi.mocked(getReports).mockClear()  // ← reset call count before each test
+    vi.mocked(getReports).mockClear()
   })
+
   it('shows error message when fetch fails', async () => {
     vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
     vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
-
     renderReports()
-
     expect(await screen.findByText(/Archive_Retrieval_Failed/i)).toBeInTheDocument()
     expect(screen.getByText(/Failed to fetch reports/i)).toBeInTheDocument()
   })
@@ -105,9 +74,7 @@ describe('Reports — error state', () => {
   it('shows a retry button when fetch fails', async () => {
     vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
     vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
-
     renderReports()
-
     expect(await screen.findByRole('button', { name: /Retry/i })).toBeInTheDocument()
   })
 
@@ -115,18 +82,14 @@ describe('Reports — error state', () => {
     const user = userEvent.setup()
     vi.mocked(getReports).mockRejectedValue(new Error('Network error'))
     vi.mocked(getDashboardSummary).mockRejectedValue(new Error('Network error'))
-
     renderReports()
-
     await screen.findByRole('button', { name: /Retry/i })
     await user.click(screen.getByRole('button', { name: /Retry/i }))
-
-    // getReports should have been called twice — once on load, once on retry
     expect(vi.mocked(getReports)).toHaveBeenCalledTimes(2)
   })
 })
 
-// ── Empty state ───────────────────────────────────────────────────────────────
+// ── Empty state ───────────────────────────────────────────────────────────────────────────────
 
 describe('Reports — empty state', () => {
   beforeEach(() => {
@@ -140,22 +103,16 @@ describe('Reports — empty state', () => {
   })
 
   it('shows Archive Isolated when filter returns no matching reports', async () => {
-    // Only a technical report exists
     vi.mocked(getReports).mockResolvedValue({ reports: [readyReport] })
     const user = userEvent.setup()
-
     renderReports()
-
     await screen.findByText(/Security Scan — example.com/i)
-
-    // Filter to executive — no executive reports exist
     await user.click(screen.getByRole('button', { name: /executive briefings/i }))
-
     expect(await screen.findByText(/Archive Isolated/i)).toBeInTheDocument()
   })
 })
 
-// ── Export buttons — ready report ─────────────────────────────────────────────
+// ── Export buttons — ready report ─────────────────────────────────────────────────────────────────
 
 describe('Reports — export buttons on a ready report', () => {
   beforeEach(() => {
@@ -166,7 +123,6 @@ describe('Reports — export buttons on a ready report', () => {
 
   it('shows PDF, HTML and CSV buttons for a ready report', async () => {
     renderReports()
-
     expect(await screen.findByRole('button', { name: /^pdf$/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^html$/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^csv$/i })).toBeInTheDocument()
@@ -174,9 +130,7 @@ describe('Reports — export buttons on a ready report', () => {
 
   it('export buttons are enabled for a ready report', async () => {
     renderReports()
-
     await screen.findByRole('button', { name: /^pdf$/i })
-
     expect(screen.getByRole('button', { name: /^pdf$/i })).not.toBeDisabled()
     expect(screen.getByRole('button', { name: /^html$/i })).not.toBeDisabled()
     expect(screen.getByRole('button', { name: /^csv$/i })).not.toBeDisabled()
@@ -185,53 +139,36 @@ describe('Reports — export buttons on a ready report', () => {
   it('clicking PDF opens the correct backend URL', async () => {
     const user = userEvent.setup()
     renderReports()
-
     await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
-
     expect(openSpy).toHaveBeenCalledWith(
-      expect.stringContaining(`/task/${readyReport.task_id}/report/pdf`),
-      '_blank',
-    )
+      expect.stringContaining('/task/' + readyReport.task_id + '/report/pdf'), '_blank')
   })
 
   it('clicking HTML opens the correct backend URL', async () => {
     const user = userEvent.setup()
     renderReports()
-
     await user.click(await screen.findByRole('button', { name: /^html$/i }))
-
     expect(openSpy).toHaveBeenCalledWith(
-      expect.stringContaining(`/task/${readyReport.task_id}/report/html`),
-      '_blank',
-    )
+      expect.stringContaining('/task/' + readyReport.task_id + '/report/html'), '_blank')
   })
 
   it('clicking CSV opens the correct backend URL', async () => {
     const user = userEvent.setup()
     renderReports()
-
     await user.click(await screen.findByRole('button', { name: /^csv$/i }))
-
     expect(openSpy).toHaveBeenCalledWith(
-      expect.stringContaining(`/task/${readyReport.task_id}/report/csv`),
-      '_blank',
-    )
+      expect.stringContaining('/task/' + readyReport.task_id + '/report/csv'), '_blank')
   })
 
   it('does not use the old placeholder latest-report route', async () => {
     const user = userEvent.setup()
     renderReports()
-
     await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
-
-    expect(openSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining('latest'),
-      expect.anything(),
-    )
+    expect(openSpy).not.toHaveBeenCalledWith(expect.stringContaining('latest'), expect.anything())
   })
 })
 
-// ── Export buttons — non-ready reports ───────────────────────────────────────
+// ── Export buttons — generating report ────────────────────────────────────────────────────────────
 
 describe('Reports — export buttons on a generating report', () => {
   beforeEach(() => {
@@ -242,9 +179,7 @@ describe('Reports — export buttons on a generating report', () => {
 
   it('export buttons are disabled when report is generating', async () => {
     renderReports()
-
     await screen.findByRole('button', { name: /^pdf$/i })
-
     expect(screen.getByRole('button', { name: /^pdf$/i })).toBeDisabled()
     expect(screen.getByRole('button', { name: /^html$/i })).toBeDisabled()
     expect(screen.getByRole('button', { name: /^csv$/i })).toBeDisabled()
@@ -253,10 +188,8 @@ describe('Reports — export buttons on a generating report', () => {
   it('clicking a disabled button does not open any URL', async () => {
     const user = userEvent.setup()
     renderReports()
-
     await screen.findByRole('button', { name: /^pdf$/i })
     await user.click(screen.getByRole('button', { name: /^pdf$/i }))
-
     expect(openSpy).not.toHaveBeenCalled()
   })
 })
@@ -270,28 +203,23 @@ describe('Reports — export buttons on a failed report', () => {
 
   it('export buttons are enabled for a failed report since backend supports it', async () => {
     renderReports()
-
     await screen.findByRole('button', { name: /^pdf$/i })
-
     expect(screen.getByRole('button', { name: /^pdf$/i })).not.toBeDisabled()
     expect(screen.getByRole('button', { name: /^html$/i })).not.toBeDisabled()
     expect(screen.getByRole('button', { name: /^csv$/i })).not.toBeDisabled()
   })
 })
 
-// ── Filter ────────────────────────────────────────────────────────────────────
+// ── Type filter ─────────────────────────────────────────────────────────────────────────────────────
 
 describe('Reports — type filter', () => {
   beforeEach(() => {
-    vi.mocked(getReports).mockResolvedValue({
-      reports: [readyReport, generatingReport],
-    })
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport, generatingReport] })
     vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
   })
 
   it('shows all reports when All filter is selected', async () => {
     renderReports()
-
     expect(await screen.findByText(/Security Scan — example.com/i)).toBeInTheDocument()
     expect(screen.getByText(/Security Scan — staging.example.com/i)).toBeInTheDocument()
   })
@@ -299,15 +227,149 @@ describe('Reports — type filter', () => {
   it('shows only matching reports when a type filter is selected', async () => {
     const user = userEvent.setup()
     renderReports()
-
     await screen.findByText(/Security Scan — example.com/i)
-
-    // Filter to executive — only generatingReport is executive
     await user.click(screen.getByRole('button', { name: /executive briefings/i }))
-
     await waitFor(() => {
       expect(screen.queryByText(/Security Scan — example.com/i)).not.toBeInTheDocument()
     })
     expect(screen.getByText(/Security Scan — staging.example.com/i)).toBeInTheDocument()
+  })
+})
+
+// ── Status filter ────────────────────────────────────────────────────────────────────────────────
+
+describe('Reports — status filter', () => {
+  beforeEach(() => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport, generatingReport, failedReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+  })
+
+  it('shows only ready reports when status filter is Ready', async () => {
+    const user = userEvent.setup()
+    renderReports()
+    await screen.findByText(/Security Scan — example.com/i)
+    await user.click(screen.getByRole('button', { name: /status ready/i }))
+    expect(await screen.findByText(/Security Scan — example.com/i)).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByText(/Security Scan — staging.example.com/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Security Scan — api.example.com/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows only failed reports when status filter is Failed', async () => {
+    const user = userEvent.setup()
+    renderReports()
+    await screen.findByText(/Security Scan — example.com/i)
+    await user.click(screen.getByRole('button', { name: /status failed/i }))
+    expect(await screen.findByText(/Security Scan — api.example.com/i)).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByText(/Security Scan — example.com/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Security Scan — staging.example.com/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows only generating reports when status filter is Generating', async () => {
+    const user = userEvent.setup()
+    renderReports()
+    await screen.findByText(/Security Scan — example.com/i)
+    await user.click(screen.getByRole('button', { name: /status generating/i }))
+    expect(await screen.findByText(/Security Scan — staging.example.com/i)).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByText(/Security Scan — example.com/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Security Scan — api.example.com/i)).not.toBeInTheDocument()
+    })
+  })
+})
+
+// ── isWithinDateRange unit tests ──────────────────────────────────────────────────────────────────────
+
+describe('isWithinDateRange', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(BASE_NOW))
+  })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('always returns true for range all', () => {
+    expect(isWithinDateRange('2020-01-01T00:00:00Z', 'all')).toBe(true)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isWithinDateRange('', '24h')).toBe(false)
+  })
+
+  it('returns false for invalid date string', () => {
+    expect(isWithinDateRange('not-a-date', '7d')).toBe(false)
+  })
+
+  it('matches a date 1 hour ago within 24h', () => {
+    const d = new Date(BASE_NOW - 60 * 60 * 1000).toISOString()
+    expect(isWithinDateRange(d, '24h')).toBe(true)
+  })
+
+  it('does not match a date 25 hours ago within 24h', () => {
+    const d = new Date(BASE_NOW - 25 * 60 * 60 * 1000).toISOString()
+    expect(isWithinDateRange(d, '24h')).toBe(false)
+  })
+
+  it('matches a date 2 days ago within 7d', () => {
+    const d = new Date(BASE_NOW - 2 * 86400000).toISOString()
+    expect(isWithinDateRange(d, '7d')).toBe(true)
+  })
+
+  it('does not match a date 8 days ago within 7d', () => {
+    const d = new Date(BASE_NOW - 8 * 86400000).toISOString()
+    expect(isWithinDateRange(d, '7d')).toBe(false)
+  })
+
+  it('matches a date 10 days ago within 30d', () => {
+    const d = new Date(BASE_NOW - 10 * 86400000).toISOString()
+    expect(isWithinDateRange(d, '30d')).toBe(true)
+  })
+
+  it('does not match a date 31 days ago within 30d', () => {
+    const d = new Date(BASE_NOW - 31 * 86400000).toISOString()
+    expect(isWithinDateRange(d, '30d')).toBe(false)
+  })
+
+  it('does not match a future date within 24h', () => {
+    const d = new Date(BASE_NOW + 60 * 60 * 1000).toISOString()
+    expect(isWithinDateRange(d, '24h')).toBe(false)
+  })
+
+  it('does not match a future date within 7d', () => {
+    const d = new Date(BASE_NOW + 2 * 86400000).toISOString()
+    expect(isWithinDateRange(d, '7d')).toBe(false)
+  })
+})
+
+// ── Combined filters ─────────────────────────────────────────────────────────────────────────────────
+
+describe('Reports — combined filters', () => {
+  beforeEach(() => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyReport, generatingReport, failedReport] })
+    vi.mocked(getDashboardSummary).mockResolvedValue(emptySummary)
+  })
+
+  it('type + status filter works correctly', async () => {
+    const user = userEvent.setup()
+    renderReports()
+    await screen.findByText(/Security Scan — example.com/i)
+    await user.click(screen.getByRole('button', { name: /technical/i }))
+    await user.click(screen.getByRole('button', { name: /status ready/i }))
+    expect(await screen.findByText(/Security Scan — example.com/i)).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByText(/Security Scan — staging.example.com/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Security Scan — api.example.com/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when combined status + date filters match nothing', async () => {
+    const user = userEvent.setup()
+    renderReports()
+    await screen.findByText(/Security Scan — example.com/i)
+    await user.click(screen.getByRole('button', { name: /status failed/i }))
+    await user.click(screen.getByRole('button', { name: /date last 24 hours/i }))
+    expect(await screen.findByText(/archive isolated/i)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes #29

## Changes
- `frontend/src/pages/Reports.tsx` — added Status and Date Range filter controls; updated `filteredReports` to combine all three filters (type + status + date)
- `frontend/src/utils/date.ts` — added `DateRange` type and `isWithinDateRange()` helper; fixed future dates incorrectly matching date ranges
- `frontend/testing/unit/pages/Reports.test.tsx` — restored all existing export/loading/error/empty-state tests and added new status filter, date range filter, combined filter, and deterministic `isWithinDateRange` unit tests (33 tests total)

## Test plan
cd frontend && npx vitest run
All 107 tests pass.