### PR TITLE
fix: validate_port_range now correctly handles mixed port specs like "80,443-8080"

### DIFF
--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -121,16 +121,23 @@ def validate_port_range(port_range: str) -> Tuple[bool, str]:
     Returns:
         Tuple of (is_valid, error_message)
     """
-    # Handle comma-separated ports
+    # Handle comma-separated ports (supports mixed specs like "80,443-8080")
     if ',' in port_range:
         for port_str in port_range.split(','):
-            try:
-                port = int(port_str.strip())
-                is_valid, msg = validate_port(port)
+            port_str = port_str.strip()
+            if '-' in port_str:
+                # Delegate sub-ranges like "443-8080" to the range parser below
+                is_valid, msg = validate_port_range(port_str)
                 if not is_valid:
                     return False, msg
-            except ValueError:
-                return False, f"Invalid port number: {port_str}"
+            else:
+                try:
+                    port = int(port_str)
+                    is_valid, msg = validate_port(port)
+                    if not is_valid:
+                        return False, msg
+                except ValueError:
+                    return False, f"Invalid port number: {port_str}"
         return True, ""
 
     # Handle port ranges

--- a/testing/backend/unit/test_validation.py
+++ b/testing/backend/unit/test_validation.py
@@ -1,6 +1,6 @@
 import pytest
 from backend.secuscan.validation import (
-    validate_target, validate_port, validate_url,
+    validate_target, validate_port, validate_port_range, validate_url,
     sanitize_input, is_safe_path, match_pattern
 )
 
@@ -69,3 +69,34 @@ def test_match_pattern():
     assert match_pattern("nmap", "nmap") is True
     assert match_pattern("tls_inspector", "*inspector") is True
     assert match_pattern("dirb", "http_*") is False
+
+
+def test_validate_port_range():
+    # Single port
+    assert validate_port_range("80") == (True, "")
+    assert validate_port_range("1") == (True, "")
+    assert validate_port_range("65535") == (True, "")
+
+    # Plain range
+    assert validate_port_range("1-1000") == (True, "")
+    assert validate_port_range("443-443") == (True, "")
+
+    # Comma-separated single ports
+    assert validate_port_range("80,443") == (True, "")
+    assert validate_port_range("22,80,443") == (True, "")
+
+    # Mixed comma + range — this was the bug
+    assert validate_port_range("80,443-8080") == (True, "")
+    assert validate_port_range("22,80,443-8080") == (True, "")
+    assert validate_port_range("22,80-90,443,8000-9000") == (True, "")
+
+    # Invalid: out-of-range port
+    assert validate_port_range("99999")[0] is False
+    assert validate_port_range("80,99999")[0] is False
+
+    # Invalid: inverted range
+    assert validate_port_range("1000-80")[0] is False
+
+    # Invalid: non-numeric
+    assert validate_port_range("abc")[0] is False
+    assert validate_port_range("80,bad")[0] is False


### PR DESCRIPTION
## Problem

`validate_port_range()` in `backend/secuscan/validation.py` rejected valid nmap-style mixed port specifications like `"80,443-8080"`. The comma-separated branch split on `,` then called `int()` on each segment unconditionally. When a segment was itself a range (`"443-8080"`), `int()` raised `ValueError` and the function returned `(False, "Invalid port number: 443-8080")` — a false negative.

```python
# before — broken
for port_str in port_range.split(','):
    try:
        port = int(port_str.strip())   # blows up on "443-8080"
```

## Fix

In the comma branch, check whether each segment contains `-` before calling `int()`. If it does, delegate to `validate_port_range()` recursively (the range parser that already exists below). Single-port segments are unchanged.

```python
# after — fixed
for port_str in port_range.split(','):
    port_str = port_str.strip()
    if '-' in port_str:
        is_valid, msg = validate_port_range(port_str)  # handles "443-8080"
        if not is_valid:
            return False, msg
    else:
        try:
            port = int(port_str)
            ...
```

## Changes

- `backend/secuscan/validation.py` — 6 line change inside `validate_port_range()`
- `testing/backend/unit/test_validation.py` — add `validate_port_range` import   and `test_validate_port_range()` with 13 cases

## No breaking changes

`validate_port_range` was previously not called anywhere in the codebase and had zero test coverage. This is a pure correctness fix with no call sites to regress.

Closes #52 