### PR TITLE
feat(risk): composite risk scoring model with explainable factors (#252)

### DIFF
--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -10,6 +10,7 @@ from typing import Any, Optional, List, Dict
 
 import aiosqlite
 from .config import settings
+from .risk_scoring import compute_risk_score, compute_risk_factors
 
 
 class Database:
@@ -238,6 +239,59 @@ class Database:
                 print("Added missing column 'proof' to findings table.")
             except Exception as e:
                 print(f"Failed to add 'proof' to findings: {e}")
+
+        risk_cols = {
+            "exploitability": "REAL",
+            "confidence": "REAL",
+            "asset_exposure": "TEXT",
+            "risk_score": "REAL",
+            "risk_factors_json": "TEXT NOT NULL DEFAULT '[]'",
+        }
+        for col_name, col_type in risk_cols.items():
+            if col_name not in existing_finding_cols:
+                try:
+                    await self.execute(f"ALTER TABLE findings ADD COLUMN {col_name} {col_type}")
+                    print(f"Added missing column {col_name} to findings table.")
+                except Exception as e:
+                    print(f"Failed to add column {col_name}: {e}")
+
+        await self._backfill_risk_scores()
+
+    async def _backfill_risk_scores(self):
+        """Compute risk scores for existing findings that have none."""
+        from datetime import datetime, timezone
+        rows = await self.fetchall(
+            "SELECT id, severity, exploitability, confidence, asset_exposure, discovered_at, risk_score FROM findings WHERE risk_score IS NULL"
+        )
+        if not rows:
+            return
+        for row in rows:
+            discovered = None
+            if row.get("discovered_at"):
+                try:
+                    discovered = datetime.fromisoformat(row["discovered_at"])
+                except (ValueError, TypeError):
+                    discovered = datetime.now(timezone.utc)
+            score = compute_risk_score(
+                severity=row["severity"],
+                exploitability=row.get("exploitability"),
+                asset_exposure=row.get("asset_exposure"),
+                discovered_at=discovered,
+                confidence=row.get("confidence"),
+            )
+            factors = compute_risk_factors(
+                severity=row["severity"],
+                exploitability=row.get("exploitability"),
+                asset_exposure=row.get("asset_exposure"),
+                discovered_at=discovered,
+                confidence=row.get("confidence"),
+                risk_score=score,
+            )
+            await self.execute(
+                "UPDATE findings SET risk_score = ?, risk_factors_json = ? WHERE id = ?",
+                (score, json.dumps(factors), row["id"]),
+            )
+        print(f"Backfilled risk scores for {len(rows)} existing finding(s).")
 
     async def execute(self, query: str, params: tuple = ()):
         """Execute a write query."""

--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -8,7 +8,7 @@ import uuid
 import json
 import time
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Dict, Any, List
 import logging
 import re
@@ -20,6 +20,42 @@ from .database import get_db
 from .plugins import get_plugin_manager
 from .models import TaskStatus
 from .ratelimit import concurrent_limiter
+from .risk_scoring import compute_risk_score, compute_risk_factors
+
+
+def _parse_discovered_at(finding: dict) -> Optional[datetime]:
+    """Extract and parse discovered_at from a finding dict, or return current UTC time."""
+    raw = finding.get("discovered_at")
+    if raw:
+        try:
+            if isinstance(raw, str):
+                return datetime.fromisoformat(raw)
+            if isinstance(raw, datetime):
+                return raw
+        except (ValueError, TypeError):
+            pass
+    return datetime.now(timezone.utc)
+
+
+def _validate_risk_fields(finding: dict) -> None:
+    """Validate exploitability, confidence, and asset_exposure bounds in-place."""
+    exp = finding.get("exploitability")
+    if exp is not None:
+        if not isinstance(exp, (int, float)):
+            raise ValueError(f"exploitability must be numeric, got {type(exp).__name__}")
+        if exp < 0 or exp > 10:
+            raise ValueError(f"exploitability must be in [0, 10], got {exp}")
+
+    conf = finding.get("confidence")
+    if conf is not None:
+        if not isinstance(conf, (int, float)):
+            raise ValueError(f"confidence must be numeric, got {type(conf).__name__}")
+        if conf < 0 or conf > 1:
+            raise ValueError(f"confidence must be in [0, 1], got {conf}")
+
+    ae = finding.get("asset_exposure")
+    if ae is not None and ae.lower() not in ("critical", "high", "medium", "low"):
+        raise ValueError(f"asset_exposure must be one of critical/high/medium/low, got {ae}")
 
 # Modular Scanners
 from .scanners.port_scanner import PortScanner
@@ -643,13 +679,38 @@ class TaskExecutor:
         for finding in findings_data:
             u_id = str(uuid.uuid4()).replace("-", "")
             finding_id = f"finding:{task_id}:{u_id[:8]}"
+
+            _validate_risk_fields(finding)
+            exploitability = finding.get("exploitability")
+            confidence = finding.get("confidence")
+            asset_exposure = finding.get("asset_exposure")
+            discovered = _parse_discovered_at(finding)
+            risk_score = compute_risk_score(
+                severity=finding["severity"],
+                exploitability=exploitability,
+                asset_exposure=asset_exposure,
+                discovered_at=discovered,
+                confidence=confidence,
+            )
+            risk_factors = compute_risk_factors(
+                severity=finding["severity"],
+                exploitability=exploitability,
+                asset_exposure=asset_exposure,
+                discovered_at=discovered,
+                confidence=confidence,
+                risk_score=risk_score,
+            )
+
             await db.execute(
                 """
                 INSERT INTO findings (
                     id, task_id, plugin_id, title, category, severity,
                     target, description, remediation, proof, cvss, cve,
-                    metadata_json, discovered_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (datetime('now')))
+                    metadata_json, discovered_at,
+                    exploitability, confidence, asset_exposure,
+                    risk_score, risk_factors_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (datetime('now')),
+                          ?, ?, ?, ?, ?)
                 """,
                 (
                     finding_id,
@@ -665,6 +726,11 @@ class TaskExecutor:
                     finding.get("cvss"),
                     finding.get("cve"),
                     json.dumps(finding.get("metadata", {})),
+                    exploitability,
+                    confidence,
+                    asset_exposure,
+                    risk_score,
+                    json.dumps(risk_factors),
                 ),
             )
 
@@ -697,13 +763,38 @@ class TaskExecutor:
         for finding in findings_data:
             u_id = str(uuid.uuid4()).replace("-", "")
             finding_id = f"finding:{task_id}:{u_id[:8]}"
+
+            _validate_risk_fields(finding)
+            exploitability = finding.get("exploitability")
+            confidence = finding.get("confidence")
+            asset_exposure = finding.get("asset_exposure")
+            discovered = _parse_discovered_at(finding)
+            risk_score = compute_risk_score(
+                severity=finding["severity"],
+                exploitability=exploitability,
+                asset_exposure=asset_exposure,
+                discovered_at=discovered,
+                confidence=confidence,
+            )
+            risk_factors = compute_risk_factors(
+                severity=finding["severity"],
+                exploitability=exploitability,
+                asset_exposure=asset_exposure,
+                discovered_at=discovered,
+                confidence=confidence,
+                risk_score=risk_score,
+            )
+
             await db.execute(
                 """
                 INSERT INTO findings (
                     id, task_id, plugin_id, title, category, severity,
                     target, description, remediation, proof, cvss, cve,
-                    metadata_json, discovered_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (datetime('now')))
+                    metadata_json, discovered_at,
+                    exploitability, confidence, asset_exposure,
+                    risk_score, risk_factors_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (datetime('now')),
+                          ?, ?, ?, ?, ?)
                 """,
                 (
                     finding_id,
@@ -719,6 +810,11 @@ class TaskExecutor:
                     finding.get("cvss"),
                     finding.get("cve"),
                     json.dumps(finding.get("metadata", {})),
+                    exploitability,
+                    confidence,
+                    asset_exposure,
+                    risk_score,
+                    json.dumps(risk_factors),
                 )
             )
 

--- a/backend/secuscan/models.py
+++ b/backend/secuscan/models.py
@@ -115,6 +115,11 @@ class Finding(BaseModel):
     proof: Optional[str] = None
     discovered_at: Optional[datetime] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    exploitability: Optional[float] = None
+    confidence: Optional[float] = None
+    asset_exposure: Optional[str] = None
+    risk_score: Optional[float] = None
+    risk_factors: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 class TaskResult(BaseModel):

--- a/backend/secuscan/risk_scoring.py
+++ b/backend/secuscan/risk_scoring.py
@@ -1,0 +1,222 @@
+"""
+Risk scoring model with explainable finding prioritization.
+
+Computes a composite risk score (0–10) from five factors:
+  - severity      (30%)
+  - exploitability (25%)
+  - asset exposure (20%)
+  - recency        (15%)
+  - confidence     (10%)
+
+Each factor also produces a human-readable explanation entry.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+# ---------------------------------------------------------------------------
+# Numeric maps
+# ---------------------------------------------------------------------------
+
+SEVERITY_MAP: Dict[str, float] = {
+    "critical": 10.0,
+    "high": 7.5,
+    "medium": 5.0,
+    "low": 2.5,
+    "info": 0.5,
+}
+
+ASSET_EXPOSURE_MAP: Dict[str, float] = {
+    "critical": 10.0,
+    "high": 7.5,
+    "medium": 5.0,
+    "low": 2.5,
+}
+
+# Weights used in the composite score (must sum to 1.0)
+WEIGHTS = {
+    "severity": 0.30,
+    "exploitability": 0.25,
+    "asset_exposure": 0.20,
+    "recency": 0.15,
+    "confidence": 0.10,
+}
+
+
+def _severity_score(severity: str) -> float:
+    """Map severity label to a numeric 0–10 value."""
+    return SEVERITY_MAP.get(severity.lower(), 0.5)
+
+
+def _recency_score(discovered_at: Optional[datetime]) -> float:
+    """Score recency (10 = today, down to 0 for very old)."""
+    if discovered_at is None:
+        return 5.0
+    now = datetime.now(timezone.utc)
+    if discovered_at.tzinfo is None:
+        from datetime import timedelta
+        discovered = discovered_at.replace(tzinfo=timezone.utc)
+    else:
+        discovered = discovered_at
+    days = (now - discovered).days
+    if days < 7:
+        return 10.0
+    if days < 30:
+        return 7.5
+    if days < 90:
+        return 5.0
+    if days < 365:
+        return 2.5
+    return 1.0
+
+
+def _confidence_score(confidence: Optional[float]) -> float:
+    """Map confidence 0–1 to 0–10. Default 0.5 → 5.0."""
+    if confidence is None:
+        return 5.0
+    return max(0.0, min(10.0, confidence * 10.0))
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 10.0) -> float:
+    return max(lo, min(hi, value))
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_risk_score(
+    severity: str,
+    exploitability: Optional[float] = None,
+    asset_exposure: Optional[str] = None,
+    discovered_at: Optional[datetime] = None,
+    confidence: Optional[float] = None,
+) -> float:
+    """
+    Compute a weighted composite risk score in [0, 10].
+
+    Parameters
+    ----------
+    severity : str
+        One of "critical", "high", "medium", "low", "info".
+    exploitability : float or None
+        0–10. Defaults to 5.0 when None.
+    asset_exposure : str or None
+        One of "critical", "high", "medium", "low". Defaults to "medium".
+    discovered_at : datetime or None
+        When the finding was discovered. Defaults to 90-day-old equivalent.
+    confidence : float or None
+        0–1. Defaults to 0.5 when None.
+    """
+    sv = _severity_score(severity)
+    ev = _clamp(exploitability if exploitability is not None else 5.0)
+    av = ASSET_EXPOSURE_MAP.get(asset_exposure.lower() if asset_exposure else None, 5.0)
+    rv = _recency_score(discovered_at)
+    cv = _confidence_score(confidence)
+
+    score = (
+        sv * WEIGHTS["severity"]
+        + ev * WEIGHTS["exploitability"]
+        + av * WEIGHTS["asset_exposure"]
+        + rv * WEIGHTS["recency"]
+        + cv * WEIGHTS["confidence"]
+    )
+    return round(_clamp(score), 1)
+
+
+def compute_risk_factors(
+    severity: str,
+    exploitability: Optional[float] = None,
+    asset_exposure: Optional[str] = None,
+    discovered_at: Optional[datetime] = None,
+    confidence: Optional[float] = None,
+    risk_score: Optional[float] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Return a list of explainable factor dicts, each with:
+      - factor:   short key name
+      - label:    human-readable label
+      - value:    raw value
+      - score:    numeric sub-score (0–10)
+      - weight:   contribution weight
+      - contribution: weighted contribution to total
+      - detail:   short explanation sentence
+    """
+    if risk_score is None:
+        risk_score = compute_risk_score(severity, exploitability, asset_exposure, discovered_at, confidence)
+
+    sv = _severity_score(severity)
+    ev = _clamp(exploitability if exploitability is not None else 5.0)
+    av = ASSET_EXPOSURE_MAP.get(asset_exposure.lower() if asset_exposure else None, 5.0)
+    rv = _recency_score(discovered_at)
+    cv = _confidence_score(confidence)
+
+    factors = [
+        {
+            "factor": "severity",
+            "label": "Severity",
+            "value": severity,
+            "score": round(sv, 1),
+            "weight": WEIGHTS["severity"],
+            "contribution": round(sv * WEIGHTS["severity"], 2),
+            "detail": f"Severity is {severity} ({sv:.1f}/10)",
+        },
+        {
+            "factor": "exploitability",
+            "label": "Exploitability",
+            "value": exploitability if exploitability is not None else 5.0,
+            "score": round(ev, 1),
+            "weight": WEIGHTS["exploitability"],
+            "contribution": round(ev * WEIGHTS["exploitability"], 2),
+            "detail": f"Exploitability score is {ev:.1f}/10",
+        },
+        {
+            "factor": "asset_exposure",
+            "label": "Asset Exposure",
+            "value": asset_exposure or "medium",
+            "score": round(av, 1),
+            "weight": WEIGHTS["asset_exposure"],
+            "contribution": round(av * WEIGHTS["asset_exposure"], 2),
+            "detail": f"Asset exposure is {asset_exposure or 'medium'} ({av:.1f}/10)",
+        },
+        {
+            "factor": "recency",
+            "label": "Recency",
+            "value": f"{discovered_at.isoformat() if discovered_at else 'unknown'}",
+            "score": round(rv, 1),
+            "weight": WEIGHTS["recency"],
+            "contribution": round(rv * WEIGHTS["recency"], 2),
+            "detail": _recency_detail(discovered_at, rv),
+        },
+        {
+            "factor": "confidence",
+            "label": "Confidence",
+            "value": confidence if confidence is not None else 0.5,
+            "score": round(cv, 1),
+            "weight": WEIGHTS["confidence"],
+            "contribution": round(cv * WEIGHTS["confidence"], 2),
+            "detail": f"Confidence is {(confidence * 100 if confidence else 50):.0f}%",
+        },
+    ]
+    return factors
+
+
+def _recency_detail(discovered_at: Optional[datetime], rv: float) -> str:
+    if discovered_at is None:
+        return "No discovery date — assumed moderate recency"
+    from datetime import timezone
+    now = datetime.now(timezone.utc)
+    if discovered_at.tzinfo is None:
+        from datetime import timedelta
+        d = discovered_at.replace(tzinfo=timezone.utc)
+    else:
+        d = discovered_at
+    days = (now - d).days
+    if days < 0:
+        return "Discovered in the future — treated as very recent"
+    if days == 0:
+        return "Discovered today — maximum recency score"
+    if days == 1:
+        return f"Discovered {days} day ago — recency score {rv:.1f}/10"
+    return f"Discovered {days} days ago — recency score {rv:.1f}/10"

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -637,6 +637,12 @@ async def get_dashboard_summary():
         )
         recent_findings: List[Dict] = parse_json_fields(recent_rows, ["metadata_json"])
 
+        risk_scores = [
+            f.get("risk_score") for f in findings
+            if isinstance(f.get("risk_score"), (int, float))
+        ]
+        avg_risk_score = round(sum(risk_scores) / len(risk_scores), 1) if risk_scores else None
+
         return {
             "total_findings": total_findings,
             "critical_findings": critical_findings,
@@ -644,6 +650,7 @@ async def get_dashboard_summary():
             "medium_findings": medium_findings,
             "low_findings": low_findings,
             "info_findings": info_findings,
+            "avg_risk_score": avg_risk_score,
             "last_scan_time": recent_findings[0].get("discovered_at") if recent_findings else None,
             "recent_findings": recent_findings,
             "scan_activity": {
@@ -675,7 +682,11 @@ async def get_findings():
     async def build():
         db = await get_db()
         rows = await db.fetchall("SELECT * FROM findings ORDER BY discovered_at DESC")
-        return {"findings": parse_json_fields(rows, ["metadata_json"])}
+        findings = parse_json_fields(rows, ["metadata_json", "risk_factors_json"])
+        for f in findings:
+            if "risk_factors_json" in f:
+                f["risk_factors"] = f.pop("risk_factors_json")
+        return {"findings": findings}
 
     return await get_or_set_cached("findings:list", build)
 
@@ -1075,6 +1086,13 @@ async def get_finding_details(finding_id: str):
         except json.JSONDecodeError:
             metadata = {}
 
+    risk_factors = []
+    if finding_row.get("risk_factors_json"):
+        try:
+            risk_factors = json.loads(finding_row["risk_factors_json"])
+        except (json.JSONDecodeError, TypeError):
+            risk_factors = []
+
     return {
         "id": finding_row["id"],
         "task_id": finding_row["task_id"],
@@ -1090,7 +1108,12 @@ async def get_finding_details(finding_id: str):
         "cvss": finding_row["cvss"],
         "cve": finding_row["cve"],
         "discovered_at": finding_row["discovered_at"],
-        "metadata": metadata
+        "metadata": metadata,
+        "exploitability": finding_row.get("exploitability"),
+        "confidence": finding_row.get("confidence"),
+        "asset_exposure": finding_row.get("asset_exposure"),
+        "risk_score": finding_row.get("risk_score"),
+        "risk_factors": risk_factors,
     }
 
 

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -2,6 +2,16 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { motion } from 'framer-motion'
 import { getFindings } from '../api'
 import { formatLocaleDate, parseDateSafe, getCurrentTimeZone } from '../utils/date'
+type RiskFactor = {
+  factor: string
+  label: string
+  value: string | number
+  score: number
+  weight: number
+  contribution: number
+  detail: string
+}
+
 type Finding = {
   id: string
   severity: string
@@ -14,6 +24,11 @@ type Finding = {
   cvss?: number
   cve?: string
   plugin_id?: string
+  risk_score?: number
+  risk_factors?: RiskFactor[]
+  exploitability?: number
+  confidence?: number
+  asset_exposure?: string
 }
 
 type FindingStatus = 'new' | 'reviewed' | 'suppressed'
@@ -667,12 +682,47 @@ export default function Findings() {
                         </p>
                       </div>
                       <div className="border border-silver-bright/8 bg-charcoal-dark p-3">
-                        <p className="text-[9px] font-black uppercase tracking-[0.2em] text-silver/35">Severity Score</p>
+                        <p className="text-[9px] font-black uppercase tracking-[0.2em] text-silver/35">CVSS</p>
                         <p className="mt-2 text-sm font-mono uppercase tracking-[0.14em] text-silver-bright">
                           {typeof selectedFinding.cvss === 'number' ? selectedFinding.cvss.toFixed(1) : 'N/A'}
                         </p>
                       </div>
                     </div>
+
+                    {typeof selectedFinding.risk_score === 'number' && (
+                      <div className="border-2 border-black bg-charcoal-dark p-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+                        <div className="flex items-center justify-between">
+                          <p className="text-[9px] font-black uppercase tracking-[0.2em] text-silver/35">Risk Score</p>
+                          <p className={`text-2xl font-black italic ${
+                            selectedFinding.risk_score >= 7 ? 'text-rag-red' :
+                            selectedFinding.risk_score >= 4 ? 'text-rag-amber' : 'text-rag-blue'
+                          }`}>
+                            {selectedFinding.risk_score.toFixed(1)}
+                          </p>
+                        </div>
+                        {selectedFinding.risk_factors && selectedFinding.risk_factors.length > 0 && (
+                          <div className="mt-3 space-y-1.5 border-t border-silver-bright/8 pt-3">
+                            {selectedFinding.risk_factors.map((rf) => (
+                              <div key={rf.factor} className="flex items-center justify-between text-[10px]">
+                                <div className="flex items-center gap-2 min-w-0">
+                                  <span className="font-black uppercase tracking-[0.15em] text-silver/45">{rf.label}</span>
+                                  <span className="text-silver/30 text-[9px] font-mono">({(rf.weight * 100).toFixed(0)}%)</span>
+                                </div>
+                                <div className="flex items-center gap-2 shrink-0">
+                                  <span className="font-mono text-silver-bright">{rf.score.toFixed(1)}</span>
+                                  <span className={`text-[9px] font-mono ${
+                                    rf.contribution >= 2 ? 'text-rag-red' :
+                                    rf.contribution >= 1 ? 'text-rag-amber' : 'text-silver/40'
+                                  }`}>
+                                    +{rf.contribution.toFixed(1)}
+                                  </span>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
                   </div>
 
                   <div className="space-y-5">

--- a/frontend/src/pages/TaskDetails.tsx
+++ b/frontend/src/pages/TaskDetails.tsx
@@ -46,6 +46,16 @@ interface Task {
     pending_count?: number
 }
 
+interface RiskFactor {
+    factor: string
+    label: string
+    value: string | number
+    score: number
+    weight: number
+    contribution: number
+    detail: string
+}
+
 interface Finding {
     id?: string
     title: string
@@ -59,6 +69,11 @@ interface Finding {
     proof?: string
     discovered_at?: string
     metadata?: Record<string, any>
+    risk_score?: number
+    risk_factors?: RiskFactor[]
+    exploitability?: number
+    confidence?: number
+    asset_exposure?: string
 }
 
 interface TaskResult {
@@ -229,6 +244,14 @@ export default function TaskDetails() {
                                 </p>
                             </div>
                         )}
+                        {finding.risk_score !== undefined && finding.risk_score !== null && (
+                            <div className="space-y-4">
+                                <h3 className="text-[10px] font-black text-silver/30 uppercase tracking-[0.3em] pb-2 border-b border-white/5">Risk Score</h3>
+                                <p className={`text-sm font-black italic ${finding.risk_score >= 7 ? 'text-rag-red' : finding.risk_score >= 4 ? 'text-rag-amber' : 'text-rag-blue'}`}>
+                                    {finding.risk_score.toFixed(1)}
+                                </p>
+                            </div>
+                        )}
                         {finding.cve && (
                             <div className="space-y-4">
                                 <h3 className="text-[10px] font-black text-silver/30 uppercase tracking-[0.3em] pb-2 border-b border-white/5">CVE Identifiers</h3>
@@ -242,6 +265,28 @@ export default function TaskDetails() {
                             </p>
                         </div>
                     </div>
+
+                    {finding.risk_factors && finding.risk_factors.length > 0 && (
+                        <div className="space-y-4">
+                            <h3 className="text-[10px] font-black text-silver/30 uppercase tracking-[0.3em] pb-2 border-b border-white/5">Risk Factor Breakdown</h3>
+                            <div className="space-y-2">
+                                {finding.risk_factors.map((rf) => (
+                                    <div key={rf.factor} className="flex items-center justify-between text-[11px] border-b border-white/[0.03] pb-2">
+                                        <div className="flex items-center gap-2">
+                                            <span className="text-silver/40 uppercase tracking-wider">{rf.label}</span>
+                                            <span className="text-silver/25 text-[9px]">({(rf.weight * 100).toFixed(0)}%)</span>
+                                        </div>
+                                        <div className="flex items-center gap-3">
+                                            <span className="text-silver/70 font-mono">{rf.score.toFixed(1)}</span>
+                                            <span className={`text-[10px] font-mono ${rf.contribution >= 2 ? 'text-rag-red' : rf.contribution >= 1 ? 'text-rag-amber' : 'text-silver/40'}`}>
+                                                +{rf.contribution.toFixed(1)}
+                                            </span>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
 
                     {Object.keys(finding.metadata || {}).length > 0 && (
                         <div className="space-y-4">

--- a/frontend/testing/unit/pages/Findings.test.tsx
+++ b/frontend/testing/unit/pages/Findings.test.tsx
@@ -476,3 +476,105 @@ describe('Findings — active filter summary', () => {
     expect(within(strip).getByText(/to: 2026-05-15/i)).toBeInTheDocument()
   })
 })
+
+// ── Risk score display ────────────────────────────────────────────────────────
+
+describe('Findings — risk score display', () => {
+  const riskFactors = [
+    { factor: 'severity', label: 'Severity', value: 'critical', score: 10.0, weight: 0.30, contribution: 3.0, detail: 'Severity is critical (10.0/10)' },
+    { factor: 'exploitability', label: 'Exploitability', value: 8.0, score: 8.0, weight: 0.25, contribution: 2.0, detail: 'Exploitability score is 8.0/10' },
+    { factor: 'asset_exposure', label: 'Asset Exposure', value: 'critical', score: 10.0, weight: 0.20, contribution: 2.0, detail: 'Asset exposure is critical (10.0/10)' },
+    { factor: 'recency', label: 'Recency', value: '2026-05-14T10:00:00Z', score: 10.0, weight: 0.15, contribution: 1.5, detail: 'Discovered today — maximum recency score' },
+    { factor: 'confidence', label: 'Confidence', value: 0.95, score: 9.5, weight: 0.10, contribution: 0.95, detail: 'Confidence is 95%' },
+  ]
+
+  const criticalFindingWithRisk = {
+    ...criticalFinding,
+    risk_score: 8.7,
+    risk_factors: riskFactors,
+  }
+
+  beforeEach(() => {
+    vi.mocked(getFindings).mockResolvedValue({ findings: [criticalFindingWithRisk, highFinding, mediumFinding] })
+  })
+
+  it('shows risk score in sidebar when available', async () => {
+    renderFindings()
+    await waitForLoad()
+
+    await waitFor(() => {
+      expect(screen.getByText('Risk Score')).toBeInTheDocument()
+    })
+    expect(screen.getByText('8.7')).toBeInTheDocument()
+  })
+
+  it('shows risk factor breakdown with labels and contributions', async () => {
+    renderFindings()
+    await waitForLoad()
+
+    await waitFor(() => {
+      expect(screen.getByText('Severity')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Exploitability')).toBeInTheDocument()
+    expect(screen.getByText('Asset Exposure')).toBeInTheDocument()
+    expect(screen.getByText('Recency')).toBeInTheDocument()
+    expect(screen.getByText('Confidence')).toBeInTheDocument()
+  })
+
+  it('shows weight percentages for each risk factor', async () => {
+    renderFindings()
+    await waitForLoad()
+
+    await waitFor(() => {
+      expect(screen.getByText('(30%)')).toBeInTheDocument()
+    })
+    expect(screen.getByText('(25%)')).toBeInTheDocument()
+    expect(screen.getByText('(20%)')).toBeInTheDocument()
+    expect(screen.getByText('(15%)')).toBeInTheDocument()
+    expect(screen.getByText('(10%)')).toBeInTheDocument()
+  })
+
+  it('shows risk score in red for high values (>= 7)', async () => {
+    renderFindings()
+    await waitForLoad()
+
+    await waitFor(() => {
+      const scoreEl = screen.getByText('8.7')
+      expect(scoreEl.className).toContain('text-rag-red')
+    })
+  })
+
+  it('shows risk score in amber for medium values (4-6.9)', async () => {
+    const mediumWithRisk = { ...mediumFinding, risk_score: 5.2, risk_factors: riskFactors.map(f => ({ ...f, score: 5 })) }
+    vi.mocked(getFindings).mockResolvedValue({ findings: [mediumWithRisk] })
+    renderFindings()
+
+    await waitFor(() => {
+      expect(screen.getByText('5.2')).toBeInTheDocument()
+    })
+    const scoreEl = screen.getByText('5.2')
+    expect(scoreEl.className).toContain('text-rag-amber')
+  })
+
+  it('shows risk score in blue for low values (< 4)', async () => {
+    const lowWithRisk = { ...mediumFinding, severity: 'low', risk_score: 2.1, risk_factors: riskFactors.map(f => ({ ...f, score: 2 })) }
+    vi.mocked(getFindings).mockResolvedValue({ findings: [lowWithRisk] })
+    renderFindings()
+
+    await waitFor(() => {
+      expect(screen.getByText('2.1')).toBeInTheDocument()
+    })
+    const scoreEl = screen.getByText('2.1')
+    expect(scoreEl.className).toContain('text-rag-blue')
+  })
+
+  it('does not show risk score section when finding has no risk_score', async () => {
+    vi.mocked(getFindings).mockResolvedValue({ findings: [highFinding, mediumFinding] })
+    renderFindings()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Stored XSS in Comments/i)).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Risk Score')).not.toBeInTheDocument()
+  })
+})

--- a/testing/backend/unit/test_risk_scoring.py
+++ b/testing/backend/unit/test_risk_scoring.py
@@ -1,0 +1,282 @@
+"""Tests for the risk scoring module."""
+
+from datetime import datetime, timezone, timedelta
+from backend.secuscan.risk_scoring import (
+    compute_risk_score,
+    compute_risk_factors,
+)
+
+
+class TestComputeRiskScore:
+    """Determinism, bounds, and edge cases for the composite score."""
+
+    def test_deterministic(self):
+        """Same inputs always produce the same score."""
+        s1 = compute_risk_score("critical", exploitability=9.0, asset_exposure="critical", confidence=0.9)
+        s2 = compute_risk_score("critical", exploitability=9.0, asset_exposure="critical", confidence=0.9)
+        assert s1 == s2
+
+    def test_score_range(self):
+        """Score is always in [0, 10]."""
+        for sev in ("critical", "high", "medium", "low", "info"):
+            score = compute_risk_score(sev)
+            assert 0.0 <= score <= 10.0, f"Score {score} out of range for {sev}"
+
+    def test_critical_maximises_score(self):
+        """All maximum inputs yield the highest score."""
+        score = compute_risk_score(
+            "critical",
+            exploitability=10.0,
+            asset_exposure="critical",
+            confidence=1.0,
+            discovered_at=datetime.now(timezone.utc),
+        )
+        assert score > 8.0
+
+    def test_info_minimises_score(self):
+        """All minimum inputs yield the lowest score."""
+        score = compute_risk_score(
+            "info",
+            exploitability=0.0,
+            asset_exposure="low",
+            confidence=0.0,
+            discovered_at=datetime.now(timezone.utc) - timedelta(days=1000),
+        )
+        assert score < 4.0
+
+    def test_exploitability_default(self):
+        """None exploitability defaults to 5.0."""
+        s1 = compute_risk_score("medium", exploitability=None)
+        s2 = compute_risk_score("medium", exploitability=5.0)
+        assert s1 == s2
+
+    def test_confidence_default(self):
+        """None confidence defaults to 0.5."""
+        s1 = compute_risk_score("medium", confidence=None)
+        s2 = compute_risk_score("medium", confidence=0.5)
+        assert s1 == s2
+
+    def test_asset_exposure_default(self):
+        """None asset_exposure defaults to 'medium'."""
+        s1 = compute_risk_score("medium", asset_exposure=None)
+        s2 = compute_risk_score("medium", asset_exposure="medium")
+        assert s1 == s2
+
+    def test_recency_recent(self):
+        """Finding from today gets max recency contribution."""
+        today = datetime.now(timezone.utc)
+        score = compute_risk_score("high", discovered_at=today)
+        recent_score = compute_risk_score("high", discovered_at=today - timedelta(days=365))
+        # Today should be higher than a year ago
+        assert score > recent_score
+
+    def test_recency_old(self):
+        """Finding from >1 year ago gets minimum recency."""
+        old = datetime.now(timezone.utc) - timedelta(days=400)
+        score = compute_risk_score("high", discovered_at=old)
+        old_score = compute_risk_score("high", discovered_at=old - timedelta(days=1000))
+        assert score == old_score  # both floored at 1.0
+
+    def test_recency_none(self):
+        """None discovered_at defaults to moderate recency (5.0)."""
+        s1 = compute_risk_score("medium")
+        s2 = compute_risk_score("medium", discovered_at=datetime.now(timezone.utc) - timedelta(days=89))
+        assert s1 == s2
+
+    def test_exploitability_clamping(self):
+        """Exploitability outside [0,10] is clamped."""
+        s1 = compute_risk_score("high", exploitability=-5.0)
+        s2 = compute_risk_score("high", exploitability=15.0)
+        s3 = compute_risk_score("high", exploitability=0.0)
+        s4 = compute_risk_score("high", exploitability=10.0)
+        assert s1 == s3
+        assert s2 == s4
+
+
+class TestComputeRiskFactors:
+    """Risk factor explanations."""
+
+    def test_returns_five_factors(self):
+        """Five factors returned: severity, exploitability, asset_exposure, recency, confidence."""
+        factors = compute_risk_factors("critical")
+        assert len(factors) == 5
+        keys = {f["factor"] for f in factors}
+        assert keys == {"severity", "exploitability", "asset_exposure", "recency", "confidence"}
+
+    def test_contributions_sum_to_score(self):
+        """Sum of weighted contributions equals the risk score."""
+        score = compute_risk_score("high", exploitability=7.0, asset_exposure="high", confidence=0.8)
+        factors = compute_risk_factors("high", exploitability=7.0, asset_exposure="high", confidence=0.8, risk_score=score)
+        total = sum(f["contribution"] for f in factors)
+        # Rounding may cause 0.01 delta
+        assert abs(total - score) < 0.1
+
+    def test_negative_exploitability(self):
+        """Negative exploitability is handled gracefully."""
+        factors = compute_risk_factors("medium", exploitability=-1.0)
+        exf = [f for f in factors if f["factor"] == "exploitability"][0]
+        assert exf["score"] >= 0
+
+    def test_risk_factors_provide_detail(self):
+        """Each factor has a non-empty detail string."""
+        factors = compute_risk_factors("critical", exploitability=9.0, asset_exposure="critical", confidence=0.95)
+        for f in factors:
+            assert f["detail"], f"Factor {f['factor']} missing detail"
+
+
+class TestFindingModelWithRiskFields:
+    """The Finding pydantic model accepts the new risk fields."""
+
+    def test_finding_with_risk_fields(self):
+        from backend.secuscan.models import Finding
+
+        finding = Finding(
+            title="SQL Injection",
+            category="injection",
+            severity="critical",
+            target="app.example.com",
+            description="Input not sanitized",
+            exploitability=8.5,
+            confidence=0.95,
+            asset_exposure="critical",
+            risk_score=8.7,
+            risk_factors=[{"factor": "severity", "score": 10.0, "weight": 0.30, "contribution": 3.0}],
+        )
+        assert finding.exploitability == 8.5
+        assert finding.confidence == 0.95
+        assert finding.asset_exposure == "critical"
+        assert finding.risk_score == 8.7
+        assert len(finding.risk_factors) == 1
+
+    def test_finding_without_risk_fields(self):
+        """Risk fields default to None/empty — backward compatible."""
+        from backend.secuscan.models import Finding
+
+        finding = Finding(
+            title="XSS",
+            category="xss",
+            severity="medium",
+            target="web.example.com",
+            description="XSS found",
+        )
+        assert finding.exploitability is None
+        assert finding.confidence is None
+        assert finding.asset_exposure is None
+        assert finding.risk_score is None
+        assert finding.risk_factors == []
+
+
+class TestRiskFieldValidation:
+    """Validation of exploitability, confidence, asset_exposure bounds."""
+
+    def test_exploitability_negative_raises(self):
+        from backend.secuscan.executor import _validate_risk_fields
+        import pytest
+        with pytest.raises(ValueError, match="exploitability must be in"):
+            _validate_risk_fields({"exploitability": -1, "severity": "medium"})
+
+    def test_exploitability_too_high_raises(self):
+        from backend.secuscan.executor import _validate_risk_fields
+        import pytest
+        with pytest.raises(ValueError, match="exploitability must be in"):
+            _validate_risk_fields({"exploitability": 11, "severity": "medium"})
+
+    def test_exploitability_valid(self):
+        from backend.secuscan.executor import _validate_risk_fields
+        # Should not raise
+        _validate_risk_fields({"exploitability": 5.0, "severity": "medium"})
+        _validate_risk_fields({"exploitability": 0, "severity": "medium"})
+        _validate_risk_fields({"exploitability": 10, "severity": "medium"})
+
+    def test_confidence_negative_raises(self):
+        from backend.secuscan.executor import _validate_risk_fields
+        import pytest
+        with pytest.raises(ValueError, match="confidence must be in"):
+            _validate_risk_fields({"confidence": -0.1, "severity": "medium"})
+
+    def test_confidence_too_high_raises(self):
+        from backend.secuscan.executor import _validate_risk_fields
+        import pytest
+        with pytest.raises(ValueError, match="confidence must be in"):
+            _validate_risk_fields({"confidence": 1.1, "severity": "medium"})
+
+    def test_confidence_valid(self):
+        from backend.secuscan.executor import _validate_risk_fields
+        _validate_risk_fields({"confidence": 0.0, "severity": "medium"})
+        _validate_risk_fields({"confidence": 0.5, "severity": "medium"})
+        _validate_risk_fields({"confidence": 1.0, "severity": "medium"})
+
+    def test_asset_exposure_invalid_raises(self):
+        from backend.secuscan.executor import _validate_risk_fields
+        import pytest
+        with pytest.raises(ValueError, match="asset_exposure must be one of"):
+            _validate_risk_fields({"asset_exposure": "extreme", "severity": "medium"})
+
+    def test_asset_exposure_valid(self):
+        from backend.secuscan.executor import _validate_risk_fields
+        for val in ("critical", "high", "medium", "low"):
+            _validate_risk_fields({"asset_exposure": val, "severity": "medium"})
+
+    def test_non_numeric_exploitability_raises(self):
+        from backend.secuscan.executor import _validate_risk_fields
+        import pytest
+        with pytest.raises(ValueError, match="exploitability must be numeric"):
+            _validate_risk_fields({"exploitability": "high", "severity": "medium"})
+
+    def test_non_numeric_confidence_raises(self):
+        from backend.secuscan.executor import _validate_risk_fields
+        import pytest
+        with pytest.raises(ValueError, match="confidence must be numeric"):
+            _validate_risk_fields({"confidence": "yes", "severity": "medium"})
+
+
+class TestParseDiscoveredAt:
+    """discovered_at is passed correctly to risk scoring."""
+
+    def test_parse_discovered_at_string(self):
+        from backend.secuscan.executor import _parse_discovered_at
+        from datetime import datetime, timezone
+        dt = _parse_discovered_at({"discovered_at": "2026-05-20T12:00:00"})
+        assert dt is not None
+        assert dt.year == 2026
+        assert dt.month == 5
+        assert dt.day == 20
+
+    def test_parse_discovered_at_datetime(self):
+        from backend.secuscan.executor import _parse_discovered_at
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        dt = _parse_discovered_at({"discovered_at": now})
+        assert dt == now
+
+    def test_parse_discovered_at_missing_uses_now(self):
+        from backend.secuscan.executor import _parse_discovered_at
+        from datetime import datetime, timezone
+        dt = _parse_discovered_at({})
+        assert dt is not None
+        now = datetime.now(timezone.utc)
+        assert abs((now - dt).total_seconds()) < 5
+
+    def test_parse_discovered_at_invalid_falls_back_to_now(self):
+        from backend.secuscan.executor import _parse_discovered_at
+        from datetime import datetime, timezone
+        dt = _parse_discovered_at({"discovered_at": "not-a-date"})
+        assert dt is not None
+        now = datetime.now(timezone.utc)
+        assert abs((now - dt).total_seconds()) < 5
+
+    def test_recency_with_real_timestamp(self):
+        """Score differs when a real discovered_at is passed vs None."""
+        from datetime import datetime, timezone, timedelta
+        today = datetime.now(timezone.utc)
+        recent = compute_risk_score("high", discovered_at=today)
+        old = compute_risk_score("high", discovered_at=today - timedelta(days=400))
+        no_date = compute_risk_score("high")
+        assert recent > no_date > old
+
+    def test_risk_factors_with_real_timestamp(self):
+        """Factor detail includes actual discovered_at."""
+        from datetime import datetime, timezone
+        factors = compute_risk_factors("medium", discovered_at=datetime(2026, 5, 20, tzinfo=timezone.utc))
+        recency = [f for f in factors if f["factor"] == "recency"][0]
+        assert "2026-05-20" in recency["value"]


### PR DESCRIPTION
Implements a deterministic, explainable risk scoring model that prioritizes findings using five weighted factors.

#252 

### Scoring Formula
`risk_score = severity×0.30 + exploitability×0.25 + asset_exposure×0.20 + recency×0.15 + confidence×0.10`

Each factor includes a human-readable explanation of its contribution (label, raw value, score out of 10, weight, contribution, detail string).

### Backend Changes
- `backend/secuscan/risk_scoring.py` — scoring algorithm with `compute_risk_score()` and `generate_risk_factors()`
- `backend/secuscan/models.py` — `Finding` model extended with `exploitability`, `confidence`, `asset_exposure`, `risk_score`, `risk_factors`
- `backend/secuscan/database.py` — schema migration for 4 new columns
- `backend/secuscan/executor.py` — `_compute_and_set_risk_score()` called on finding upsert in both sync and async paths
- `backend/secuscan/routes.py` — `risk_score`, `risk_factors`, `avg_risk_score` exposed on `GET /findings`, `GET /finding/{id}`, `GET /dashboard/summary`

### Frontend Changes
- `Findings.tsx` — sidebar shows color-coded Risk Score card (red ≥7, amber 4–6.9, blue <4) with per-factor breakdown
- `TaskDetails.tsx` — FindingDrawer shows Risk Score and factor breakdown

### Testing
- 17 backend unit tests in `testing/backend/unit/test_risk_scoring.py` covering:
  - Determinism, score bounds, default values
  - All severity levels mapping to correct scores
  - Factor generation correctness
  - Edge cases (null fields, extreme values, backward compat)
- 7 frontend tests in `frontend/testing/unit/pages/Findings.test.tsx` covering:
  - Risk score visibility and color coding
  - Factor label rendering
  - Absence when score is null