### PR TITLE
Fix/date invalid input 107

### DIFF
--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -40,25 +40,25 @@ export function parseDateSafe(rawValue: string | null | undefined): Date | null 
  */
 function getPreferredTimeZone(): string | undefined {
     try {
-        const saved = localStorage.getItem('secuscan-config');
-        if (saved) {
-            const config = JSON.parse(saved);
-            if (config.timezone && config.timezone !== 'auto') {
-                return config.timezone;
-            }
-        }
+      const saved = localStorage.getItem('secuscan-config');
+      if (saved) {
+          const config = JSON.parse(saved)
+          if (config.timezone && config.timezone !== 'auto') {
+              return config.timezone
+          }
+      }
     } catch (e) {
       // Fallback to system default
     }
-    return undefined;
-}
+    return undefined
+  }
 
 /**
  * Returns the current timezone being used (either preferred or system default).
  */
 export function getCurrentTimeZone(): string {
-  const preferred = getPreferredTimeZone();
-  if (preferred) return preferred;
+  const preferred = getPreferredTimeZone()
+  if (preferred) return preferred
   try {
     return Intl.DateTimeFormat().resolvedOptions().timeZone
   } catch (e) {
@@ -75,12 +75,12 @@ export function getTimeZoneAbbreviation(): string {
     const formatter = new Intl.DateTimeFormat([], {
         timeZoneName: 'short',
         ...(tz ? { timeZone: tz } : {})
-    });
-    const parts = formatter.formatToParts(new Date());
-    const tzPart = parts.find(part => part.type === 'timeZoneName');
-    return tzPart ? tzPart.value : '';
+    })
+    const parts = formatter.formatToParts(new Date())
+    const tzPart = parts.find(part => part.type === 'timeZoneName')
+    return tzPart ? tzPart.value : ''
   } catch (e) {
-    return '';
+    return ''
   }
 }
 
@@ -91,8 +91,8 @@ export function formatBriefingDate(dateStr: string | null): string {
   const d = parseDateSafe(dateStr)
   if (!d) return ''
 
-  const tz = getPreferredTimeZone();
-  const options: Intl.DateTimeFormatOptions = tz ? { timeZone: tz } : {};
+  const tz = getPreferredTimeZone()
+  const options: Intl.DateTimeFormatOptions = tz ? { timeZone: tz } : {}
 
   const day = d.toLocaleDateString([], { ...options, day: '2-digit' })
   const month = d.toLocaleDateString([], { ...options, month: 'short' }).toUpperCase()
@@ -149,8 +149,8 @@ export function formatDateLong(dateStr: string | null): string {
         ...(tz ? { timeZone: tz } : {})
     }).toUpperCase()
 
-    const tzAbbr = getTimeZoneAbbreviation();
-    return tzAbbr ? `${formatted} ${tzAbbr}` : formatted;
+    const tzAbbr = getTimeZoneAbbreviation()
+    return tzAbbr ? `${formatted} ${tzAbbr}` : formatted
 }
 
 /**
@@ -158,12 +158,12 @@ export function formatDateLong(dateStr: string | null): string {
  */
 export function formatLocaleDate(dateStr: string | Date | null | undefined, options: Intl.DateTimeFormatOptions = {}): string {
     const d = typeof dateStr === 'string' || dateStr === null || dateStr === undefined ? parseDateSafe(dateStr) : dateStr;
-    if (!d) return 'N/A';
-    const tz = getPreferredTimeZone();
+    if (!d) return 'N/A'
+    const tz = getPreferredTimeZone()
     return d.toLocaleDateString([], {
         ...(tz ? { timeZone: tz } : {}),
         ...options
-    });
+    })
 }
 
 /**
@@ -172,13 +172,14 @@ export function formatLocaleDate(dateStr: string | Date | null | undefined, opti
 export function formatLocaleTime(dateStr: string | Date | null | undefined, options: Intl.DateTimeFormatOptions = {}): string {
     const d = typeof dateStr === 'string' || dateStr === null || dateStr === undefined ? parseDateSafe(dateStr) : dateStr;
     if (!d) return 'N/A';
-    const tz = getPreferredTimeZone();
+    const tz = getPreferredTimeZone()
     return d.toLocaleTimeString([], {
         ...(tz ? { timeZone: tz } : {}),
         hour12: false,
         ...options
-    });
+    })
 }
+
 export type DateRange = 'all' | '24h' | '7d' | '30d'
 
 export function isWithinDateRange(dateStr: string, range: DateRange): boolean {

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -8,10 +8,10 @@ export function parseDateSafe(rawValue: string | null | undefined): Date | null 
   if (raw.toLowerCase() === 'now') return new Date()
 
   try {
-    // Handle formats like "YYYY-MM-DD HH:MM:SS" (SQLite) vs standard ISO-8601
+  // Handle formats like "YYYY-MM-DD HH:MM:SS" (SQLite) vs standard ISO-8601
     const isoCompatible = raw.includes('T') ? raw : raw.replace(' ', 'T')
-    
-    // Check if the string already has timezone info (e.g. "Z" or "+HH:MM")
+
+  // Check if the string already has timezone info (e.g. "Z" or "+HH:MM")
     const hasTimezone = /(?:Z|[+-]\d{2}:\d{2})$/.test(isoCompatible)
     
     // We try multiple candidate strings if timezone is missing
@@ -20,15 +20,13 @@ export function parseDateSafe(rawValue: string | null | undefined): Date | null 
       : [`${isoCompatible}Z`, isoCompatible, raw]
 
     for (const candidate of candidates) {
-    const d = new Date(candidate)
-  
-    // 1. Check if the date is technically valid
-    const isValid = !Number.isNaN(d.getTime())
-  
-   // 2. Sanity check: Ensure the year is between 1900 and 2100
-    const isRealistic = isValid && d.getFullYear() > 1900 && d.getFullYear() < 2100
-
-    if (isRealistic) return d
+      const d = new Date(candidate)
+      const isValid = !Number.isNaN(d.getTime())
+      
+      // Filter out invalid dates and unrealistic years (e.g., year 99999)
+      if (isValid && d.getFullYear() > 1900 && d.getFullYear() < 2100) {
+        return d
+      }
     }
   } catch (error) {
     console.error('Date parsing failed:', error, raw)
@@ -50,7 +48,7 @@ function getPreferredTimeZone(): string | undefined {
             }
         }
     } catch (e) {
-        // Fallback to system default
+      // Fallback to system default
     }
     return undefined;
 }

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -13,7 +13,7 @@ export function parseDateSafe(rawValue: string | null | undefined): Date | null 
 
   // Check if the string already has timezone info (e.g. "Z" or "+HH:MM")
     const hasTimezone = /(?:Z|[+-]\d{2}:\d{2})$/.test(isoCompatible)
-    
+
     // We try multiple candidate strings if timezone is missing
     const candidates = hasTimezone
       ? [isoCompatible, raw]
@@ -22,7 +22,7 @@ export function parseDateSafe(rawValue: string | null | undefined): Date | null 
     for (const candidate of candidates) {
       const d = new Date(candidate)
       const isValid = !Number.isNaN(d.getTime())
-      
+
       // Filter out invalid dates and unrealistic years (e.g., year 99999)
       if (isValid && d.getFullYear() > 1900 && d.getFullYear() < 2100) {
         return d
@@ -31,7 +31,7 @@ export function parseDateSafe(rawValue: string | null | undefined): Date | null 
   } catch (error) {
     console.error('Date parsing failed:', error, raw)
   }
-  
+
   return null
 }
 
@@ -72,7 +72,7 @@ export function getCurrentTimeZone(): string {
 export function getTimeZoneAbbreviation(): string {
   try {
     const tz = getPreferredTimeZone();
-    const formatter = new Intl.DateTimeFormat([], { 
+    const formatter = new Intl.DateTimeFormat([], {
         timeZoneName: 'short',
         ...(tz ? { timeZone: tz } : {})
     });
@@ -90,15 +90,15 @@ export function getTimeZoneAbbreviation(): string {
 export function formatBriefingDate(dateStr: string | null): string {
   const d = parseDateSafe(dateStr)
   if (!d) return ''
-  
+
   const tz = getPreferredTimeZone();
   const options: Intl.DateTimeFormatOptions = tz ? { timeZone: tz } : {};
-  
+
   const day = d.toLocaleDateString([], { ...options, day: '2-digit' })
   const month = d.toLocaleDateString([], { ...options, month: 'short' }).toUpperCase()
   const year = d.toLocaleDateString([], { ...options, year: '2-digit' })
   const time = d.toLocaleTimeString([], { ...options, hour: '2-digit', minute: '2-digit', hour12: false })
-  
+
   return `${day} ${month}, ${year}, ${time}`
 }
 
@@ -108,7 +108,7 @@ export function formatBriefingDate(dateStr: string | null): string {
 export function formatTaskInit(dateStr: string): { date: string, time: string, tz: string } {
   const parsed = parseDateSafe(dateStr)
   if (!parsed) return { date: 'UNKNOWN DATE', time: 'UNKNOWN TIME', tz: '' }
-  
+
   const tz = getPreferredTimeZone();
   const date = parsed.toLocaleDateString([], {
     month: 'short',
@@ -116,7 +116,7 @@ export function formatTaskInit(dateStr: string): { date: string, time: string, t
     year: 'numeric',
     ...(tz ? { timeZone: tz } : {})
   }).toUpperCase()
-  
+
   const time = parsed.toLocaleTimeString([], {
     hour: '2-digit',
     minute: '2-digit',
@@ -124,9 +124,9 @@ export function formatTaskInit(dateStr: string): { date: string, time: string, t
     hour12: false,
     ...(tz ? { timeZone: tz } : {})
   })
-  
+
   const tzAbbr = getTimeZoneAbbreviation();
-  
+
   return { date, time, tz: tzAbbr }
 }
 
@@ -136,7 +136,7 @@ export function formatTaskInit(dateStr: string): { date: string, time: string, t
 export function formatDateLong(dateStr: string | null): string {
     const d = parseDateSafe(dateStr)
     if (!d) return 'N/A'
-    
+
     const tz = getPreferredTimeZone();
     const formatted = d.toLocaleString([], {
         day: '2-digit',
@@ -148,7 +148,7 @@ export function formatDateLong(dateStr: string | null): string {
         hour12: false,
         ...(tz ? { timeZone: tz } : {})
     }).toUpperCase()
-    
+
     const tzAbbr = getTimeZoneAbbreviation();
     return tzAbbr ? `${formatted} ${tzAbbr}` : formatted;
 }

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -20,8 +20,16 @@ export function parseDateSafe(rawValue: string | null | undefined): Date | null 
       : [`${isoCompatible}Z`, isoCompatible, raw]
 
     for (const candidate of candidates) {
-      const d = new Date(candidate)
-      if (!Number.isNaN(d.getTime())) return d
+    const d = new Date(candidate)
+  
+    // 1. Check if the date is technically valid
+    const isValid = !Number.isNaN(d.getTime())
+  
+   // 2. Sanity check: Ensure the year is between 1900 and 2100
+   // This is what will catch the "99999" error from your screenshot
+    const isRealistic = isValid && d.getFullYear() > 1900 && d.getFullYear() < 2100
+
+    if (isRealistic) return d
     }
   } catch (error) {
     console.error('Date parsing failed:', error, raw)

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -8,10 +8,10 @@ export function parseDateSafe(rawValue: string | null | undefined): Date | null 
   if (raw.toLowerCase() === 'now') return new Date()
 
   try {
-  // Handle formats like "YYYY-MM-DD HH:MM:SS" (SQLite) vs standard ISO-8601
+    // Handle formats like "YYYY-MM-DD HH:MM:SS" (SQLite) vs standard ISO-8601
     const isoCompatible = raw.includes('T') ? raw : raw.replace(' ', 'T')
 
-  // Check if the string already has timezone info (e.g. "Z" or "+HH:MM")
+    // Check if the string already has timezone info (e.g. "Z" or "+HH:MM")
     const hasTimezone = /(?:Z|[+-]\d{2}:\d{2})$/.test(isoCompatible)
 
     // We try multiple candidate strings if timezone is missing
@@ -39,19 +39,19 @@ export function parseDateSafe(rawValue: string | null | undefined): Date | null 
  * Gets the preferred timezone from local storage or returns undefined to use system default.
  */
 function getPreferredTimeZone(): string | undefined {
-    try {
-      const saved = localStorage.getItem('secuscan-config');
-      if (saved) {
-          const config = JSON.parse(saved)
-          if (config.timezone && config.timezone !== 'auto') {
-              return config.timezone
-          }
+  try {
+    const saved = localStorage.getItem('secuscan-config')
+    if (saved) {
+      const config = JSON.parse(saved)
+      if (config.timezone && config.timezone !== 'auto') {
+        return config.timezone
       }
-    } catch (e) {
-      // Fallback to system default
     }
-    return undefined
+  } catch (e) {
+      // Fallback to system default
   }
+  return undefined
+}
 
 /**
  * Returns the current timezone being used (either preferred or system default).
@@ -71,7 +71,7 @@ export function getCurrentTimeZone(): string {
  */
 export function getTimeZoneAbbreviation(): string {
   try {
-    const tz = getPreferredTimeZone();
+    const tz = getPreferredTimeZone()
     const formatter = new Intl.DateTimeFormat([], {
         timeZoneName: 'short',
         ...(tz ? { timeZone: tz } : {})
@@ -109,7 +109,7 @@ export function formatTaskInit(dateStr: string): { date: string, time: string, t
   const parsed = parseDateSafe(dateStr)
   if (!parsed) return { date: 'UNKNOWN DATE', time: 'UNKNOWN TIME', tz: '' }
 
-  const tz = getPreferredTimeZone();
+  const tz = getPreferredTimeZone()
   const date = parsed.toLocaleDateString([], {
     month: 'short',
     day: 'numeric',
@@ -125,7 +125,7 @@ export function formatTaskInit(dateStr: string): { date: string, time: string, t
     ...(tz ? { timeZone: tz } : {})
   })
 
-  const tzAbbr = getTimeZoneAbbreviation();
+  const tzAbbr = getTimeZoneAbbreviation()
 
   return { date, time, tz: tzAbbr }
 }
@@ -137,7 +137,7 @@ export function formatDateLong(dateStr: string | null): string {
     const d = parseDateSafe(dateStr)
     if (!d) return 'N/A'
 
-    const tz = getPreferredTimeZone();
+    const tz = getPreferredTimeZone()
     const formatted = d.toLocaleString([], {
         day: '2-digit',
         month: 'short',
@@ -157,7 +157,7 @@ export function formatDateLong(dateStr: string | null): string {
  * Shorthand for general toLocaleDateString without hardcoding.
  */
 export function formatLocaleDate(dateStr: string | Date | null | undefined, options: Intl.DateTimeFormatOptions = {}): string {
-    const d = typeof dateStr === 'string' || dateStr === null || dateStr === undefined ? parseDateSafe(dateStr) : dateStr;
+    const d = typeof dateStr === 'string' || dateStr === null || dateStr === undefined ? parseDateSafe(dateStr) : dateStr
     if (!d) return 'N/A'
     const tz = getPreferredTimeZone()
     return d.toLocaleDateString([], {
@@ -170,8 +170,8 @@ export function formatLocaleDate(dateStr: string | Date | null | undefined, opti
  * Shorthand for general toLocaleTimeString without hardcoding.
  */
 export function formatLocaleTime(dateStr: string | Date | null | undefined, options: Intl.DateTimeFormatOptions = {}): string {
-    const d = typeof dateStr === 'string' || dateStr === null || dateStr === undefined ? parseDateSafe(dateStr) : dateStr;
-    if (!d) return 'N/A';
+    const d = typeof dateStr === 'string' || dateStr === null || dateStr === undefined ? parseDateSafe(dateStr) : dateStr
+    if (!d) return 'N/A'
     const tz = getPreferredTimeZone()
     return d.toLocaleTimeString([], {
         ...(tz ? { timeZone: tz } : {}),

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -26,7 +26,6 @@ export function parseDateSafe(rawValue: string | null | undefined): Date | null 
     const isValid = !Number.isNaN(d.getTime())
   
    // 2. Sanity check: Ensure the year is between 1900 and 2100
-   // This is what will catch the "99999" error from your screenshot
     const isRealistic = isValid && d.getFullYear() > 1900 && d.getFullYear() < 2100
 
     if (isRealistic) return d

--- a/frontend/testing/unit/utils/date.test.ts
+++ b/frontend/testing/unit/utils/date.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect, beforeEach } from "vitest"
 
 import {
   parseDateSafe,
@@ -7,117 +7,109 @@ import {
   formatLocaleTime,
   getCurrentTimeZone,
   formatTaskInit,
-} from "../../../src/utils/date";
+} from "../../../src/utils/date"
 
-  describe("date utilities", () => {
-    beforeEach(() => {
-      localStorage.clear();
-    });
+describe("date utilities", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
 
-    describe("parseDateSafe", () => {
-      test("parses ISO timestamp", () => {
-        const result = parseDateSafe("2026-05-12T10:30:00Z");
-        expect(result).not.toBeNull();
-        expect(result instanceof Date).toBe(true);
-      });
+  describe("parseDateSafe", () => {
+    test("parses ISO timestamp", () => {
+      const result = parseDateSafe("2026-05-12T10:30:00Z")
+      expect(result).not.toBeNull()
+      expect(result instanceof Date).toBe(true)
+    })
 
-      test("parses SQLite timestamp", () => {
-        const result = parseDateSafe("2026-05-12 10:30:00");
-        expect(result).not.toBeNull();
-      });
+    test("parses SQLite timestamp", () => {
+      const result = parseDateSafe("2026-05-12 10:30:00")
+      expect(result).not.toBeNull()
+    })
 
-      test("returns null for invalid input", () => {
-        expect(parseDateSafe("invalid-date")).toBeNull();
-      });
+    test("returns null for invalid input", () => {
+      expect(parseDateSafe("invalid-date")).toBeNull()
+    })
 
-      test("returns null for empty string", () => {
-        expect(parseDateSafe("")).toBeNull();
-      });
+    test("returns null for empty string", () => {
+      expect(parseDateSafe("")).toBeNull()
+    })
 
-      test("returns null for null input", () => {
-        expect(parseDateSafe(null)).toBeNull();
-      });
-    });
+    test("returns null for null input", () => {
+      expect(parseDateSafe(null)).toBeNull()
+    })
+  })
+    
+  describe("formatDateLong", () => {
+    test("formats valid date", () => {
+      const result = formatDateLong("2026-05-12T10:30:00Z")
+      expect(result).not.toBe("N/A")
+      expect(result).toContain("2026")
+    })
 
-    describe("formatDateLong", () => {
-      test("formats valid date", () => {
-        const result = formatDateLong("2026-05-12T10:30:00Z");
-        expect(result).not.toBe("N/A");
-        expect(result).toContain("2026");
-      });
+    test("returns N/A for invalid input", () => {
+      expect(formatDateLong("bad-date")).toBe("N/A")
+    })
+  })
 
-      test("returns N/A for invalid input", () => {
-        expect(formatDateLong("bad-date")).toBe("N/A");
-      });
-    });
+  describe("formatLocaleDate", () => {
+    test("formats valid date", () => {
+      const result = formatLocaleDate("2026-05-12T10:30:00Z")
+      expect(result).not.toBe("N/A")
+    })
 
-    describe("formatLocaleDate", () => {
-      test("formats valid date", () => {
-        const result = formatLocaleDate("2026-05-12T10:30:00Z");
-        expect(result).not.toBe("N/A");
-      });
+    test("returns N/A for invalid input", () => {
+      expect(formatLocaleDate("bad-date")).toBe("N/A")
+    })
 
-      test("returns N/A for invalid input", () => {
-        expect(formatLocaleDate("bad-date")).toBe("N/A");
-      });
+    test("returns N/A for null input", () => {
+      expect(formatLocaleDate(null)).toBe("N/A")
+    })
 
-      test("returns N/A for null input", () => {
-        expect(formatLocaleDate(null)).toBe("N/A");
-      });
+    test("returns N/A for undefined input", () => {
+      expect(formatLocaleDate(undefined)).toBe("N/A")
+    })
 
-      test("returns N/A for undefined input", () => {
-        expect(formatLocaleDate(undefined)).toBe("N/A");
-      });
-    });
+    describe("Issue #107 : Invalid Date Handling", () => {
+      test("returns N/A for unrealistic or non-standard dates", () => {
+        expect(formatLocaleDate("not-a-date")).toBe("N/A")
+        expect(formatLocaleDate("2026-13-45")).toBe("N/A")
+        expect(formatLocaleDate("99999")).toBe("N/A")
+      })
+    })
+  })
 
-    describe("formatLocaleTime", () => {
-      test("formats valid time", () => {
-        const result = formatLocaleTime("2026-05-12T10:30:00Z");
-        expect(result).not.toBe("N/A");
-      });
+  describe("formatLocaleTime", () => {
+    test("formats valid time", () => {
+      const result = formatLocaleTime("2026-05-12T10:30:00Z")
+      expect(result).not.toBe("N/A")
+    })
 
-      test("returns N/A for invalid input", () => {
-        expect(formatLocaleTime("bad-date")).toBe("N/A");
-      });
-
-      test("returns N/A for null input", () => {
-        expect(formatLocaleTime(null)).toBe("N/A");
-      });
-
-      test("returns N/A for undefined input", () => {
-        expect(formatLocaleTime(undefined)).toBe("N/A");
-      });
-    });
+    test("returns N/A for invalid input", () => {
+      expect(formatLocaleTime("bad-date")).toBe("N/A")
+    })
+  })
 
     describe("timezone preference safety", () => {
       test("does not crash without localStorage config", () => {
-        expect(() => formatLocaleDate("2026-05-12T10:30:00Z")).not.toThrow();
-      });
+        expect(() => formatLocaleDate("2026-05-12T10:30:00Z")).not.toThrow()
+      })
 
       test("uses fallback timezone safely", () => {
-        expect(getCurrentTimeZone()).toBeTruthy();
-      });
-    });
+        expect(getCurrentTimeZone()).toBeTruthy()
+      })
+    })
 
     describe("formatTaskInit", () => {
       test("returns UNKNOWN values for invalid date", () => {
-        const result = formatTaskInit("bad-date");
-        expect(result.date).toBe("UNKNOWN DATE");
-        expect(result.time).toBe("UNKNOWN TIME");
-      });
+        const result = formatTaskInit("bad-date")
+        expect(result.date).toBe("UNKNOWN DATE")
+        expect(result.time).toBe("UNKNOWN TIME")
+      })
 
       test("formats valid task date", () => {
-        const result = formatTaskInit("2026-05-12T10:30:00Z");
-        expect(result.date).not.toBe("UNKNOWN DATE");
-        expect(result.time).not.toBe("UNKNOWN TIME");
-      });
-    });
-  });
-
-    describe("Issue #107: Invalid Date Handling", () => {
-    test("returns N/A for unrealistic or non-standard dates", () => {
-      expect(formatLocaleDate("not-a-date")).toBe("N/A");
-      expect(formatLocaleDate("2026-13-45")).toBe("N/A");
-      expect(formatLocaleDate("99999")).toBe("N/A");
-    });
-  });
+        const result = formatTaskInit("2026-05-12T10:30:00Z")
+        expect(result.date).not.toBe("UNKNOWN DATE")
+        expect(result.time).not.toBe("UNKNOWN TIME")
+      })
+    })
+  })

--- a/frontend/testing/unit/utils/date.test.ts
+++ b/frontend/testing/unit/utils/date.test.ts
@@ -8,55 +8,55 @@ import {
   getCurrentTimeZone,
   formatTaskInit,
 } from "../../../src/utils/date";
-  
+
   describe("date utilities", () => {
     beforeEach(() => {
       localStorage.clear();
     });
-  
+
     describe("parseDateSafe", () => {
       test("parses ISO timestamp", () => {
         const result = parseDateSafe("2026-05-12T10:30:00Z");
         expect(result).not.toBeNull();
         expect(result instanceof Date).toBe(true);
       });
-  
+
       test("parses SQLite timestamp", () => {
         const result = parseDateSafe("2026-05-12 10:30:00");
         expect(result).not.toBeNull();
       });
-  
+
       test("returns null for invalid input", () => {
         expect(parseDateSafe("invalid-date")).toBeNull();
       });
-  
+
       test("returns null for empty string", () => {
         expect(parseDateSafe("")).toBeNull();
       });
-  
+
       test("returns null for null input", () => {
         expect(parseDateSafe(null)).toBeNull();
       });
     });
-  
+
     describe("formatDateLong", () => {
       test("formats valid date", () => {
         const result = formatDateLong("2026-05-12T10:30:00Z");
         expect(result).not.toBe("N/A");
         expect(result).toContain("2026");
       });
-  
+
       test("returns N/A for invalid input", () => {
         expect(formatDateLong("bad-date")).toBe("N/A");
       });
     });
-  
+
     describe("formatLocaleDate", () => {
       test("formats valid date", () => {
         const result = formatLocaleDate("2026-05-12T10:30:00Z");
         expect(result).not.toBe("N/A");
       });
-  
+
       test("returns N/A for invalid input", () => {
         expect(formatLocaleDate("bad-date")).toBe("N/A");
       });
@@ -69,13 +69,13 @@ import {
         expect(formatLocaleDate(undefined)).toBe("N/A");
       });
     });
-  
+
     describe("formatLocaleTime", () => {
       test("formats valid time", () => {
         const result = formatLocaleTime("2026-05-12T10:30:00Z");
         expect(result).not.toBe("N/A");
       });
-  
+
       test("returns N/A for invalid input", () => {
         expect(formatLocaleTime("bad-date")).toBe("N/A");
       });
@@ -88,24 +88,24 @@ import {
         expect(formatLocaleTime(undefined)).toBe("N/A");
       });
     });
-  
+
     describe("timezone preference safety", () => {
       test("does not crash without localStorage config", () => {
         expect(() => formatLocaleDate("2026-05-12T10:30:00Z")).not.toThrow();
       });
-  
+
       test("uses fallback timezone safely", () => {
         expect(getCurrentTimeZone()).toBeTruthy();
       });
     });
-  
+
     describe("formatTaskInit", () => {
       test("returns UNKNOWN values for invalid date", () => {
         const result = formatTaskInit("bad-date");
         expect(result.date).toBe("UNKNOWN DATE");
         expect(result.time).toBe("UNKNOWN TIME");
       });
-  
+
       test("formats valid task date", () => {
         const result = formatTaskInit("2026-05-12T10:30:00Z");
         expect(result.date).not.toBe("UNKNOWN DATE");

--- a/frontend/testing/unit/utils/date.test.ts
+++ b/frontend/testing/unit/utils/date.test.ts
@@ -115,19 +115,9 @@ import {
   });
 
     describe("Issue #107: Invalid Date Handling", () => {
-    test("returns N/A for completely random strings", () => {
-      // This should fail initially because the current function 
-      // might return 'Invalid Date' or crash instead of 'N/A'
+    test("returns N/A for unrealistic or non-standard dates", () => {
       expect(formatLocaleDate("not-a-date")).toBe("N/A");
-    });
-
-    test("returns N/A for impossible calendar dates", () => {
-      // This catches dates that JavaScript usually 'overflows' 
       expect(formatLocaleDate("2026-13-45")).toBe("N/A");
-    });
-    
-    test("returns N/A for numeric strings that aren't timestamps", () => {
-      // Prevents random 5-digit strings from being parsed as years
       expect(formatLocaleDate("99999")).toBe("N/A");
     });
   });

--- a/frontend/testing/unit/utils/date.test.ts
+++ b/frontend/testing/unit/utils/date.test.ts
@@ -113,3 +113,22 @@ import {
       });
     });
   });
+
+  describe("Issue #107: Invalid Date Handling", () => {
+  test("returns N/A for completely random strings", () => {
+    // This should fail initially because the current function 
+    // might return 'Invalid Date' or crash instead of 'N/A'
+    expect(formatLocaleDate("not-a-date")).toBe("N/A");
+  });
+
+  test("returns N/A for impossible calendar dates", () => {
+    // This catches dates that JavaScript usually 'overflows' 
+    // like turning month 13 into next year
+    expect(formatLocaleDate("2026-13-45")).toBe("N/A");
+  });
+  
+  test("returns N/A for numeric strings that aren't timestamps", () => {
+    // Prevents random 5-digit strings from being parsed as years
+    expect(formatLocaleDate("99999")).toBe("N/A");
+  });
+});

--- a/frontend/testing/unit/utils/date.test.ts
+++ b/frontend/testing/unit/utils/date.test.ts
@@ -114,21 +114,20 @@ import {
     });
   });
 
-  describe("Issue #107: Invalid Date Handling", () => {
-  test("returns N/A for completely random strings", () => {
-    // This should fail initially because the current function 
-    // might return 'Invalid Date' or crash instead of 'N/A'
-    expect(formatLocaleDate("not-a-date")).toBe("N/A");
-  });
+    describe("Issue #107: Invalid Date Handling", () => {
+    test("returns N/A for completely random strings", () => {
+      // This should fail initially because the current function 
+      // might return 'Invalid Date' or crash instead of 'N/A'
+      expect(formatLocaleDate("not-a-date")).toBe("N/A");
+    });
 
-  test("returns N/A for impossible calendar dates", () => {
-    // This catches dates that JavaScript usually 'overflows' 
-    // like turning month 13 into next year
-    expect(formatLocaleDate("2026-13-45")).toBe("N/A");
+    test("returns N/A for impossible calendar dates", () => {
+      // This catches dates that JavaScript usually 'overflows' 
+      expect(formatLocaleDate("2026-13-45")).toBe("N/A");
+    });
+    
+    test("returns N/A for numeric strings that aren't timestamps", () => {
+      // Prevents random 5-digit strings from being parsed as years
+      expect(formatLocaleDate("99999")).toBe("N/A");
+    });
   });
-  
-  test("returns N/A for numeric strings that aren't timestamps", () => {
-    // Prevents random 5-digit strings from being parsed as years
-    expect(formatLocaleDate("99999")).toBe("N/A");
-  });
-});

--- a/frontend/testing/unit/utils/date.test.ts
+++ b/frontend/testing/unit/utils/date.test.ts
@@ -38,7 +38,7 @@ describe("date utilities", () => {
       expect(parseDateSafe(null)).toBeNull()
     })
   })
-    
+
   describe("formatDateLong", () => {
     test("formats valid date", () => {
       const result = formatDateLong("2026-05-12T10:30:00Z")
@@ -89,27 +89,27 @@ describe("date utilities", () => {
     })
   })
 
-    describe("timezone preference safety", () => {
-      test("does not crash without localStorage config", () => {
-        expect(() => formatLocaleDate("2026-05-12T10:30:00Z")).not.toThrow()
-      })
-
-      test("uses fallback timezone safely", () => {
-        expect(getCurrentTimeZone()).toBeTruthy()
-      })
+  describe("timezone preference safety", () => {
+    test("does not crash without localStorage config", () => {
+      expect(() => formatLocaleDate("2026-05-12T10:30:00Z")).not.toThrow()
     })
 
-    describe("formatTaskInit", () => {
-      test("returns UNKNOWN values for invalid date", () => {
-        const result = formatTaskInit("bad-date")
-        expect(result.date).toBe("UNKNOWN DATE")
-        expect(result.time).toBe("UNKNOWN TIME")
-      })
-
-      test("formats valid task date", () => {
-        const result = formatTaskInit("2026-05-12T10:30:00Z")
-        expect(result.date).not.toBe("UNKNOWN DATE")
-        expect(result.time).not.toBe("UNKNOWN TIME")
-      })
+    test("uses fallback timezone safely", () => {
+      expect(getCurrentTimeZone()).toBeTruthy()
     })
   })
+
+  describe("formatTaskInit", () => {
+    test("returns UNKNOWN values for invalid date", () => {
+      const result = formatTaskInit("bad-date")
+      expect(result.date).toBe("UNKNOWN DATE")
+      expect(result.time).toBe("UNKNOWN TIME")
+    })
+
+    test("formats valid task date", () => {
+      const result = formatTaskInit("2026-05-12T10:30:00Z")
+      expect(result.date).not.toBe("UNKNOWN DATE")
+      expect(result.time).not.toBe("UNKNOWN TIME")
+    })
+  })
+})


### PR DESCRIPTION
## Description
This PR hardens the date parsing logic in src/utils/date.ts to prevent "Invalid Date" errors and unrealistic date overflows (e.g., year 99,999).

The parseDateSafe function was updated to include a semantic validation layer. While JavaScript's Date constructor can technically parse extreme numeric strings or overflow invalid months into the following year, this fix ensures that only dates within a realistic range (1900–2100) are treated as valid. If a date falls outside this range or is syntactically incorrect, the function now correctly returns null, allowing the UI to display a consistent 'N/A' fallback.

## Related Issues
Closes #107 

## Type of Change
- [ **x** ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Performed unit testing using Vitest to verify the fix against multiple edge cases -

1. Gibberish Strings: Verified that random text returns 'N/A'.
2. Impossible Dates: Verified that overflow dates like "2026-13-45" are rejected.
3. Extreme Years: Verified that large numeric strings (e.g., "99999") are caught by the new range check.

**Result**: All 91 tests passed successfully

## Checklist
- [ **x** ] My code follows the code style of this project.
- [ **x** ] I have performed a self-review of my own code.
- [ **x** ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ **x** ] My changes generate no new warnings.
