### PR TITLE
feat: add benchmark suite for concurrent scans and report generation (#256)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,35 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt -r backend/requirements-dev.txt
       - name: Run backend tests
-        run: pytest testing/backend -q
+        run: pytest testing/backend -q -m "not benchmark"
+
+  benchmark:
+    runs-on: ubuntu-latest
+    needs: [backend-lint]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install backend system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcairo2-dev pkg-config
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt -r backend/requirements-dev.txt
+      - name: Run benchmarks
+        id: run_benchmarks
+        run: python3 scripts/run_benchmarks.py
+        continue-on-error: true
+      - name: Upload benchmark results artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmark_results.json
+      - name: Add warning annotation on failure
+        if: steps.run_benchmarks.outcome == 'failure'
+        run: |
+          echo "::warning::Performance benchmark thresholds exceeded or benchmarks failed to run. Check the job logs for details."
 
   frontend-checks:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -35,13 +35,13 @@ venv_tests/
 *.swo
 *~
 .DS_Store
-
 # Testing
 .pytest_cache/
 .coverage
 htmlcov/
 *.cover
 .hypothesis/
+benchmark_results.json
 
 # Database
 *.db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,10 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["backend*"]
+
+[tool.pytest.ini_options]
+markers = [
+    "benchmark: performance benchmark tests (deselect with '-m not benchmark')",
+]
+asyncio_mode = "strict"
+python_files = ["test_*.py", "bench_*.py"]

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Benchmark Runner Script for SecuScan.
+Runs the performance benchmarks, compares results against thresholds,
+and exits non-zero if any regressions are detected.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# ANSI color codes
+GREEN = "\033[92m"
+RED = "\033[91m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+
+def main():
+    root_dir = Path(__file__).resolve().parents[1]
+    thresholds_path = (
+        root_dir / "testing" / "backend" / "benchmarks" / "thresholds.json"
+    )
+    results_path = root_dir / "benchmark_results.json"
+
+    # 1. Load thresholds
+    if not thresholds_path.exists():
+        print(f"{RED}Error: Thresholds file not found at {thresholds_path}{RESET}")
+        sys.exit(1)
+
+    with open(thresholds_path) as f:
+        thresholds = json.load(f)
+
+    # Remove stale results if they exist from a previous run
+    if results_path.exists():
+        try:
+            results_path.unlink()
+        except OSError:
+            pass
+
+    # 2. Run pytest benchmarks
+    print(f"{BOLD}Running SecuScan Performance Benchmarks...{RESET}\n")
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        str(root_dir / "testing" / "backend" / "benchmarks"),
+        "-m",
+        "benchmark",
+        "-v",
+        "-s",
+    ]
+
+    # Run the tests. We capture output/errors normally.
+    result = subprocess.run(cmd, cwd=str(root_dir))
+
+    # 3. Read results
+    if not results_path.exists():
+        print(f"\n{RED}Error: Benchmark run did not produce {results_path}{RESET}")
+        sys.exit(1)
+
+    with open(results_path) as f:
+        results = json.load(f)
+
+    # 4. Compare results against thresholds
+    print(f"\n{BOLD}=== Performance Benchmark Report ==={RESET}\n")
+    print(
+        f"{'Benchmark Metric':<45} | {'Measured':<12} | {'Threshold':<12} | {'Status':<6}"
+    )
+    print("-" * 82)
+
+    has_regression = False
+    for metric, threshold in thresholds.items():
+        if metric not in results:
+            print(f"{metric:<45} | {'N/A':<12} | {threshold:<12} | {RED}MISSING{RESET}")
+            has_regression = True
+            continue
+
+        value = results[metric]
+
+        # Check if throughput metric (higher is better) or latency metric (lower is better)
+        if "throughput" in metric:
+            passed = value >= threshold
+            status_str = f"{GREEN}PASS{RESET}" if passed else f"{RED}FAIL{RESET}"
+            unit = "calls/s"
+        else:
+            passed = value <= threshold
+            status_str = f"{GREEN}PASS{RESET}" if passed else f"{RED}FAIL{RESET}"
+            unit = "ms"
+
+        val_fmt = f"{value:.2f} {unit}"
+        thresh_fmt = f"{threshold:.2f} {unit}"
+
+        # If we failed the threshold, mark regression
+        if not passed:
+            has_regression = True
+
+        print(f"{metric:<45} | {val_fmt:<12} | {thresh_fmt:<12} | {status_str:<6}")
+
+    print("\n" + "=" * 82 + "\n")
+
+    if has_regression:
+        print(
+            f"{RED}{BOLD}Performance regression detected! One or more metrics exceeded thresholds.{RESET}"
+        )
+        sys.exit(1)
+    else:
+        print(f"{GREEN}{BOLD}All performance benchmarks passed!{RESET}")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/backend/benchmarks/__init__.py
+++ b/testing/backend/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+# Benchmark suite package

--- a/testing/backend/benchmarks/bench_concurrent_task_start.py
+++ b/testing/backend/benchmarks/bench_concurrent_task_start.py
@@ -1,0 +1,111 @@
+import asyncio
+import statistics
+import time
+import pytest
+from testing.backend.benchmarks.conftest import load_threshold
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_10_concurrent_task_creates(bench_env, record_benchmark):
+    executor = bench_env["executor"]
+    plugin_id = "icmp_ping"
+    inputs = {"target": "127.0.0.1"}
+
+    latencies = []
+
+    async def create_one():
+        start = time.perf_counter()
+        tid = await executor.create_task(plugin_id, inputs)
+        latencies.append((time.perf_counter() - start) * 1000.0)
+        return tid
+
+    start_total = time.perf_counter()
+    tasks = [create_one() for _ in range(10)]
+    await asyncio.gather(*tasks)
+    total_time_ms = (time.perf_counter() - start_total) * 1000.0
+
+    mean_lat = statistics.mean(latencies)
+    p50_lat = statistics.median(latencies)
+    latencies.sort()
+    p95_lat = (
+        latencies[int(len(latencies) * 0.95)] if len(latencies) >= 2 else latencies[-1]
+    )
+
+    # Record metric
+    record_benchmark("concurrent_task_creates_10_total_ms", total_time_ms)
+
+    threshold_total = load_threshold("concurrent_task_creates_10_total_ms")
+
+    print(
+        f"\n[bench_10_concurrent_task_creates] Total time: {total_time_ms:.2f}ms (threshold: {threshold_total}ms)"
+    )
+    print(f"Mean: {mean_lat:.2f}ms, P50: {p50_lat:.2f}ms, P95: {p95_lat:.2f}ms")
+
+    assert total_time_ms < threshold_total, (
+        f"10 concurrent task creates took {total_time_ms:.2f}ms, threshold: {threshold_total}ms"
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_20_sequential_task_creates(bench_env, record_benchmark):
+    executor = bench_env["executor"]
+    plugin_id = "icmp_ping"
+    inputs = {"target": "127.0.0.1"}
+
+    latencies = []
+    for _ in range(20):
+        start = time.perf_counter()
+        await executor.create_task(plugin_id, inputs)
+        latencies.append((time.perf_counter() - start) * 1000.0)
+
+    mean_lat = statistics.mean(latencies)
+
+    # Record metric
+    record_benchmark("sequential_task_creates_mean_ms", mean_lat)
+
+    threshold_mean = load_threshold("sequential_task_creates_mean_ms")
+
+    print(
+        f"\n[bench_20_sequential_task_creates] Mean latency: {mean_lat:.2f}ms (threshold: {threshold_mean}ms)"
+    )
+
+    assert mean_lat < threshold_mean, (
+        f"Mean sequential task create took {mean_lat:.2f}ms, threshold: {threshold_mean}ms"
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_concurrent_slot_saturation(bench_env, record_benchmark):
+    from backend.secuscan.ratelimit import concurrent_limiter
+
+    # Fills all 3 concurrency slots (via limiter), tries to acquire a 4th slot,
+    # asserts it is rejected in < 5 ms (no spin-wait regression).
+    async with concurrent_limiter.lock:
+        concurrent_limiter.running_tasks.clear()
+
+    # Fill slots
+    assert (await concurrent_limiter.acquire("task-1")) == (True, "")
+    assert (await concurrent_limiter.acquire("task-2")) == (True, "")
+    assert (await concurrent_limiter.acquire("task-3")) == (True, "")
+
+    # Try acquiring 4th slot, measure time
+    start = time.perf_counter()
+    acquired, msg = await concurrent_limiter.acquire("task-4")
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+    # Record metric
+    record_benchmark("slot_rejection_ms", elapsed_ms)
+
+    threshold_rejection = load_threshold("slot_rejection_ms")
+
+    print(
+        f"\n[bench_concurrent_slot_saturation] Slot rejection elapsed: {elapsed_ms:.4f}ms (threshold: {threshold_rejection}ms)"
+    )
+
+    assert not acquired, "Should not be able to acquire 4th slot"
+    assert elapsed_ms < threshold_rejection, (
+        f"Slot rejection took {elapsed_ms:.2f}ms, threshold: {threshold_rejection}ms"
+    )

--- a/testing/backend/benchmarks/bench_db_reads.py
+++ b/testing/backend/benchmarks/bench_db_reads.py
@@ -1,0 +1,138 @@
+import statistics
+import time
+import pytest
+from testing.backend.benchmarks.conftest import load_threshold
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_task_fetchall_100_rows(bench_env, record_benchmark):
+    db = bench_env["db"]
+
+    # Seed 100 tasks
+    for i in range(100):
+        await db.execute(
+            """
+            INSERT INTO tasks (
+                id, plugin_id, tool_name, target, inputs_json, status, consent_granted
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (f"task-{i}", "icmp_ping", "ICMP Ping", "127.0.0.1", "{}", "completed", 1),
+        )
+
+    # Benchmark fetchall
+    start = time.perf_counter()
+    rows = await db.fetchall("SELECT * FROM tasks")
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+    # Record metric
+    record_benchmark("task_fetchall_100_rows_ms", elapsed_ms)
+
+    threshold = load_threshold("task_fetchall_100_rows_ms")
+    print(
+        f"\n[bench_task_fetchall_100_rows] Fetched {len(rows)} rows in {elapsed_ms:.2f}ms (threshold: {threshold}ms)"
+    )
+
+    assert len(rows) >= 100, f"Expected at least 100 rows, got {len(rows)}"
+    assert elapsed_ms < threshold, (
+        f"Fetchall took {elapsed_ms:.2f}ms, threshold: {threshold}ms"
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_task_fetchone_repeated_50x(bench_env, record_benchmark):
+    db = bench_env["db"]
+
+    # Seed 1 task
+    task_id = "target-task-id"
+    await db.execute(
+        """
+        INSERT INTO tasks (
+            id, plugin_id, tool_name, target, inputs_json, status, consent_granted
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (task_id, "icmp_ping", "ICMP Ping", "127.0.0.1", "{}", "completed", 1),
+    )
+
+    # Benchmark fetchone repeated 50 times
+    latencies = []
+    for _ in range(50):
+        start = time.perf_counter()
+        row = await db.fetchone("SELECT * FROM tasks WHERE id = ?", (task_id,))
+        latencies.append((time.perf_counter() - start) * 1000.0)
+        assert row is not None
+
+    latencies.sort()
+    p95_ms = (
+        latencies[int(len(latencies) * 0.95)] if len(latencies) >= 2 else latencies[-1]
+    )
+    mean_ms = statistics.mean(latencies)
+
+    # Record metric
+    record_benchmark("task_fetchone_p95_ms", p95_ms)
+
+    threshold = load_threshold("task_fetchone_p95_ms")
+
+    print(
+        f"\n[bench_task_fetchone_repeated_50x] Mean: {mean_ms:.2f}ms, P95: {p95_ms:.2f}ms (threshold: {threshold}ms)"
+    )
+    assert p95_ms < threshold, (
+        f"P95 fetchone latency {p95_ms:.2f}ms exceeded threshold {threshold}ms"
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_findings_fetchall_500_rows(bench_env, record_benchmark):
+    db = bench_env["db"]
+
+    # Seed 1 task
+    task_id = "findings-task-id"
+    await db.execute(
+        """
+        INSERT INTO tasks (
+            id, plugin_id, tool_name, target, inputs_json, status, consent_granted
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (task_id, "icmp_ping", "ICMP Ping", "127.0.0.1", "{}", "completed", 1),
+    )
+
+    # Seed 500 findings
+    for i in range(500):
+        await db.execute(
+            """
+            INSERT INTO findings (
+                id, task_id, plugin_id, title, category, severity, target, description, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                f"finding-{i}",
+                task_id,
+                "icmp_ping",
+                f"Finding Title {i}",
+                "Network",
+                "HIGH",
+                "127.0.0.1",
+                f"Description for finding {i}",
+                "{}",
+            ),
+        )
+
+    # Benchmark fetchall
+    start = time.perf_counter()
+    rows = await db.fetchall("SELECT * FROM findings WHERE task_id = ?", (task_id,))
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+    # Record metric
+    record_benchmark("findings_fetchall_500_rows_ms", elapsed_ms)
+
+    threshold = load_threshold("findings_fetchall_500_rows_ms")
+    print(
+        f"\n[bench_findings_fetchall_500_rows] Fetched {len(rows)} findings in {elapsed_ms:.2f}ms (threshold: {threshold}ms)"
+    )
+
+    assert len(rows) >= 500, f"Expected at least 500 findings, got {len(rows)}"
+    assert elapsed_ms < threshold, (
+        f"Fetchall findings took {elapsed_ms:.2f}ms, threshold: {threshold}ms"
+    )

--- a/testing/backend/benchmarks/bench_parser_throughput.py
+++ b/testing/backend/benchmarks/bench_parser_throughput.py
@@ -1,0 +1,118 @@
+import statistics
+import time
+import pytest
+from backend.secuscan.reporting import ReportGenerator
+from testing.backend.benchmarks.conftest import load_threshold
+
+
+def _get_mock_task_and_result():
+    task = {
+        "id": "test-task-id",
+        "tool_name": "ICMP Ping",
+        "plugin_id": "icmp_ping",
+        "target": "127.0.0.1",
+        "status": "completed",
+        "created_at": "2026-05-24T12:00:00.000000",
+        "preset": "default",
+        "command_used": "ping -c 4 127.0.0.1",
+        "inputs": {"target": "127.0.0.1"},
+    }
+
+    result = {
+        "findings": [
+            {
+                "id": f"finding-{i}",
+                "title": f"Finding {i}",
+                "category": "Network",
+                "severity": "medium" if i % 2 == 0 else "high",
+                "target": "127.0.0.1",
+                "description": f"Description {i} with some details.",
+                "remediation": "Mitigation steps here.",
+                "proof": "Proof details.",
+                "cve": "CVE-2026-1234",
+                "cwe": "CWE-79",
+                "cvss": 7.5,
+                "discovered_at": "2026-05-24T12:00:05.000",
+                "metadata": {"some_key": "some_value"},
+            }
+            for i in range(20)
+        ],
+        "structured": {"open_ports": [80, 443], "technologies": ["nginx", "openssl"]},
+        "errors": [],
+    }
+    return task, result
+
+
+@pytest.mark.benchmark
+def test_build_report_payload_100x(bench_env, record_benchmark):
+    task, result = _get_mock_task_and_result()
+
+    latencies = []
+    for _ in range(100):
+        start = time.perf_counter()
+        ReportGenerator._build_report_payload(task, result)
+        latencies.append((time.perf_counter() - start) * 1000.0)
+
+    mean_ms = statistics.mean(latencies)
+
+    # Record metric
+    record_benchmark("report_payload_build_mean_ms", mean_ms)
+
+    threshold = load_threshold("report_payload_build_mean_ms")
+
+    print(
+        f"\n[bench_build_report_payload_100x] Mean: {mean_ms:.2f}ms (threshold: {threshold}ms)"
+    )
+    assert mean_ms < threshold, (
+        f"Mean payload build latency {mean_ms:.2f}ms exceeded threshold {threshold}ms"
+    )
+
+
+@pytest.mark.benchmark
+def test_normalize_1000_findings(bench_env, record_benchmark):
+    _, result = _get_mock_task_and_result()
+    finding = result["findings"][0]
+
+    start = time.perf_counter()
+    for _ in range(1000):
+        ReportGenerator._normalize_finding(finding)
+    elapsed = time.perf_counter() - start
+
+    throughput = 1000.0 / elapsed
+
+    # Record metric
+    record_benchmark("finding_normalization_throughput_per_sec", throughput)
+
+    threshold = load_threshold("finding_normalization_throughput_per_sec")
+
+    print(
+        f"\n[bench_normalize_1000_findings] Throughput: {throughput:.2f} calls/sec (threshold: {threshold} calls/sec)"
+    )
+    assert throughput > threshold, (
+        f"Throughput {throughput:.2f} calls/sec was below threshold {threshold} calls/sec"
+    )
+
+
+@pytest.mark.benchmark
+def test_html_report_generate_10x(bench_env, record_benchmark):
+    task, result = _get_mock_task_and_result()
+
+    latencies = []
+    for _ in range(10):
+        start = time.perf_counter()
+        ReportGenerator.generate_html_report(task, result)
+        latencies.append((time.perf_counter() - start) * 1000.0)
+
+    mean_ms = statistics.mean(latencies)
+
+    # Record metric
+    record_benchmark("html_report_generate_mean_ms", mean_ms)
+
+    threshold = load_threshold("html_report_generate_mean_ms")
+
+    print(
+        f"\n[bench_html_report_generate_10x] Mean: {mean_ms:.2f}ms (threshold: {threshold}ms)"
+    )
+    assert mean_ms < threshold, (
+        f"Mean HTML report generation latency {mean_ms:.2f}ms exceeded threshold {threshold}ms"
+    )

--- a/testing/backend/benchmarks/bench_report_export.py
+++ b/testing/backend/benchmarks/bench_report_export.py
@@ -1,0 +1,94 @@
+import statistics
+import time
+import pytest
+from backend.secuscan.reporting import ReportGenerator
+from testing.backend.benchmarks.conftest import load_threshold
+
+
+# Note: PDF export is excluded from CI benchmarks because xhtml2pdf has non-deterministic
+# font rendering and layout engine performance in headless and container environments.
+# PDF export performance should be verified manually or through local profiling.
+
+
+def _get_mock_task_and_result_50x():
+    task = {
+        "id": "test-task-id",
+        "tool_name": "ICMP Ping",
+        "plugin_id": "icmp_ping",
+        "target": "127.0.0.1",
+        "status": "completed",
+        "created_at": "2026-05-24T12:00:00.000000",
+        "preset": "default",
+        "command_used": "ping -c 4 127.0.0.1",
+        "inputs": {"target": "127.0.0.1"},
+    }
+
+    result = {
+        "findings": [
+            {
+                "id": f"finding-{i}",
+                "title": f"Finding Title {i}",
+                "category": "Network Security",
+                "severity": "HIGH" if i % 2 == 0 else "MEDIUM",
+                "target": "127.0.0.1",
+                "description": f"Detailed description for finding {i} that contains some random text to simulate real-world payloads.",
+                "remediation": "Do this and do that to resolve the issue.",
+                "proof": "Here is proof.",
+                "cve": "CVE-2026-1234",
+                "cwe": "CWE-79",
+                "cvss": 7.5,
+                "discovered_at": "2026-05-24T12:00:05.000",
+                "metadata": {"key": "value"},
+            }
+            for i in range(50)
+        ],
+        "structured": {"open_ports": [80, 443], "technologies": ["nginx", "openssl"]},
+        "errors": [],
+    }
+    return task, result
+
+
+@pytest.mark.benchmark
+def test_csv_export_10x(bench_env, record_benchmark):
+    task, result = _get_mock_task_and_result_50x()
+
+    latencies = []
+    for _ in range(10):
+        start = time.perf_counter()
+        ReportGenerator.generate_csv_report(task, result)
+        latencies.append((time.perf_counter() - start) * 1000.0)
+
+    mean_ms = statistics.mean(latencies)
+
+    # Record metric
+    record_benchmark("csv_export_mean_ms", mean_ms)
+
+    threshold = load_threshold("csv_export_mean_ms")
+
+    print(f"\n[bench_csv_export_10x] Mean: {mean_ms:.2f}ms (threshold: {threshold}ms)")
+    assert mean_ms < threshold, (
+        f"Mean CSV export latency {mean_ms:.2f}ms exceeded threshold {threshold}ms"
+    )
+
+
+@pytest.mark.benchmark
+def test_html_export_10x(bench_env, record_benchmark):
+    task, result = _get_mock_task_and_result_50x()
+
+    latencies = []
+    for _ in range(10):
+        start = time.perf_counter()
+        ReportGenerator.generate_html_report(task, result)
+        latencies.append((time.perf_counter() - start) * 1000.0)
+
+    mean_ms = statistics.mean(latencies)
+
+    # Record metric
+    record_benchmark("html_export_mean_ms", mean_ms)
+
+    threshold = load_threshold("html_export_mean_ms")
+
+    print(f"\n[bench_html_export_10x] Mean: {mean_ms:.2f}ms (threshold: {threshold}ms)")
+    assert mean_ms < threshold, (
+        f"Mean HTML export latency {mean_ms:.2f}ms exceeded threshold {threshold}ms"
+    )

--- a/testing/backend/benchmarks/conftest.py
+++ b/testing/backend/benchmarks/conftest.py
@@ -1,0 +1,82 @@
+import pytest
+import pytest_asyncio
+from pathlib import Path
+
+
+@pytest_asyncio.fixture
+async def bench_env(setup_test_environment):
+    """
+    Provide an isolated execution environment for benchmark tests.
+    Resets ratelimits and concurrency slot limits, and initializes the DB, cache, and plugins.
+    """
+    from backend.secuscan.config import settings
+    from backend.secuscan import database as db_module
+    from backend.secuscan import cache as cache_module
+    from backend.secuscan.plugins import init_plugins
+    from backend.secuscan.executor import TaskExecutor
+    from backend.secuscan.ratelimit import concurrent_limiter, rate_limiter
+
+    # Reset shared rate-limiter state
+    await rate_limiter.reset()
+    async with concurrent_limiter.lock:
+        concurrent_limiter.running_tasks.clear()
+
+    # Initialize the DB, cache, and plugin registry
+    test_db = await db_module.init_db(settings.database_path)
+    await cache_module.init_cache()
+    await init_plugins(settings.plugins_dir)
+
+    executor = TaskExecutor()
+
+    yield {
+        "executor": executor,
+        "db": test_db,
+        "db_path": settings.database_path,
+        "raw_dir": Path(settings.raw_output_dir),
+    }
+
+    # Teardown
+    await test_db.disconnect()
+    db_module.db = None
+    if cache_module.cache is not None:
+        await cache_module.cache.disconnect()
+        cache_module.cache = None
+
+
+def load_threshold(name: str) -> float:
+    """Load a threshold by key from thresholds.json"""
+    import json
+
+    threshold_path = Path(__file__).parent / "thresholds.json"
+    with open(threshold_path) as f:
+        thresholds = json.load(f)
+    return float(thresholds[name])
+
+
+# Dictionary to hold the collected benchmark metrics during a run
+_benchmark_results = {}
+
+
+@pytest.fixture
+def record_benchmark():
+    """
+    Fixture to record custom benchmark metrics to be exported at the end of the session.
+    """
+
+    def _record(name: str, value: float):
+        _benchmark_results[name] = value
+
+    return _record
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """
+    Write collected benchmark results to benchmark_results.json at the workspace root.
+    """
+    if _benchmark_results:
+        import json
+
+        results_path = Path(session.config.rootdir) / "benchmark_results.json"
+        with open(results_path, "w") as f:
+            json.dump(_benchmark_results, f, indent=2)
+        print(f"\nSaved benchmark results to {results_path}")

--- a/testing/backend/benchmarks/thresholds.json
+++ b/testing/backend/benchmarks/thresholds.json
@@ -1,0 +1,13 @@
+{
+  "concurrent_task_creates_10_total_ms": 1000,
+  "sequential_task_creates_mean_ms": 50,
+  "slot_rejection_ms": 5,
+  "report_payload_build_mean_ms": 5,
+  "finding_normalization_throughput_per_sec": 5000,
+  "html_report_generate_mean_ms": 30,
+  "task_fetchall_100_rows_ms": 50,
+  "task_fetchone_p95_ms": 5,
+  "findings_fetchall_500_rows_ms": 100,
+  "csv_export_mean_ms": 10,
+  "html_export_mean_ms": 30
+}

--- a/testing/test_python.sh
+++ b/testing/test_python.sh
@@ -21,7 +21,7 @@ python - <<'PY'
 import os
 import pytest
 
-exit_code = pytest.main(["testing/backend", "-q"])
+exit_code = pytest.main(["testing/backend", "-q", "-m", "not benchmark"])
 # Force process exit to avoid hangs from lingering background resources.
 os._exit(exit_code)
 PY


### PR DESCRIPTION
Hey @utksh1 .
## Description
Implements a production-grade, offline-first performance benchmark suite to measure, baseline, and prevent regressions in critical SecuScan performance areas. This PR covers:
- **Concurrent Task Creation**: Throughput and P50/P95 latencies for task start operations.
- **Parser & normalizer throughput**: Performance checks for report payload construction and finding normalization.
- **Database operations**: Read latencies for fetching multiple rows and singular key lookups.
- **Export execution**: CSV and HTML rendering latency performance.
- **SAT-3 slot saturation protection**: Explicit resource safety test checking instantaneous reject times.
- **CLI benchmark runner**: A standalone comparison script (`scripts/run_benchmarks.py`) that checks measurements against `thresholds.json`.

No third-party `pip` dependencies were added, relying solely on standard library utilities (`time`, `statistics`) and existing dev-requirements (`pytest`, `pytest-asyncio`).

## Related Issues
Closes #256

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- **Benchmark Suite**: Run locally with `python3 scripts/run_benchmarks.py` to confirm that all 11 performance metrics correctly query and pass against baseline thresholds.
- **Existing Test Verification**: Run `./testing/test_python.sh` to ensure all 349 existing test cases pass and benchmarks are correctly excluded from the main test suite.
- **Linting and Hygiene**: Ran `ruff check` and `git diff --check` to ensure no trailing whitespace or lint warnings.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

🟢 GSSoC note – I’m a GSSoC open source contributor. All checks are passing; please add the gssoc:approved label when merging.