### PR TITLE
feat: add endpoint rate-limit buckets

### DIFF
--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -60,6 +60,11 @@ class Settings(BaseSettings):
     max_concurrent_tasks: int = 3
     max_tasks_per_hour: int = 50
     max_requests_per_minute: int = 100
+    endpoint_rate_limit_window_seconds: int = 60
+    task_start_rate_limit: int = 20
+    vault_rate_limit: int = 30
+    report_download_rate_limit: int = 60
+    read_heavy_rate_limit: int = 120
     
     # Sandbox
     docker_enabled: bool = False

--- a/backend/secuscan/ratelimit.py
+++ b/backend/secuscan/ratelimit.py
@@ -4,8 +4,10 @@ Rate limiting for task execution
 
 from collections import defaultdict
 from datetime import datetime, timedelta
+from dataclasses import dataclass
 from typing import Tuple, Dict, List
 import asyncio
+import time
 
 
 class RateLimiter:
@@ -95,6 +97,80 @@ class ConcurrentTaskLimiter:
             return self.max_concurrent - len(self.running_tasks)
 
 
+@dataclass(frozen=True)
+class EndpointRateLimitDecision:
+    allowed: bool
+    limit: int
+    remaining: int
+    reset: int
+    retry_after: int
+
+
+class EndpointRateLimiter:
+    """Fixed-window limiter for endpoint and client-identity buckets."""
+
+    def __init__(self):
+        self.buckets: Dict[Tuple[str, str], Tuple[int, float]] = {}
+        self.lock = asyncio.Lock()
+
+    async def check(
+        self,
+        bucket: str,
+        identity: str,
+        limit: int,
+        window_seconds: int,
+    ) -> EndpointRateLimitDecision:
+        async with self.lock:
+            now = time.time()
+            window = max(1, int(window_seconds))
+            safe_limit = max(1, int(limit))
+            key = (bucket, identity)
+            count, reset_at = self.buckets.get(key, (0, now + window))
+
+            if now >= reset_at:
+                count = 0
+                reset_at = now + window
+
+            reset = int(reset_at)
+            retry_after = max(1, int(reset_at - now))
+
+            if count >= safe_limit:
+                return EndpointRateLimitDecision(
+                    allowed=False,
+                    limit=safe_limit,
+                    remaining=0,
+                    reset=reset,
+                    retry_after=retry_after,
+                )
+
+            count += 1
+            self.buckets[key] = (count, reset_at)
+            return EndpointRateLimitDecision(
+                allowed=True,
+                limit=safe_limit,
+                remaining=max(0, safe_limit - count),
+                reset=reset,
+                retry_after=retry_after,
+            )
+
+    async def reset(self, bucket: str | None = None, identity: str | None = None):
+        """Reset endpoint buckets, optionally scoped by bucket and identity."""
+        async with self.lock:
+            if bucket is None and identity is None:
+                self.buckets.clear()
+                return
+
+            keys_to_delete = [
+                key
+                for key in self.buckets
+                if (bucket is None or key[0] == bucket)
+                and (identity is None or key[1] == identity)
+            ]
+            for key in keys_to_delete:
+                del self.buckets[key]
+
+
 # Global instances
 rate_limiter = RateLimiter()
 concurrent_limiter = ConcurrentTaskLimiter()
+endpoint_rate_limiter = EndpointRateLimiter()

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -71,7 +71,7 @@ from .config import settings
 from .database import get_db
 from .plugins import get_plugin_manager, init_plugins
 from .executor import executor
-from .ratelimit import rate_limiter, concurrent_limiter
+from .ratelimit import rate_limiter, concurrent_limiter, endpoint_rate_limiter
 from .validation import validate_target, validate_task_start_payload
 from .reporting import reporting
 from .vault import VaultCrypto
@@ -80,6 +80,67 @@ from .workflows import scheduler
 from sse_starlette.sse import EventSourceResponse
 
 router = APIRouter(prefix="/api/v1")
+
+
+ENDPOINT_RATE_LIMITS = {
+    "task_start": lambda: settings.task_start_rate_limit,
+    "vault": lambda: settings.vault_rate_limit,
+    "report_download": lambda: settings.report_download_rate_limit,
+    "read_heavy": lambda: settings.read_heavy_rate_limit,
+}
+
+
+def _client_identity(request: Request) -> str:
+    api_key = request.headers.get("x-api-key")
+    if api_key:
+        return f"api-key:{api_key}"
+
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        token = auth_header[7:].strip()
+        if token:
+            return f"bearer:{token}"
+
+    host = request.client.host if request.client else "unknown"
+    return f"ip:{host}"
+
+
+def _apply_rate_limit_headers(response: Response, decision) -> None:
+    response.headers["X-RateLimit-Limit"] = str(decision.limit)
+    response.headers["X-RateLimit-Remaining"] = str(decision.remaining)
+    response.headers["X-RateLimit-Reset"] = str(decision.reset)
+
+
+async def enforce_endpoint_rate_limit(
+    request: Request,
+    response: Response,
+    bucket: str,
+) -> None:
+    limit = ENDPOINT_RATE_LIMITS[bucket]()
+    decision = await endpoint_rate_limiter.check(
+        bucket=bucket,
+        identity=_client_identity(request),
+        limit=limit,
+        window_seconds=settings.endpoint_rate_limit_window_seconds,
+    )
+    _apply_rate_limit_headers(response, decision)
+
+    if not decision.allowed:
+        headers = {
+            "Retry-After": str(decision.retry_after),
+            "X-RateLimit-Limit": str(decision.limit),
+            "X-RateLimit-Remaining": str(decision.remaining),
+            "X-RateLimit-Reset": str(decision.reset),
+        }
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "error": "rate_limit_exceeded",
+                "bucket": bucket,
+                "message": "Too many requests for this endpoint bucket.",
+            },
+            headers=headers,
+        )
 
 
 async def get_or_set_cached(key: str, builder):
@@ -195,10 +256,13 @@ async def start_task(
     request: TaskCreateRequest,
     background_tasks: BackgroundTasks,
     raw_request: Request,
+    response: Response,
 ):
     """
     Start a new scan task.
     """
+    await enforce_endpoint_rate_limit(raw_request, response, "task_start")
+
     # ── Payload size / field-length guard ─────────────────────────────────
     raw_body = await raw_request.body()
     ok, status_code, error_msg = validate_task_start_payload(raw_body, request.inputs)
@@ -342,8 +406,9 @@ async def stream_task_output(task_id: str):
     return EventSourceResponse(event_generator())
 
 @router.get("/task/{task_id}/report/csv")
-async def download_csv_report(task_id: str):
+async def download_csv_report(task_id: str, request: Request, response: Response):
     """Download task results as a CSV report."""
+    await enforce_endpoint_rate_limit(request, response, "report_download")
     db = await get_db()
     task_row = await db.fetchone(
         "SELECT id, plugin_id, tool_name, target, status, created_at, preset, inputs_json, command_used, structured_json FROM tasks WHERE id = ?",
@@ -377,8 +442,9 @@ async def download_csv_report(task_id: str):
     )
 
 @router.get("/task/{task_id}/report/html")
-async def download_html_report(task_id: str):
+async def download_html_report(task_id: str, request: Request, response: Response):
     """Download task results as an HTML report."""
+    await enforce_endpoint_rate_limit(request, response, "report_download")
     db = await get_db()
     task_row = await db.fetchone(
         "SELECT id, plugin_id, tool_name, target, status, created_at, preset, inputs_json, command_used, structured_json FROM tasks WHERE id = ?",
@@ -412,8 +478,9 @@ async def download_html_report(task_id: str):
     )
 
 @router.get("/task/{task_id}/report/pdf")
-async def download_pdf_report(task_id: str):
+async def download_pdf_report(task_id: str, request: Request, response: Response):
     """Download task results as a PDF report."""
+    await enforce_endpoint_rate_limit(request, response, "report_download")
     db = await get_db()
     task_row = await db.fetchone(
         "SELECT id, plugin_id, tool_name, target, status, created_at, preset, inputs_json, command_used, structured_json FROM tasks WHERE id = ?",
@@ -448,8 +515,9 @@ async def download_pdf_report(task_id: str):
 
 
 @router.get("/task/{task_id}/report/sarif")
-async def download_sarif_report(task_id: str):
+async def download_sarif_report(task_id: str, request: Request, response: Response):
     """Download task results as a SARIF report."""
+    await enforce_endpoint_rate_limit(request, response, "report_download")
     db = await get_db()
     task_row = await db.fetchone(
         "SELECT id, plugin_id, tool_name, target, status, created_at, preset, inputs_json, command_used, structured_json FROM tasks WHERE id = ?",
@@ -585,8 +653,9 @@ async def cancel_task(task_id: str):
 
 
 @router.get("/dashboard/summary")
-async def get_dashboard_summary():
+async def get_dashboard_summary(request: Request, response: Response):
     """Return aggregate dashboard data from the primary store, cached in Redis."""
+    await enforce_endpoint_rate_limit(request, response, "read_heavy")
 
     async def build():
         db = await get_db()
@@ -650,8 +719,9 @@ async def get_dashboard_summary():
 
 
 @router.get("/findings")
-async def get_findings():
+async def get_findings(request: Request, response: Response):
     """Return vulnerability findings."""
+    await enforce_endpoint_rate_limit(request, response, "read_heavy")
 
     async def build():
         db = await get_db()
@@ -662,8 +732,9 @@ async def get_findings():
 
 
 @router.get("/reports")
-async def get_reports():
+async def get_reports(request: Request, response: Response):
     """Return generated reports."""
+    await enforce_endpoint_rate_limit(request, response, "read_heavy")
 
     async def build():
         db = await get_db()
@@ -675,12 +746,15 @@ async def get_reports():
 
 @router.get("/tasks")
 async def list_tasks(
+    request: Request,
+    response: Response,
     page: int = 1,
     per_page: int = 25,
     plugin_id: Optional[str] = None,
     status: Optional[str] = None
 ):
     """List all tasks with pagination"""
+    await enforce_endpoint_rate_limit(request, response, "read_heavy")
     db = await get_db()
 
     # Build query
@@ -879,7 +953,8 @@ async def get_settings():
 
 
 @router.get("/vault")
-async def list_vault_secrets():
+async def list_vault_secrets(request: Request, response: Response):
+    await enforce_endpoint_rate_limit(request, response, "vault")
     db = await get_db()
     rows = await db.fetchall(
         "SELECT id, name, created_at, updated_at FROM credential_vault ORDER BY name ASC"
@@ -888,7 +963,8 @@ async def list_vault_secrets():
 
 
 @router.put("/vault/{name}")
-async def upsert_vault_secret(name: str, payload: Dict[str, str]):
+async def upsert_vault_secret(name: str, payload: Dict[str, str], request: Request, response: Response):
+    await enforce_endpoint_rate_limit(request, response, "vault")
     value = str(payload.get("value", ""))
     if not value:
         raise HTTPException(status_code=400, detail="Secret value is required")
@@ -913,7 +989,8 @@ async def upsert_vault_secret(name: str, payload: Dict[str, str]):
 
 
 @router.get("/vault/{name}")
-async def get_vault_secret(name: str):
+async def get_vault_secret(name: str, request: Request, response: Response):
+    await enforce_endpoint_rate_limit(request, response, "vault")
     db = await get_db()
     row = await db.fetchone("SELECT encrypted_value FROM credential_vault WHERE name = ?", (name,))
     if not row:
@@ -923,7 +1000,8 @@ async def get_vault_secret(name: str):
 
 
 @router.delete("/vault/{name}")
-async def delete_vault_secret(name: str):
+async def delete_vault_secret(name: str, request: Request, response: Response):
+    await enforce_endpoint_rate_limit(request, response, "vault")
     db = await get_db()
     await db.execute("DELETE FROM credential_vault WHERE name = ?", (name,))
     return {"name": name, "deleted": True}

--- a/docs/API.md
+++ b/docs/API.md
@@ -41,3 +41,46 @@ curl "http://localhost:8000/api/v1/tasks?page=2&per_page=10"
 # With filters
 curl "http://localhost:8000/api/v1/tasks?status=completed&plugin_id=nmap&page=1&per_page=20"
 """
+
+## Endpoint Rate Limits
+
+SecuScan applies independent rate-limit buckets per client identity. Identity is resolved from `X-API-Key`, then bearer authorization, then the direct client IP.
+
+Default buckets:
+
+| Bucket | Endpoints | Default |
+|--------|-----------|---------|
+| `task_start` | `POST /api/v1/task/start` | 20 requests / 60 seconds |
+| `vault` | `/api/v1/vault*` | 30 requests / 60 seconds |
+| `report_download` | `/api/v1/task/{task_id}/report/{format}` | 60 requests / 60 seconds |
+| `read_heavy` | `/api/v1/tasks`, `/api/v1/findings`, `/api/v1/reports`, `/api/v1/dashboard/summary` | 120 requests / 60 seconds |
+
+Every limited response includes:
+
+```text
+X-RateLimit-Limit: 20
+X-RateLimit-Remaining: 19
+X-RateLimit-Reset: 1780000000
+```
+
+When a bucket is exhausted, SecuScan returns `429 Too Many Requests` with `Retry-After`:
+
+```json
+{
+  "detail": {
+    "error": "rate_limit_exceeded",
+    "bucket": "task_start",
+    "message": "Too many requests for this endpoint bucket."
+  }
+}
+```
+
+Operators can tune limits with environment variables:
+
+```bash
+SECUSCAN_ENDPOINT_RATE_LIMIT_WINDOW_SECONDS=60
+SECUSCAN_TASK_START_RATE_LIMIT=20
+SECUSCAN_VAULT_RATE_LIMIT=30
+SECUSCAN_REPORT_DOWNLOAD_RATE_LIMIT=60
+SECUSCAN_READ_HEAVY_RATE_LIMIT=120
+```

--- a/testing/backend/conftest.py
+++ b/testing/backend/conftest.py
@@ -14,7 +14,7 @@ from backend.secuscan import database as database_module
 from backend.secuscan.database import init_db
 from backend.secuscan.main import app
 from backend.secuscan.plugins import init_plugins
-from backend.secuscan.ratelimit import concurrent_limiter, rate_limiter
+from backend.secuscan.ratelimit import concurrent_limiter, endpoint_rate_limiter, rate_limiter
 
 
 @pytest.fixture(autouse=True)
@@ -43,6 +43,7 @@ def test_client(setup_test_environment):
 
     async def setup():
         await rate_limiter.reset()
+        await endpoint_rate_limiter.reset()
         async with concurrent_limiter.lock:
             concurrent_limiter.running_tasks.clear()
         await init_db(settings.database_path)
@@ -55,6 +56,7 @@ def test_client(setup_test_environment):
 
     async def teardown():
         await rate_limiter.reset()
+        await endpoint_rate_limiter.reset()
         async with concurrent_limiter.lock:
             concurrent_limiter.running_tasks.clear()
         if database_module.db:

--- a/testing/backend/integration/test_endpoint_rate_limits.py
+++ b/testing/backend/integration/test_endpoint_rate_limits.py
@@ -1,0 +1,75 @@
+import time
+
+from backend.secuscan.config import settings
+
+
+def test_task_start_bucket_returns_clear_429(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "task_start_rate_limit", 1)
+    monkeypatch.setattr(settings, "endpoint_rate_limit_window_seconds", 60)
+
+    payload = {
+        "plugin_id": "missing_plugin",
+        "inputs": {"url": "http://127.0.0.1:8000"},
+        "consent_granted": True,
+    }
+
+    first = test_client.post("/api/v1/task/start", json=payload)
+    assert first.status_code == 404
+
+    second = test_client.post("/api/v1/task/start", json=payload)
+    assert second.status_code == 429
+    body = second.json()["detail"]
+    assert body["error"] == "rate_limit_exceeded"
+    assert body["bucket"] == "task_start"
+    assert "Retry-After" in second.headers
+    assert second.headers["X-RateLimit-Remaining"] == "0"
+
+
+def test_endpoint_buckets_are_independent(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "task_start_rate_limit", 1)
+    monkeypatch.setattr(settings, "vault_rate_limit", 2)
+    monkeypatch.setattr(settings, "endpoint_rate_limit_window_seconds", 60)
+
+    payload = {
+        "plugin_id": "missing_plugin",
+        "inputs": {"url": "http://127.0.0.1:8000"},
+        "consent_granted": True,
+    }
+
+    assert test_client.post("/api/v1/task/start", json=payload).status_code == 404
+    assert test_client.post("/api/v1/task/start", json=payload).status_code == 429
+
+    vault_response = test_client.get("/api/v1/vault")
+    assert vault_response.status_code == 200
+    assert vault_response.headers["X-RateLimit-Limit"] == "2"
+    assert vault_response.headers["X-RateLimit-Remaining"] == "1"
+
+
+def test_endpoint_bucket_resets_after_window(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "read_heavy_rate_limit", 1)
+    monkeypatch.setattr(settings, "endpoint_rate_limit_window_seconds", 1)
+
+    first = test_client.get("/api/v1/tasks")
+    assert first.status_code == 200
+    assert first.headers["X-RateLimit-Remaining"] == "0"
+
+    limited = test_client.get("/api/v1/tasks")
+    assert limited.status_code == 429
+
+    time.sleep(1.1)
+
+    reset = test_client.get("/api/v1/tasks")
+    assert reset.status_code == 200
+    assert reset.headers["X-RateLimit-Remaining"] == "0"
+
+
+def test_api_key_identity_has_separate_bucket(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "read_heavy_rate_limit", 1)
+    monkeypatch.setattr(settings, "endpoint_rate_limit_window_seconds", 60)
+
+    assert test_client.get("/api/v1/tasks").status_code == 200
+    assert test_client.get("/api/v1/tasks").status_code == 429
+
+    keyed = test_client.get("/api/v1/tasks", headers={"X-API-Key": "ci-user"})
+    assert keyed.status_code == 200
+    assert keyed.headers["X-RateLimit-Limit"] == "1"


### PR DESCRIPTION
## Summary
- add fixed-window endpoint rate limiting keyed by endpoint bucket and client identity
- add configurable buckets for task starts, vault operations, report downloads, and read-heavy endpoints
- return clear 429 responses with Retry-After and X-RateLimit headers
- document the new settings and add integration coverage for independent buckets, reset behavior, and API-key identity separation

Fixes #223

## Verification
- python -m pytest testing/backend/integration/test_endpoint_rate_limits.py testing/backend/unit/test_concurrent_limiter.py testing/backend/integration/test_routes.py
- python -m ruff check backend/secuscan/ratelimit.py backend/secuscan/routes.py backend/secuscan/config.py testing/backend/conftest.py testing/backend/integration/test_endpoint_rate_limits.py
- git diff --check