### PR TITLE
fix: add missing quote and backslash chars to sanitize_input to preve…

### DIFF
--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -198,7 +198,7 @@ def sanitize_input(value: str) -> str:
         Sanitized value
     """
     # Remove shell metacharacters
-    dangerous_chars = [';', '|', '&', '$', '`', '(', ')', '<', '>', '\n', '\r']
+    dangerous_chars = [';', '|', '&', '$', '`', '(', ')', '<', '>', '\n', '\r', "'", '"', '\\', '!', '{', '}']
     for char in dangerous_chars:
         value = value.replace(char, '')
     


### PR DESCRIPTION
##  fix: patch command injection bypass in `sanitize_input()`

Closes #309

### Problem
`sanitize_input()` was missing critical shell characters from its blocklist, allowing attackers to bypass sanitization using quoted strings or backslash sequences.

### Changes
- Updated `dangerous_chars` in `backend/secuscan/validation.py` to include:
  - `'` — single quote (breaks out of quoted strings)
  - `"` — double quote (breaks out of double-quoted strings)
  - `\` — backslash (escapes characters)
  - `!` — bash history expansion
  - `{` `}` — brace expansion

### Before / After
```python
# Before
dangerous_chars = [';', '|', '&', '$', '`', '(', ')', '<', '>', '\n', '\r']

# After
dangerous_chars = [';', '|', '&', '$', '`', '(', ')', '<', '>', '\n', '\r', "'", '"', '\\', '!', '{', '}']
```

### Security Impact
**Severity: High** — Attackers could bypass sanitization and inject shell commands using quoted strings or backslash sequences on any input passed to shell commands.