### PR TITLE
fix(executor): clamp user-supplied timeout to settings.sandbox_timeout

### DIFF
--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -558,7 +558,12 @@ class TaskExecutor:
             return f"Execution error: {str(e)}", -1
 
     def _resolve_execution_timeout(self, inputs: Dict[str, Any]) -> int:
-        """Resolve per-task process timeout from plugin inputs."""
+        """Resolve per-task process timeout from plugin inputs.
+
+        The caller may request a shorter timeout than the operator cap, but
+        never a longer one. ``settings.sandbox_timeout`` is the hard ceiling
+        and is always enforced regardless of what the client supplies.
+        """
         for key in ("max_scan_time", "timeout"):
             raw_value = inputs.get(key)
             try:
@@ -566,7 +571,7 @@ class TaskExecutor:
             except (TypeError, ValueError):
                 continue
             if timeout > 0:
-                return timeout
+                return min(timeout, settings.sandbox_timeout)
         return settings.sandbox_timeout
 
     def _classify_command_result(self, plugin, output: str, exit_code: int) -> tuple[str, Optional[str]]:

--- a/testing/backend/unit/test_executor.py
+++ b/testing/backend/unit/test_executor.py
@@ -197,6 +197,38 @@ def test_classify_command_result_fails_on_undefined_flag_even_with_zero_exit(set
     assert error is not None
 
 
+def test_resolve_execution_timeout_clamps_requested_timeout(monkeypatch):
+    monkeypatch.setattr(settings, "sandbox_timeout", 600)
+
+    executor = TaskExecutor()
+
+    assert executor._resolve_execution_timeout({"timeout": 9999}) == 600
+
+
+def test_resolve_execution_timeout_allows_shorter_requested_timeout(monkeypatch):
+    monkeypatch.setattr(settings, "sandbox_timeout", 600)
+
+    executor = TaskExecutor()
+
+    assert executor._resolve_execution_timeout({"timeout": 120}) == 120
+
+
+def test_resolve_execution_timeout_ignores_invalid_values(monkeypatch):
+    monkeypatch.setattr(settings, "sandbox_timeout", 600)
+
+    executor = TaskExecutor()
+
+    assert executor._resolve_execution_timeout({"timeout": "invalid"}) == 600
+
+
+def test_resolve_execution_timeout_prefers_max_scan_time(monkeypatch):
+    monkeypatch.setattr(settings, "sandbox_timeout", 600)
+
+    executor = TaskExecutor()
+
+    assert executor._resolve_execution_timeout({"max_scan_time": 90, "timeout": 120}) == 90
+
+
 @pytest.mark.asyncio
 async def test_execute_task_sets_cancelled_status_in_db(setup_test_environment):
     """


### PR DESCRIPTION
## Description

Fixes #311

`_resolve_execution_timeout()` in `backend/secuscan/executor.py` accepted any positive integer from task inputs as the subprocess timeout. This allowed a caller to silently override the operator-configured `settings.sandbox_timeout` (default 600 s) with an arbitrarily large value. A single request with `max_scan_time=2147483647` could hold a worker thread for years and starve every subsequent scan of a concurrency slot.

### Root cause

```python
# Before
if timeout > 0:
    return timeout          # no upper bound applied
```

### Fix

```python
# After
if timeout > 0:
    return min(timeout, settings.sandbox_timeout)   # operator cap enforced
```

Callers may still request a *shorter* timeout than the configured default; they cannot exceed it. The operator retains full control via `settings.sandbox_timeout`.

## Related Issues

Closes #311

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual verification: passing `max_scan_time=9999999` in task inputs now returns `600` (the default `sandbox_timeout`) rather than `9999999`.
- Passing `max_scan_time=30` correctly returns `30` (shorter than cap, honoured).
- Passing no timeout key returns `settings.sandbox_timeout` unchanged.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.

---
**GSSoC '26**