### PR TITLE
fix(ratelimit): key RateLimiter history on (client_id, plugin_id) to prevent global quota starvation

### DIFF
--- a/backend/secuscan/ratelimit.py
+++ b/backend/secuscan/ratelimit.py
@@ -21,42 +21,55 @@ class RateLimiter:
     async def can_execute(
         self,
         plugin_id: str,
-        max_per_hour: int = 50
+        max_per_hour: int = 50,
+        client_id: str = "global",
     ) -> Tuple[bool, str]:
         """
         Check if a task can be executed based on rate limits.
 
+        Each (client_id, plugin_id) pair has its own independent quota so
+        one client exhausting their limit does not block other clients from
+        running the same plugin.
+
         Args:
             plugin_id: Plugin identifier
-            max_per_hour: Maximum tasks per hour for this plugin
+            max_per_hour: Maximum tasks per hour for this (client, plugin) pair
+            client_id: Opaque client identifier (IP, API key, user ID, etc.).
+                       Defaults to ``"global"`` for backwards-compatible callers
+                       that do not supply a client identity.
 
         Returns:
             Tuple of (allowed, error_message)
         """
+        bucket = f"{client_id}:{plugin_id}"
+
         async with self.lock:
             now = datetime.now()
             hour_ago = now - timedelta(hours=1)
 
-            # Clean old entries
-            self.task_history[plugin_id] = [
-                ts for ts in self.task_history[plugin_id]
+            # Clean old entries for this bucket
+            self.task_history[bucket] = [
+                ts for ts in self.task_history[bucket]
                 if ts > hour_ago
             ]
 
-            recent_count = len(self.task_history[plugin_id])
+            recent_count = len(self.task_history[bucket])
 
             if recent_count >= max_per_hour:
                 return False, f"Rate limit exceeded: {recent_count}/{max_per_hour} per hour"
 
             # Record this execution
-            self.task_history[plugin_id].append(now)
+            self.task_history[bucket].append(now)
             return True, ""
 
     async def reset(self, plugin_id: str = None):
-        """Reset rate limits for a plugin or all plugins"""
+        """Reset rate limits for a plugin (all clients) or all buckets"""
         async with self.lock:
             if plugin_id:
-                self.task_history[plugin_id] = []
+                # Remove every bucket that ends with :<plugin_id>
+                keys_to_clear = [k for k in self.task_history if k.endswith(f":{plugin_id}")]
+                for k in keys_to_clear:
+                    self.task_history[k] = []
             else:
                 self.task_history.clear()
 

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -74,7 +74,8 @@ from .executor import executor
 from .ratelimit import (
     rate_limiter, concurrent_limiter,
     task_start_limiter, vault_limiter,
-    report_download_limiter, read_heavy_limiter
+    report_download_limiter, read_heavy_limiter,
+    resolve_client_identity,
 )
 from .validation import validate_target, validate_task_start_payload
 from .reporting import reporting
@@ -237,10 +238,13 @@ async def start_task(
                 logger.warning(f"Task start failed: Target validation failed for '{target}': {error_msg}")
                 raise HTTPException(status_code=400, detail=error_msg)
 
-    # Check rate limits
+    # Check rate limits per (client, plugin) so one client cannot exhaust
+    # the quota for all other users of the same plugin.
+    client_id = resolve_client_identity(raw_request)
     can_execute, error_msg = await rate_limiter.can_execute(
         request.plugin_id,
-        plugin.safety.get("rate_limit", {}).get("max_per_hour", settings.max_tasks_per_hour)
+        plugin.safety.get("rate_limit", {}).get("max_per_hour", settings.max_tasks_per_hour),
+        client_id=client_id,
     )
 
     if not can_execute:

--- a/testing/backend/unit/test_endpoint_rate_limiter.py
+++ b/testing/backend/unit/test_endpoint_rate_limiter.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from backend.secuscan.config import settings
 from backend.secuscan.ratelimit import (
     EndpointRateLimiter,
+    RateLimiter,
     resolve_client_identity,
     reset_all_endpoint_limiters,
     task_start_limiter,
@@ -212,3 +213,107 @@ def test_route_level_integration_and_independent_buckets(test_client, monkeypatc
     assert resp_vault1.status_code == 200
     assert resp_vault1.headers["X-RateLimit-Limit"] == "2"
     assert resp_vault1.headers["X-RateLimit-Remaining"] == "1"
+
+
+# ── RateLimiter per-client keying tests ───────────────────────────────────────
+
+
+class TestRateLimiterClientKeying:
+    """Tests for the task-execution RateLimiter with per-(client_id, plugin_id) buckets."""
+
+    @pytest.mark.asyncio
+    async def test_independent_client_buckets(self):
+        """Two different clients sharing the same plugin have independent quotas.
+
+        Exhausting client_A's allowance must not prevent client_B from executing
+        the same plugin.
+        """
+        limiter = RateLimiter()
+        plugin_id = "nmap"
+        max_per_hour = 2
+
+        # Drain client_A's quota entirely
+        for _ in range(max_per_hour):
+            allowed, _ = await limiter.can_execute(plugin_id, max_per_hour=max_per_hour, client_id="client_A")
+            assert allowed
+
+        # client_A is now blocked
+        allowed_a, msg_a = await limiter.can_execute(plugin_id, max_per_hour=max_per_hour, client_id="client_A")
+        assert not allowed_a
+        assert "Rate limit exceeded" in msg_a
+
+        # client_B must still be allowed despite client_A being blocked
+        allowed_b, msg_b = await limiter.can_execute(plugin_id, max_per_hour=max_per_hour, client_id="client_B")
+        assert allowed_b, f"client_B was blocked unexpectedly: {msg_b}"
+
+    @pytest.mark.asyncio
+    async def test_reset_plugin_clears_all_client_buckets(self):
+        """reset(plugin_id) must clear the history for every client that used that plugin."""
+        limiter = RateLimiter()
+        plugin_id = "nmap"
+        max_per_hour = 1
+
+        # Exhaust both clients for the same plugin
+        await limiter.can_execute(plugin_id, max_per_hour=max_per_hour, client_id="client_A")
+        await limiter.can_execute(plugin_id, max_per_hour=max_per_hour, client_id="client_B")
+
+        # Confirm both are blocked before reset
+        allowed_a, _ = await limiter.can_execute(plugin_id, max_per_hour=max_per_hour, client_id="client_A")
+        allowed_b, _ = await limiter.can_execute(plugin_id, max_per_hour=max_per_hour, client_id="client_B")
+        assert not allowed_a
+        assert not allowed_b
+
+        # Reset quota for the plugin (all clients)
+        await limiter.reset(plugin_id)
+
+        # Both clients must be allowed again after reset
+        allowed_a_after, _ = await limiter.can_execute(plugin_id, max_per_hour=max_per_hour, client_id="client_A")
+        allowed_b_after, _ = await limiter.can_execute(plugin_id, max_per_hour=max_per_hour, client_id="client_B")
+        assert allowed_a_after, "client_A should be allowed after reset"
+        assert allowed_b_after, "client_B should be allowed after reset"
+
+    @pytest.mark.asyncio
+    async def test_reset_plugin_does_not_affect_other_plugins(self):
+        """reset(plugin_id) must only clear buckets for that specific plugin."""
+        limiter = RateLimiter()
+        max_per_hour = 1
+
+        # Exhaust quotas for two different plugins under the same client
+        await limiter.can_execute("nmap", max_per_hour=max_per_hour, client_id="client_A")
+        await limiter.can_execute("gobuster", max_per_hour=max_per_hour, client_id="client_A")
+
+        # Reset only nmap
+        await limiter.reset("nmap")
+
+        # nmap bucket cleared: request should be allowed
+        allowed_nmap, _ = await limiter.can_execute("nmap", max_per_hour=max_per_hour, client_id="client_A")
+        assert allowed_nmap, "nmap bucket should be cleared after reset"
+
+        # gobuster bucket untouched: request should still be blocked
+        allowed_gobuster, _ = await limiter.can_execute("gobuster", max_per_hour=max_per_hour, client_id="client_A")
+        assert not allowed_gobuster, "gobuster bucket should remain exhausted"
+
+    @pytest.mark.asyncio
+    async def test_backward_compatible_global_bucket(self):
+        """Callers that omit client_id default to the 'global' bucket.
+
+        This ensures no regression for existing call sites that do not pass a
+        client identity.
+        """
+        limiter = RateLimiter()
+        plugin_id = "nikto"
+        max_per_hour = 2
+
+        # Call without explicit client_id (uses default "global")
+        allowed_1, _ = await limiter.can_execute(plugin_id, max_per_hour=max_per_hour)
+        allowed_2, _ = await limiter.can_execute(plugin_id, max_per_hour=max_per_hour)
+        allowed_3, msg = await limiter.can_execute(plugin_id, max_per_hour=max_per_hour)
+
+        assert allowed_1
+        assert allowed_2
+        assert not allowed_3, "Global bucket should be rate-limited after quota is exhausted"
+        assert "Rate limit exceeded" in msg
+
+        # Verify the key in task_history is the expected global bucket format
+        async with limiter.lock:
+            assert f"global:{plugin_id}" in limiter.task_history


### PR DESCRIPTION
## Description

Fixes #312

`RateLimiter.can_execute()` maintained a single history list keyed only on `plugin_id`. This meant the hourly quota for a plugin was shared globally across all callers. One client sending 50 nmap scans blocked every other user from running nmap for the rest of the hour, making the rate limiter a denial-of-service vector rather than a fair throttle.

### Root cause

```python
# Before: one global bucket per plugin
self.task_history[plugin_id] = [...]
```

### Fix

```python
# After: one bucket per (client, plugin) pair
bucket = f"{client_id}:{plugin_id}"
self.task_history[bucket] = [...]
```

### Changes

**`backend/secuscan/ratelimit.py`**
- Added `client_id: str = "global"` parameter to `can_execute()`. The history bucket key is now `f"{client_id}:{plugin_id}"`.
- Updated `reset(plugin_id=...)` to clear all buckets ending with `:{plugin_id}` rather than a single exact key.
- Default `client_id="global"` preserves backwards compatibility for any caller that does not supply an identity.

**`backend/secuscan/routes.py`**
- Added `resolve_client_identity` to the ratelimit import.
- Extracted `client_id = resolve_client_identity(raw_request)` (which resolves API key, user ID, or IP in priority order using the existing helper) before the `can_execute` call.
- Passed `client_id=client_id` to `can_execute()`.

## Related Issues

Closes #312

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Two separate clients sending 50 requests for the same plugin: client A reaching the limit no longer blocks client B.
- A single client still cannot exceed `max_per_hour` for a given plugin.
- `reset(plugin_id="nmap")` clears buckets for all clients for that plugin.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.

---
**GSSoC '26**