### PR TITLE
fix: redact sensitive task inputs from API responses

### DIFF
--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -623,7 +623,6 @@ class TaskExecutor:
             "exit_code": task_row["exit_code"],
             "error_message": task_row["error_message"],
             "preset": task_row["preset"],
-            "inputs": json.loads(task_row["inputs_json"] or "{}"),
             "queue_position": queue_position,
             "pending_count": pending_count,
         }

--- a/backend/secuscan/redaction.py
+++ b/backend/secuscan/redaction.py
@@ -202,6 +202,62 @@ def redact_dict(data: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+# Keys whose values are unconditionally redacted in task inputs regardless of
+# value format.  Matched case-insensitively against the full key name.
+_SENSITIVE_INPUT_KEYS: frozenset[str] = frozenset({
+    "api_key",
+    "apikey",
+    "api_secret",
+    "secret",
+    "secret_key",
+    "password",
+    "passwd",
+    "pass",
+    "pwd",
+    "token",
+    "access_token",
+    "refresh_token",
+    "auth",
+    "auth_token",
+    "authorization",
+    "credentials",
+    "private_key",
+    "client_secret",
+    "webhook_secret",
+    "signing_key",
+    "encryption_key",
+})
+
+
+def redact_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
+    """
+    Redact sensitive values from a task inputs dict before it is included in
+    any API response.
+
+    Keys whose names appear in ``_SENSITIVE_INPUT_KEYS`` (case-insensitive) have
+    their value replaced with ``[REDACTED]``.  All other string values are also
+    passed through the pattern-based ``redact()`` function so that accidentally
+    embedded secrets (e.g. a token pasted into a ``target`` field) are caught as
+    well.  Non-string values are left untouched.
+
+    Args:
+        inputs: Parsed task inputs dict (from ``inputs_json`` column).
+
+    Returns:
+        A new dict with sensitive values replaced by ``[REDACTED]``.
+    """
+    if not isinstance(inputs, dict):
+        return inputs
+
+    result: dict[str, Any] = {}
+    for key, value in inputs.items():
+        if key.lower() in _SENSITIVE_INPUT_KEYS:
+            result[key] = REDACTED
+        else:
+            result[key] = _redact_value(value)
+    return result
+
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -71,6 +71,7 @@ from .config import settings
 from .database import get_db
 from .plugins import get_plugin_manager, init_plugins
 from .executor import executor
+from .redaction import redact_inputs
 from .ratelimit import (
     rate_limiter, concurrent_limiter,
     task_start_limiter, vault_limiter,
@@ -557,7 +558,7 @@ async def get_task_result(task_id: str):
         "duration_seconds": task_row["duration_seconds"],
         "status": task_row["status"],
         "preset": task_row["preset"],
-        "inputs": json.loads(task_row["inputs_json"] or "{}"),
+        "inputs": redact_inputs(json.loads(task_row["inputs_json"] or "{}")),
         "summary": summary,
         "severity_counts": severity_counts,
         "findings": findings,
@@ -735,7 +736,7 @@ async def list_tasks(
     for t in tasks_list:
         if "id" in t:
             t["task_id"] = t.pop("id")
-        t["inputs"] = t.pop("inputs_json", {})
+        t["inputs"] = redact_inputs(t.pop("inputs_json", {}) or {})
 
     total_pages = (total + per_page - 1) // per_page if per_page > 0 else 0
 

--- a/testing/backend/integration/test_redact_inputs_routes.py
+++ b/testing/backend/integration/test_redact_inputs_routes.py
@@ -1,0 +1,117 @@
+"""
+Integration tests verifying that task inputs containing sensitive values
+(api_key, token, password, private_key) are never returned in plain text
+by the list, status, or result API endpoints.
+"""
+
+import time
+from unittest.mock import patch
+
+from backend.secuscan.models import TaskStatus
+
+
+SENSITIVE_INPUTS = {
+    "url": "http://127.0.0.1:8000",
+    "api_key": "supersecret_api_key_value",
+    "token": "supersecret_token_value_1234",
+    "password": "supersecret_password_99",
+    "private_key": "supersecret_private_key_pem",
+}
+
+SENSITIVE_VALUES = [
+    SENSITIVE_INPUTS["api_key"],
+    SENSITIVE_INPUTS["token"],
+    SENSITIVE_INPUTS["password"],
+    SENSITIVE_INPUTS["private_key"],
+]
+
+
+def _start_task_with_sensitive_inputs(test_client) -> str:
+    """Start a task carrying all four sensitive input fields and return the task_id."""
+    with patch("backend.secuscan.executor.TaskExecutor._execute_command") as mock_exec:
+        mock_exec.return_value = ("Mocked output", 0)
+
+        payload = {
+            "plugin_id": "http_inspector",
+            "preset": "quick",
+            "inputs": SENSITIVE_INPUTS,
+            "consent_granted": True,
+        }
+        resp = test_client.post("/api/v1/task/start", json=payload)
+        assert resp.status_code == 200, f"Task start failed: {resp.text}"
+        task_id = resp.json()["task_id"]
+
+        # Give the executor time to complete
+        time.sleep(0.3)
+
+    return task_id
+
+
+def _assert_no_secrets_in_response(data: dict | list | str, label: str = ""):
+    """Recursively assert that none of the known secret strings appear in data."""
+    text = str(data)
+    for secret in SENSITIVE_VALUES:
+        assert secret not in text, (
+            f"Secret '{secret}' was found in {label} response body.\n"
+            f"Full response: {text}"
+        )
+
+
+class TestRedactInputsRoutes:
+    """Route-level tests proving inputs redaction is applied consistently."""
+
+    def test_status_endpoint_does_not_expose_sensitive_inputs(self, test_client):
+        """GET /api/v1/task/{id}/status must not return raw api_key, token, password, or private_key."""
+        task_id = _start_task_with_sensitive_inputs(test_client)
+
+        resp = test_client.get(f"/api/v1/task/{task_id}/status")
+        assert resp.status_code == 200
+        _assert_no_secrets_in_response(resp.json(), label="status")
+
+    def test_result_endpoint_does_not_expose_sensitive_inputs(self, test_client):
+        """GET /api/v1/task/{id}/result must not return raw sensitive input values."""
+        task_id = _start_task_with_sensitive_inputs(test_client)
+
+        resp = test_client.get(f"/api/v1/task/{task_id}/result")
+        assert resp.status_code == 200
+        _assert_no_secrets_in_response(resp.json(), label="result")
+
+    def test_list_endpoint_does_not_expose_sensitive_inputs(self, test_client):
+        """GET /api/v1/tasks must not expose raw sensitive input values in the task list."""
+        _start_task_with_sensitive_inputs(test_client)
+
+        resp = test_client.get("/api/v1/tasks")
+        assert resp.status_code == 200
+        _assert_no_secrets_in_response(resp.json(), label="task list")
+
+    def test_status_endpoint_returns_redacted_placeholder(self, test_client):
+        """The status response inputs field must contain [REDACTED] for sensitive keys."""
+        task_id = _start_task_with_sensitive_inputs(test_client)
+
+        resp = test_client.get(f"/api/v1/task/{task_id}/status")
+        assert resp.status_code == 200
+        body = resp.json()
+
+        inputs = body.get("inputs", {})
+        if inputs:
+            # If the response includes an inputs field, sensitive keys must be [REDACTED]
+            for key in ("api_key", "token", "password", "private_key"):
+                if key in inputs:
+                    assert inputs[key] == "[REDACTED]", (
+                        f"Expected [REDACTED] for key '{key}', got: {inputs[key]!r}"
+                    )
+
+    def test_non_sensitive_inputs_pass_through_unchanged(self, test_client):
+        """The 'url' (non-sensitive) input value must still be accessible in responses."""
+        task_id = _start_task_with_sensitive_inputs(test_client)
+
+        resp = test_client.get(f"/api/v1/task/{task_id}/status")
+        assert resp.status_code == 200
+        body = resp.json()
+
+        # url is not a sensitive key and must not be redacted
+        inputs = body.get("inputs", {})
+        if inputs and "url" in inputs:
+            assert inputs["url"] == SENSITIVE_INPUTS["url"], (
+                f"Non-sensitive 'url' value was unexpectedly altered: {inputs['url']!r}"
+            )

--- a/testing/backend/unit/test_redaction.py
+++ b/testing/backend/unit/test_redaction.py
@@ -8,7 +8,7 @@ or directly:
 """
 
 import pytest
-from backend.secuscan.redaction import redact, redact_dict, REDACTED
+from backend.secuscan.redaction import redact, redact_dict, redact_inputs, REDACTED
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -272,3 +272,86 @@ class TestMultipleSecretsOnOneLine:
         result = redact(text)
         assert_redacted(result, "abc123def456")
         assert_redacted(result, "hunter2secret")
+
+
+# ── redact_inputs ─────────────────────────────────────────────────────────────
+
+
+class TestRedactInputs:
+    """Tests for redact_inputs(), which redacts sensitive keys in task input dicts."""
+
+    def test_api_key_is_redacted(self):
+        inputs = {"api_key": "supersecretkey123456", "target": "example.com"}
+        result = redact_inputs(inputs)
+        assert result["api_key"] == REDACTED
+        assert result["target"] == "example.com"
+
+    def test_token_is_redacted(self):
+        inputs = {"token": "ghp_16C7e42F292c6912E7710c838347Ae178B4a", "url": "http://example.com"}
+        result = redact_inputs(inputs)
+        assert result["token"] == REDACTED
+        assert result["url"] == "http://example.com"
+
+    def test_password_is_redacted(self):
+        inputs = {"password": "hunter2verysecure", "username": "admin"}
+        result = redact_inputs(inputs)
+        assert result["password"] == REDACTED
+        assert result["username"] == "admin"
+
+    def test_private_key_is_redacted(self):
+        inputs = {"private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----"}
+        result = redact_inputs(inputs)
+        assert result["private_key"] == REDACTED
+
+    def test_multiple_sensitive_keys_all_redacted(self):
+        inputs = {
+            "api_key": "key_abc123",
+            "password": "p@ssw0rd99",
+            "token": "tok_xyz789",
+            "private_key": "pk_value",
+            "target": "192.168.1.1",
+        }
+        result = redact_inputs(inputs)
+        assert result["api_key"] == REDACTED
+        assert result["password"] == REDACTED
+        assert result["token"] == REDACTED
+        assert result["private_key"] == REDACTED
+        assert result["target"] == "192.168.1.1"
+
+    def test_key_matching_is_case_insensitive(self):
+        inputs = {"API_KEY": "secretvalue", "Token": "another_secret"}
+        result = redact_inputs(inputs)
+        assert result["API_KEY"] == REDACTED
+        assert result["Token"] == REDACTED
+
+    def test_non_sensitive_string_passes_through_pattern_redaction(self):
+        """Non-sensitive string values are still run through the pattern redactor."""
+        inputs = {"description": "api_key=leaked123456789 found in output"}
+        result = redact_inputs(inputs)
+        assert "leaked123456789" not in result["description"]
+        assert REDACTED in result["description"]
+
+    def test_non_string_values_are_untouched(self):
+        inputs = {"count": 5, "enabled": True, "score": 9.8, "target": "host.example.com"}
+        result = redact_inputs(inputs)
+        assert result["count"] == 5
+        assert result["enabled"] is True
+        assert result["score"] == 9.8
+        assert result["target"] == "host.example.com"
+
+    def test_empty_dict_returns_empty_dict(self):
+        assert redact_inputs({}) == {}
+
+    def test_non_dict_input_is_returned_unchanged(self):
+        assert redact_inputs("not-a-dict") == "not-a-dict"  # type: ignore[arg-type]
+
+    def test_access_token_key_is_redacted(self):
+        inputs = {"access_token": "ya29.a0AfH6SMB", "scope": "read"}
+        result = redact_inputs(inputs)
+        assert result["access_token"] == REDACTED
+        assert result["scope"] == "read"
+
+    def test_secret_key_is_redacted(self):
+        inputs = {"secret_key": "aws_secret_abc123456789012345678901234567890"}
+        result = redact_inputs(inputs)
+        assert result["secret_key"] == REDACTED


### PR DESCRIPTION
## Summary

Fixes #315

Task inputs stored in `inputs_json` (fields like `api_key`, `password`, `token`, `secret`, etc.) were returned verbatim in two API endpoints, exposing credentials to any authenticated caller who queried a task they had access to.

### Root cause

`get_task_result()` in `routes.py` and `list_tasks()` both included `"inputs": json.loads(task_row["inputs_json"] or "{}")` directly in the response without any scrubbing. `get_task_status()` in `executor.py` had the same pattern.

### Changes

- **`redaction.py`**: Added `redact_inputs(inputs: dict) -> dict`. It applies two layers of defence:
  1. Any key whose name is in a denylist (`api_key`, `password`, `token`, `secret`, `credentials`, `auth`, `authorization`, `private_key`, `client_secret`, etc.) has its value unconditionally replaced with `[REDACTED]` regardless of value format.
  2. All other string values are passed through the existing pattern-based `redact()` function to catch secrets accidentally embedded in non-sensitive-named fields (e.g. a token pasted into `target`).

- **`executor.py`**: Removed `"inputs"` from `get_task_status()` entirely. The status polling endpoint exists only to track progress (queued/running/done) and has no legitimate reason to echo back the raw inputs payload.

- **`routes.py`**: Applied `redact_inputs()` to the `"inputs"` field in both `get_task_result()` and `list_tasks()`. Safe fields like `target` or `preset` are still returned; credential-bearing keys are scrubbed.

## Test plan

- [ ] Start a task with `api_key`, `password`, and `token` in inputs
- [ ] `GET /tasks/{id}/result` - verify those keys return `[REDACTED]`, `target` remains intact
- [ ] `GET /tasks` (list) - same verification on the list response
- [ ] `GET /tasks/{id}/status` - verify `inputs` key is absent entirely
- [ ] Non-sensitive keys (e.g. `target`, `threads`) still appear with their real values

---

Could you please add the appropriate labels to this PR? Thank you.