### PR TITLE
Fix safe mode validation for hostnames and URL targets

### DIFF
--- a/backend/secuscan/cli.py
+++ b/backend/secuscan/cli.py
@@ -48,9 +48,10 @@ async def run_scan(target: str, plugin_id: str, output_format: str, output_file:
         return 1
 
     # Create task
-    inputs = {"target": target}
+    safe_mode = bool(settings.safe_mode_default)
+    inputs = {"target": target, "safe_mode": safe_mode}
     try:
-        task_id = await executor.create_task(plugin_id, inputs, consent_granted=True)
+        task_id = await executor.create_task(plugin_id, inputs, safe_mode=safe_mode, consent_granted=True)
     except Exception as e:
         print(f"Error creating task: {e}")
         return 1

--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -36,6 +36,9 @@ class Settings(BaseSettings):
 
     # Security
     safe_mode_default: bool = True
+    dns_resolution_timeout_seconds: float = 1.5
+    dns_cache_ttl_seconds: int = 60
+    dns_rebind_check: bool = True
     require_consent: bool = True
     allow_loopback_scans: bool = True
     allowed_networks: List[str] = ["127.0.0.1", "192.168.*.*", "10.*.*.*", "172.16.*.*"]

--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -140,6 +140,7 @@ class TaskExecutor:
         self,
         plugin_id: str,
         inputs: Dict[str, Any],
+        safe_mode: bool,
         preset: Optional[str] = None,
         consent_granted: bool = False
     ) -> str:
@@ -187,7 +188,7 @@ class TaskExecutor:
                 TaskStatus.QUEUED.value,
                 ScanPhase.QUEUED.value,
                 consent_granted,
-                inputs.get("safe_mode", True)
+                bool(safe_mode)
             )
         )
         

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -2,7 +2,7 @@
 API routes for SecuScan backend
 """
 
-from fastapi import APIRouter, HTTPException, BackgroundTasks, Response, Request, Depends
+from fastapi import APIRouter, HTTPException, BackgroundTasks, Response, Request, Depends, Body
 from fastapi.responses import JSONResponse
 from typing import Any, Optional, List, Dict, Callable
 import json
@@ -264,13 +264,31 @@ async def start_task(
         logger.warning(f"Task start failed: Plugin not found: {request.plugin_id}")
         raise HTTPException(status_code=404, detail=f"Plugin not found: {request.plugin_id}")
 
-    if target := request.inputs.get("target"):
-        safe_mode = request.inputs.get("safe_mode", settings.safe_mode_default)
+    # Server-controlled safe mode: never trust client-supplied `inputs.safe_mode`.
+    safe_mode = bool(settings.safe_mode_default)
+
+    # Ensure downstream scanners/plugins see the effective safe-mode, but prevent client override.
+    effective_inputs = dict(request.inputs or {})
+    if "safe_mode" in effective_inputs:
+        effective_inputs.pop("safe_mode", None)
+    effective_inputs["safe_mode"] = safe_mode
+
+    if target := effective_inputs.get("target"):
         target_str = str(target)
         should_validate_target = plugin.category != "code" and not is_filesystem_target(target_str)
 
         if should_validate_target:
-            is_valid, error_msg = validate_target(target_str, safe_mode)
+            try:
+                is_valid, error_msg = await asyncio.wait_for(
+                    asyncio.to_thread(validate_target, target_str, safe_mode),
+                    timeout=float(settings.dns_resolution_timeout_seconds),
+                )
+            except asyncio.TimeoutError:
+                logger.warning("Task start failed: Target validation timed out for '%s'", target_str)
+                raise HTTPException(
+                    status_code=400,
+                    detail="Target validation timed out in safe mode (SecuScan Guardrail)",
+                )
 
             if not is_valid:
                 logger.warning(f"Task start failed: Target validation failed for '{target}': {error_msg}")
@@ -292,9 +310,10 @@ async def start_task(
     try:
         task_id = await executor.create_task(
             request.plugin_id,
-            request.inputs,
-            request.preset,
-            request.consent_granted
+            effective_inputs,
+            safe_mode=safe_mode,
+            preset=request.preset,
+            consent_granted=request.consent_granted,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
@@ -310,6 +329,10 @@ async def start_task(
 
     # Slot is held — schedule execution.
     # execute_task releases the slot in its finally block on every exit path.
+    #
+    # Use BackgroundTasks so the response can be sent without waiting in real
+    # ASGI servers, while tests using TestClient still execute the task to keep
+    # contract tests deterministic.
     background_tasks.add_task(executor.execute_task, task_id)
     await invalidate_view_cache()
 
@@ -909,6 +932,10 @@ async def bulk_delete_tasks(request: BulkDeleteRequest):
     if running_tasks:
         raise HTTPException(status_code=400, detail="Cannot delete running tasks. Abort them first.")
 
+    # If the task is currently executing but the DB hasn't been updated yet, fail closed.
+    if any(tid in executor.running_tasks for tid in task_ids):
+        raise HTTPException(status_code=400, detail="Cannot delete running tasks. Abort them first.")
+
     await delete_task_records(task_ids)
     await invalidate_view_cache()
 
@@ -1081,10 +1108,15 @@ async def run_workflow_once(workflow_id: str):
     steps = json.loads(row["steps_json"] or "[]")
     created_task_ids: List[str] = []
     for step in steps:
+        safe_mode = bool(settings.safe_mode_default)
+        effective_inputs = dict(step.get("inputs", {}) or {})
+        effective_inputs.pop("safe_mode", None)
+        effective_inputs["safe_mode"] = safe_mode
         task_id = await executor.create_task(
             step.get("plugin_id"),
-            step.get("inputs", {}),
-            step.get("preset"),
+            effective_inputs,
+            safe_mode=safe_mode,
+            preset=step.get("preset"),
             consent_granted=True,
         )
         asyncio.create_task(executor.execute_task(task_id))

--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -4,7 +4,10 @@ Input validation and security checks
 
 import re
 import ipaddress
-from typing import Any, Dict, Tuple
+import socket
+import time
+from urllib.parse import urlparse
+from typing import Any, Dict, Tuple, Optional
 from fnmatch import fnmatch
 
 from .config import settings
@@ -27,6 +30,141 @@ ALLOWED_PRIVATE = [
 
 # Blocked TLDs in safe mode
 BLOCKED_TLDS = [".mil", ".gov"]
+
+
+def _net_within_allowed_networks(net: ipaddress._BaseNetwork) -> bool:
+    """Return True if net is permitted by settings.allowed_networks (best-effort, conservative)."""
+    patterns = [str(p).strip() for p in (settings.allowed_networks or []) if str(p).strip()]
+    if not patterns:
+        return True
+
+    def wildcard_to_net(pattern: str) -> ipaddress.IPv4Network | None:
+        # Convert simple trailing-octet wildcards like "10.*.*.*" → 10.0.0.0/8.
+        parts = pattern.split(".")
+        if len(parts) != 4:
+            return None
+        fixed = []
+        wildcard_started = False
+        for part in parts:
+            if part == "*":
+                wildcard_started = True
+                fixed.append(0)
+                continue
+            if wildcard_started:
+                return None
+            if not part.isdigit():
+                return None
+            value = int(part)
+            if value < 0 or value > 255:
+                return None
+            fixed.append(value)
+        wildcard_octets = sum(1 for p in parts if p == "*")
+        if wildcard_octets == 0:
+            return None
+        prefix = (4 - wildcard_octets) * 8
+        return ipaddress.IPv4Network(f"{'.'.join(map(str, fixed))}/{prefix}", strict=False)
+
+    # Single-IP networks can be checked against wildcards and CIDRs.
+    if net.num_addresses == 1:
+        ip_str = str(net.network_address)
+        for pattern in patterns:
+            try:
+                allowed_net = ipaddress.ip_network(pattern, strict=False)
+                if net.subnet_of(allowed_net) or net.overlaps(allowed_net):
+                    return True
+            except ValueError:
+                converted = wildcard_to_net(pattern)
+                if converted and net.version == converted.version and net.subnet_of(converted):
+                    return True
+                if fnmatch(ip_str, pattern):
+                    return True
+        return False
+
+    # Multi-address networks: only allow explicit CIDR allowlist entries that fully contain the target.
+    for pattern in patterns:
+        try:
+            allowed_net = ipaddress.ip_network(pattern, strict=False)
+        except ValueError:
+            allowed_net = wildcard_to_net(pattern)
+            if not allowed_net:
+                continue
+        if net.version == allowed_net.version and net.subnet_of(allowed_net):
+            return True
+
+    return False
+
+
+def _parse_url_hostname(target: str) -> str | None:
+    parsed = urlparse(target)
+    if parsed.scheme not in {"http", "https"}:
+        return None
+    return parsed.hostname
+
+
+def _resolve_host_ips(hostname: str) -> list[ipaddress._BaseAddress]:
+    """Resolve hostname to a list of IP addresses (A/AAAA).
+
+    Note: This function is synchronous and may block on DNS resolution. Callers
+    in async request paths should run it in a thread and enforce timeouts.
+    Results are cached for a short TTL to reduce repeated resolutions.
+    """
+    now = time.time()
+    cached = _DNS_CACHE.get(hostname)
+    if cached and cached[0] > now:
+        return list(cached[1])
+    try:
+        infos = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+    except OSError:
+        _DNS_CACHE[hostname] = (now + max(1, int(settings.dns_cache_ttl_seconds)), [])
+        return []
+    ips: list[ipaddress._BaseAddress] = []
+    for family, _socktype, _proto, _canonname, sockaddr in infos:
+        try:
+            if family == socket.AF_INET:
+                ips.append(ipaddress.ip_address(sockaddr[0]))
+            elif family == socket.AF_INET6:
+                ips.append(ipaddress.ip_address(sockaddr[0]))
+        except ValueError:
+            continue
+    # Deduplicate while preserving order.
+    seen = set()
+    unique = []
+    for ip in ips:
+        if ip in seen:
+            continue
+        seen.add(ip)
+        unique.append(ip)
+    _DNS_CACHE[hostname] = (now + max(1, int(settings.dns_cache_ttl_seconds)), unique)
+    return list(unique)
+
+
+def _resolve_host_ips_uncached(hostname: str) -> list[ipaddress._BaseAddress]:
+    """Force a fresh DNS resolution (bypasses TTL cache)."""
+    _DNS_CACHE.pop(hostname, None)
+    return _resolve_host_ips(hostname)
+
+
+def _validate_resolved_ips_safe_mode(resolved_ips: list[ipaddress._BaseAddress]) -> Tuple[bool, str]:
+    if not resolved_ips:
+        return False, "Hostname did not resolve to any IPs in safe mode (SecuScan Guardrail)"
+
+    for ip in resolved_ips:
+        ip_net = ipaddress.ip_network(ip, strict=False)
+        if any(ip_net.overlaps(blocked) for blocked in BLOCKED_NETWORKS):
+            return False, "Target overlaps with blocked network range"
+        if ip.is_loopback and not settings.allow_loopback_scans:
+            return False, "Loopback scans are disabled in global settings"
+
+        is_private = any(
+            (ip_net.version == allowed.version and (ip_net.subnet_of(allowed) or ip_net.overlaps(allowed)))
+            for allowed in ALLOWED_PRIVATE
+        )
+        if not is_private:
+            return False, "Public IPs/networks not allowed in safe mode (SecuScan Guardrail)"
+        if not _net_within_allowed_networks(ip_net):
+            return False, "Target not within allowed networks in safe mode (SecuScan Guardrail)"
+
+    return True, ""
 
 
 def validate_target(target: str, safe_mode: bool = True) -> Tuple[bool, str]:
@@ -65,6 +203,9 @@ def validate_target(target: str, safe_mode: bool = True) -> Tuple[bool, str]:
             if not is_private:
                 return False, "Public IPs/networks not allowed in safe mode (SecuScan Guardrail)"
 
+            if not _net_within_allowed_networks(net):
+                return False, "Target not within allowed networks in safe mode (SecuScan Guardrail)"
+
         return True, ""
 
     except ValueError:
@@ -73,14 +214,16 @@ def validate_target(target: str, safe_mode: bool = True) -> Tuple[bool, str]:
 
     # Handle URLs
     hostname_to_validate = target
-    if target.startswith(("http://", "https://")):
-        # Extract host:port or host (handle IPv6 literals in brackets)
-        host_part = target.split("://", 1)[1].split("/", 1)[0]
-        if host_part.startswith("["):
-            # IPv6 literal like [::1]:8080 or [::1] for ipv6
-            hostname_to_validate = host_part.split("]")[0][1:]
-        else:
-            hostname_to_validate = host_part.split(":", 1)[0]
+    parsed_host = _parse_url_hostname(target)
+    if parsed_host is not None:
+        hostname_to_validate = parsed_host
+
+    # If host is an IP literal (including URL host), validate it via the same IP/CIDR path.
+    try:
+        net = ipaddress.ip_network(hostname_to_validate, strict=False)
+        return validate_target(str(net), safe_mode=safe_mode)
+    except ValueError:
+        pass
 
     # Validate hostname format (RFC 1123)
     if not re.match(r'^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$', hostname_to_validate):
@@ -92,7 +235,31 @@ def validate_target(target: str, safe_mode: bool = True) -> Tuple[bool, str]:
             if hostname_to_validate.lower().endswith(tld):
                 return False, f"Domains ending in {tld} are blocked in safe mode"
 
+        # Safe mode: resolve hostname and ensure ALL resolved IPs are within private + allowed networks.
+        # Also protect against rebinding/round-robin by optionally doing a second fresh resolution and validating the union.
+        resolved_ips = _resolve_host_ips(hostname_to_validate)
+        ok, msg = _validate_resolved_ips_safe_mode(resolved_ips)
+        if not ok:
+            return ok, msg
+
+        if settings.dns_rebind_check:
+            resolved_ips2 = _resolve_host_ips_uncached(hostname_to_validate)
+            union = []
+            seen = set()
+            for ip in list(resolved_ips) + list(resolved_ips2):
+                if ip in seen:
+                    continue
+                seen.add(ip)
+                union.append(ip)
+            ok2, msg2 = _validate_resolved_ips_safe_mode(union)
+            if not ok2:
+                return ok2, msg2
+
     return True, ""
+
+
+# Simple TTL cache: hostname -> (expires_at_epoch, [ips])
+_DNS_CACHE: dict[str, tuple[float, list[ipaddress._BaseAddress]]] = {}
 
 
 def validate_port(port: int) -> Tuple[bool, str]:

--- a/backend/secuscan/workflows.py
+++ b/backend/secuscan/workflows.py
@@ -7,6 +7,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 from .database import get_db
+from .config import settings
 from .executor import executor
 logger = logging.getLogger(__name__)
 class WorkflowScheduler:
@@ -75,14 +76,24 @@ class WorkflowScheduler:
             if not plugin_id:
                 continue
             request_id = get_request_id()
+            safe_mode = bool(settings.safe_mode_default)
+            effective_inputs = dict(inputs)
+            effective_inputs.pop("safe_mode", None)
+            effective_inputs["safe_mode"] = safe_mode
+
             task_id = await executor.create_task(
                 plugin_id,
-                inputs,
+                effective_inputs,
+                safe_mode=safe_mode,
                 preset=step.get("preset"),
-                consent_granted=True
+                consent_granted=True,
             )
-            async def run_task():
+
+            async def run_task(task_id: str) -> None:
                 set_request_id(request_id)
                 await executor.execute_task(task_id)
-            asyncio.create_task(run_task())
+
+            asyncio.create_task(run_task(task_id))
+
+
 scheduler = WorkflowScheduler()

--- a/testing/backend/benchmarks/bench_concurrent_task_start.py
+++ b/testing/backend/benchmarks/bench_concurrent_task_start.py
@@ -10,13 +10,14 @@ from testing.backend.benchmarks.conftest import load_threshold
 async def test_10_concurrent_task_creates(bench_env, record_benchmark):
     executor = bench_env["executor"]
     plugin_id = "icmp_ping"
-    inputs = {"target": "127.0.0.1"}
+    safe_mode = True
+    inputs = {"target": "127.0.0.1", "safe_mode": safe_mode}
 
     latencies = []
 
     async def create_one():
         start = time.perf_counter()
-        tid = await executor.create_task(plugin_id, inputs)
+        tid = await executor.create_task(plugin_id, inputs, safe_mode=safe_mode)
         latencies.append((time.perf_counter() - start) * 1000.0)
         return tid
 
@@ -52,12 +53,13 @@ async def test_10_concurrent_task_creates(bench_env, record_benchmark):
 async def test_20_sequential_task_creates(bench_env, record_benchmark):
     executor = bench_env["executor"]
     plugin_id = "icmp_ping"
-    inputs = {"target": "127.0.0.1"}
+    safe_mode = True
+    inputs = {"target": "127.0.0.1", "safe_mode": safe_mode}
 
     latencies = []
     for _ in range(20):
         start = time.perf_counter()
-        await executor.create_task(plugin_id, inputs)
+        await executor.create_task(plugin_id, inputs, safe_mode=safe_mode)
         latencies.append((time.perf_counter() - start) * 1000.0)
 
     mean_lat = statistics.mean(latencies)

--- a/testing/backend/conftest.py
+++ b/testing/backend/conftest.py
@@ -41,6 +41,11 @@ def setup_test_environment(monkeypatch):
 
     temp_dir.cleanup()
 
+@pytest.fixture
+def anyio_backend():
+    """Force AnyIO tests to run on asyncio (trio is not a dependency in CI)."""
+    return "asyncio"
+
 
 @pytest.fixture
 def test_client(setup_test_environment):

--- a/testing/backend/integration/test_phase2_plugins.py
+++ b/testing/backend/integration/test_phase2_plugins.py
@@ -3,6 +3,7 @@ import re
 from pathlib import Path
 from unittest.mock import patch
 from backend.secuscan.models import TaskStatus
+from backend.secuscan.config import settings
 
 PHASE2_PLUGIN_IDS = {
     "subdomain_discovery",
@@ -86,9 +87,15 @@ def test_all_scantools_have_backend_plugins(test_client):
         f"Missing backend plugins for scanTools: {sorted(scan_tool_ids - backend_plugin_ids)}"
     )
 
-def test_subdomain_discovery(test_client):
+def test_subdomain_discovery(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "safe_mode_default", False)
     mock_out = "admin.example.com\ndev.example.com\napi.example.com"
-    result = run_plugin_test(test_client, "subdomain_discovery", {"target": "example.com"}, mock_out)
+    result = run_plugin_test(
+        test_client,
+        "subdomain_discovery",
+        {"target": "example.com"},
+        mock_out,
+    )
     assert len(result["structured"]["findings"]) > 0
     assert "admin.example.com" in result["raw_output_excerpt"]
 
@@ -133,12 +140,19 @@ def test_ssh_runner(test_client):
     )
     assert "load average" in result["raw_output_excerpt"]
 
-def test_whois_lookup(test_client):
+def test_whois_lookup(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "safe_mode_default", False)
     mock_out = "Registrar: SafeNames Ltd.\nRegistry Expiry Date: 2026-01-01\nName Server: NS1.EXAMPLE.COM"
-    result = run_plugin_test(test_client, "whois_lookup", {"target": "example.com"}, mock_out)
+    result = run_plugin_test(
+        test_client,
+        "whois_lookup",
+        {"target": "example.com"},
+        mock_out,
+    )
     assert result["structured"]["detail"]["registrar"] == "SafeNames Ltd."
 
-def test_dns_enum(test_client):
+def test_dns_enum(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "safe_mode_default", False)
     mock_out = "[*] A example.com 93.184.216.34\n[*] MX mail.example.com 10"
     result = run_plugin_test(test_client, "dns_enum", {"target": "example.com"}, mock_out)
     assert result["structured"]["count"] >= 2

--- a/testing/backend/integration/test_phase3_plugins.py
+++ b/testing/backend/integration/test_phase3_plugins.py
@@ -2,6 +2,7 @@ import time
 from unittest.mock import patch
 
 from backend.secuscan.models import TaskStatus
+from backend.secuscan.config import settings
 
 PHASE3_PLUGIN_IDS = {
     "wpscan",
@@ -65,7 +66,8 @@ def test_phase3_plugins_discoverable_and_schema_accessible(test_client):
         assert schema.status_code == 200
 
 
-def test_wpscan(test_client):
+def test_wpscan(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "safe_mode_default", False)
     mock_out = '{"plugins":{"sample-plugin":{"vulnerabilities":[{"title":"CVE-2026-1000"}]}}}'
     result = run_plugin_test(
         test_client,
@@ -76,15 +78,27 @@ def test_wpscan(test_client):
     assert any("WordPress Plugin Vulnerability" in f["title"] for f in result["structured"]["findings"])
 
 
-def test_joomscan(test_client):
+def test_joomscan(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "safe_mode_default", False)
     mock_out = "[+] Vulnerable to: CVE-2015-8562\n[+] Joomla! version: 3.4.5"
-    result = run_plugin_test(test_client, "joomscan", {"target": "https://joomla.lab"}, mock_out)
+    result = run_plugin_test(
+        test_client,
+        "joomscan",
+        {"target": "https://joomla.lab"},
+        mock_out,
+    )
     assert any("Joomla Vulnerability" in f["title"] for f in result["structured"]["findings"])
 
 
-def test_droopescan(test_client):
+def test_droopescan(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "safe_mode_default", False)
     mock_out = '{"vulnerabilities":[{"description":"CVE-2025-0001"}],"interesting urls":[{"description":"/admin"}]}'
-    result = run_plugin_test(test_client, "droopescan", {"target": "https://drupal.lab"}, mock_out)
+    result = run_plugin_test(
+        test_client,
+        "droopescan",
+        {"target": "https://drupal.lab"},
+        mock_out,
+    )
     assert any("DroopeScan vulnerabilities" in f["title"] for f in result["structured"]["findings"])
 
 
@@ -136,12 +150,18 @@ def test_metasploit(test_client):
     assert any("Metasploit Session Opened" in f["title"] for f in result["structured"]["findings"])
 
 
-def test_sqli_checker(test_client):
+def test_sqli_checker(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "safe_mode_default", False)
     mock_out = "Payload: ' OR 1=1 --\navailable databases [2]:\nmain\naudit"
     result = run_plugin_test(
         test_client,
         "sqli_checker",
-        {"target": "https://api.lab/user?id=1", "level": 1, "risk": 1, "technique": "BEUSTQ"},
+        {
+            "target": "https://api.lab/user?id=1",
+            "level": 1,
+            "risk": 1,
+            "technique": "BEUSTQ",
+        },
         mock_out,
     )
     findings = result["structured"]["findings"]

--- a/testing/backend/test_safe_mode_filesystem_targets.py
+++ b/testing/backend/test_safe_mode_filesystem_targets.py
@@ -39,6 +39,7 @@ def code_payload(target: str) -> dict:
 def network_payload(target: str, safe_mode: bool = True) -> dict:
     return {
         "plugin_id": "nmap",
+        # NOTE: safe_mode is server-controlled; including it here should not change behavior.
         "inputs": {"target": target, "safe_mode": safe_mode},
         "consent_granted": True,
     }
@@ -146,7 +147,7 @@ class TestNetworkTargetSafeMode:
         "93.184.216.34",
     ])
     def test_public_targets_blocked_in_safe_mode(self, test_client, public_target):
-        """safe_mode=True must block public IPs."""
+        """Server safe-mode must block public IPs regardless of client-supplied safe_mode."""
         r = post(test_client, network_payload(public_target, safe_mode=True))
         assert r.status_code == 400, (
             f"Expected public target '{public_target}' blocked, got {r.status_code}: {r.text}"
@@ -158,8 +159,21 @@ class TestNetworkTargetSafeMode:
         "8.8.8.8",
         "1.1.1.1",
     ])
-    def test_public_targets_allowed_when_safe_mode_disabled(self, test_client, public_target):
-        """safe_mode=False lifts the public IP restriction."""
+    def test_client_cannot_disable_safe_mode(self, test_client, public_target):
+        """Client cannot bypass guardrails by setting safe_mode=False in inputs."""
+        r = post(test_client, network_payload(public_target, safe_mode=False))
+        assert r.status_code == 400, (
+            f"Expected public target '{public_target}' blocked even with client safe_mode=False, got {r.status_code}: {r.text}"
+        )
+
+    @pytest.mark.parametrize("public_target", [
+        "8.8.8.8",
+        "1.1.1.1",
+    ])
+    def test_public_targets_allowed_when_server_safe_mode_disabled(self, test_client, monkeypatch, public_target):
+        """Disabling safe-mode is a server configuration decision, not a client input."""
+        from backend.secuscan.config import settings
+        monkeypatch.setattr(settings, "safe_mode_default", False)
         r = post(test_client, network_payload(public_target, safe_mode=False))
         assert r.status_code != 400, (
             f"Public target '{public_target}' incorrectly blocked with safe_mode=False: {r.text}"
@@ -172,12 +186,10 @@ class TestNetworkTargetSafeMode:
     ])
     def test_always_blocked_ranges_rejected(self, test_client, blocked_target):
         """Broadcast, link-local, multicast blocked in all modes."""
-        for safe_mode in (True, False):
-            r = post(test_client, network_payload(blocked_target, safe_mode=safe_mode))
-            assert r.status_code == 400, (
-                f"Expected '{blocked_target}' blocked (safe_mode={safe_mode}), "
-                f"got {r.status_code}: {r.text}"
-            )
+        r = post(test_client, network_payload(blocked_target, safe_mode=True))
+        assert r.status_code == 400, (
+            f"Expected '{blocked_target}' blocked, got {r.status_code}: {r.text}"
+        )
 
     def test_raw_target_not_leaked_in_response(self, test_client):
         """Sentinel value must not appear in error response."""

--- a/testing/backend/unit/test_cli.py
+++ b/testing/backend/unit/test_cli.py
@@ -66,7 +66,12 @@ async def test_run_scan_successful_execution():
 
         result = await run_scan("127.0.0.1", "http_inspector", "console")
         assert result == 0
-        mock_executor.create_task.assert_called_once_with("http_inspector", {"target": "127.0.0.1"}, consent_granted=True)
+        mock_executor.create_task.assert_called_once_with(
+            "http_inspector",
+            {"target": "127.0.0.1", "safe_mode": True},
+            safe_mode=True,
+            consent_granted=True,
+        )
 
 
 def test_cli_help_menu():

--- a/testing/backend/unit/test_safe_mode_route_executor.py
+++ b/testing/backend/unit/test_safe_mode_route_executor.py
@@ -1,0 +1,195 @@
+"""
+Tests for server-controlled safe_mode at the route/executor boundary.
+
+Covers the behavior that was added in the safe_mode PR:
+  1. Route-level: safe_mode is server-controlled, never client-supplied
+  2. Executor-level: create_task stores safe_mode in the database
+  3. Target validation uses the server's safe_mode value, not the client's
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. Server-controlled effective_inputs logic (what the route does)
+# ---------------------------------------------------------------------------
+
+class TestServerControlledSafeMode:
+    """Tests the pattern that routes.py uses for effective_inputs."""
+
+    @pytest.fixture
+    def settings(self):
+        """Minimal settings mock for testing the effective-inputs pattern."""
+        mock = MagicMock()
+        mock.safe_mode_default = True
+        return mock
+
+    def _build_effective_inputs(self, raw_inputs: dict, safe_mode: bool) -> dict:
+        """Replicates the pattern in routes.py start_task / run_workflow_once."""
+        effective = dict(raw_inputs or {})
+        effective.pop("safe_mode", None)
+        effective["safe_mode"] = safe_mode
+        return effective
+
+    def test_client_safe_mode_is_stripped(self, settings):
+        """Client-supplied safe_mode=False is removed from inputs."""
+        raw = {"target": "8.8.8.8", "safe_mode": False}
+        effective = self._build_effective_inputs(raw, safe_mode=bool(settings.safe_mode_default))
+        assert effective["safe_mode"] is True
+        assert effective["target"] == "8.8.8.8"
+
+    def test_client_safe_mode_true_is_stripped(self, settings):
+        """Client-supplied safe_mode=True is also removed (no trust)."""
+        raw = {"target": "192.168.1.1", "safe_mode": True}
+        effective = self._build_effective_inputs(raw, safe_mode=bool(settings.safe_mode_default))
+        assert effective["safe_mode"] is True
+
+    def test_server_disabled_safe_mode(self, settings):
+        """When server-side safe_mode_default=False, effective safe_mode is False."""
+        settings.safe_mode_default = False
+        raw = {"target": "8.8.8.8", "safe_mode": True}
+        effective = self._build_effective_inputs(raw, safe_mode=bool(settings.safe_mode_default))
+        assert effective["safe_mode"] is False
+
+    def test_no_safe_mode_in_input_gets_server_default(self, settings):
+        """When client does not send safe_mode at all, server default is used."""
+        raw = {"target": "192.168.1.1"}
+        effective = self._build_effective_inputs(raw, safe_mode=bool(settings.safe_mode_default))
+        assert effective["safe_mode"] is True
+
+    def test_other_inputs_preserved(self, settings):
+        """Other input fields are not affected by the safe_mode injection."""
+        raw = {"target": "127.0.0.1", "plugin_option": "aggressive"}
+        effective = self._build_effective_inputs(raw, safe_mode=bool(settings.safe_mode_default))
+        assert effective["plugin_option"] == "aggressive"
+        assert effective["target"] == "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# 2. Executor safe_mode persistence
+# ---------------------------------------------------------------------------
+
+class TestExecutorSafeModePersistence:
+    """Tests that executor.create_task stores safe_mode in the database."""
+
+    @pytest.mark.asyncio
+    async def test_create_task_stores_safe_mode_true(self):
+        """When safe_mode=True, the tasks table row has safe_mode=1."""
+        from backend.secuscan.executor import TaskExecutor
+
+        mock_db = AsyncMock()
+        mock_plugin = MagicMock()
+        mock_plugin.name = "nmap"
+        mock_pm = MagicMock()
+        mock_pm.get_plugin.return_value = mock_plugin
+
+        exec_instance = TaskExecutor.__new__(TaskExecutor)
+        exec_instance.running_tasks = {}
+        exec_instance._listeners = {}
+
+        with (
+            patch("backend.secuscan.executor.get_db", return_value=mock_db),
+            patch("backend.secuscan.executor.get_plugin_manager", return_value=mock_pm),
+        ):
+            task_id = await exec_instance.create_task(
+                "nmap",
+                {"target": "192.168.1.1", "safe_mode": True},
+                safe_mode=True,
+                consent_granted=False,
+            )
+
+        assert task_id is not None
+        call_args = mock_db.execute.call_args
+        assert call_args is not None
+        sql, params = call_args[0]
+        assert "safe_mode" in sql
+        assert params[-1] is True
+
+    @pytest.mark.asyncio
+    async def test_create_task_stores_safe_mode_false(self):
+        """When safe_mode=False, the tasks table row has safe_mode=0."""
+        from backend.secuscan.executor import TaskExecutor
+
+        mock_db = AsyncMock()
+        mock_plugin = MagicMock()
+        mock_plugin.name = "nmap"
+        mock_pm = MagicMock()
+        mock_pm.get_plugin.return_value = mock_plugin
+
+        exec_instance = TaskExecutor.__new__(TaskExecutor)
+        exec_instance.running_tasks = {}
+        exec_instance._listeners = {}
+
+        with (
+            patch("backend.secuscan.executor.get_db", return_value=mock_db),
+            patch("backend.secuscan.executor.get_plugin_manager", return_value=mock_pm),
+        ):
+            task_id = await exec_instance.create_task(
+                "nmap",
+                {"target": "8.8.8.8", "safe_mode": False},
+                safe_mode=False,
+                consent_granted=False,
+            )
+
+        assert task_id is not None
+        call_args = mock_db.execute.call_args
+        assert call_args is not None
+        sql, params = call_args[0]
+        assert params[-1] is False
+
+    @pytest.mark.asyncio
+    async def test_create_task_default_safe_mode_true(self):
+        """Route passes safe_mode from settings; executor receives it as the caller passes it."""
+        from backend.secuscan.executor import TaskExecutor
+
+        mock_db = AsyncMock()
+        mock_plugin = MagicMock()
+        mock_plugin.name = "nmap"
+        mock_pm = MagicMock()
+        mock_pm.get_plugin.return_value = mock_plugin
+
+        exec_instance = TaskExecutor.__new__(TaskExecutor)
+        exec_instance.running_tasks = {}
+        exec_instance._listeners = {}
+
+        with (
+            patch("backend.secuscan.executor.get_db", return_value=mock_db),
+            patch("backend.secuscan.executor.get_plugin_manager", return_value=mock_pm),
+        ):
+            task_id = await exec_instance.create_task(
+                "nmap",
+                {"target": "192.168.1.1", "safe_mode": True},
+                safe_mode=True,
+                consent_granted=False,
+            )
+
+        call_args = mock_db.execute.call_args
+        sql, params = call_args[0]
+        # safe_mode is the last column in the INSERT
+        assert params[-1] is True
+
+    @pytest.mark.asyncio
+    async def test_create_task_rejects_invalid_plugin(self):
+        """create_task raises ValueError when plugin is not found."""
+        from backend.secuscan.executor import TaskExecutor
+
+        mock_pm = MagicMock()
+        mock_pm.get_plugin.return_value = None
+
+        exec_instance = TaskExecutor.__new__(TaskExecutor)
+        exec_instance.running_tasks = {}
+        exec_instance._listeners = {}
+
+        with (
+            patch("backend.secuscan.executor.get_plugin_manager", return_value=mock_pm),
+        ):
+            with pytest.raises(ValueError, match="Plugin not found"):
+                await exec_instance.create_task(
+                    "nonexistent",
+                    {},
+                    safe_mode=True,
+                    consent_granted=False,
+                )

--- a/testing/backend/unit/test_validation.py
+++ b/testing/backend/unit/test_validation.py
@@ -1,4 +1,5 @@
 import pytest
+import socket
 from backend.secuscan.validation import (
     validate_target, validate_port, validate_port_range, validate_url,
     sanitize_input, is_safe_path, match_pattern
@@ -19,6 +20,46 @@ def test_validate_target():
     # Invalid targets
     assert validate_target("10.0.0.0/24")[0] is True  # Private CIDR ranges are allowed in safe mode
     assert validate_target("not!a!valid!hostname")[0] is False
+
+
+def test_validate_target_safe_mode_blocks_public_hostname(monkeypatch):
+    def fake_getaddrinfo(_host, *_args, **_kwargs):
+        return [(socket.AF_INET, None, None, None, ("8.8.8.8", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    assert validate_target("example.com", safe_mode=True)[0] is False
+
+
+def test_validate_target_safe_mode_blocks_multi_record_when_any_public(monkeypatch):
+    """If any A/AAAA record is public, safe-mode must fail closed."""
+    def fake_getaddrinfo(_host, *_args, **_kwargs):
+        return [
+            (socket.AF_INET, None, None, None, ("192.168.1.10", 0)),
+            (socket.AF_INET, None, None, None, ("8.8.8.8", 0)),
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    assert validate_target("multirecord.example", safe_mode=True)[0] is False
+
+
+def test_validate_target_safe_mode_blocks_dns_rebinding_union(monkeypatch):
+    """Rebinding/round-robin: validate_target resolves twice and validates the union."""
+    calls = {"n": 0}
+
+    def fake_getaddrinfo(_host, *_args, **_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return [(socket.AF_INET, None, None, None, ("192.168.1.10", 0))]
+        return [(socket.AF_INET, None, None, None, ("8.8.8.8", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    ok, _msg = validate_target("rebind.example", safe_mode=True)
+    assert ok is False
+    assert calls["n"] >= 2
+
+
+def test_validate_target_safe_mode_blocks_url_ip_literal():
+    assert validate_target("http://8.8.8.8", safe_mode=True)[0] is False
 
 
 def test_validate_port():


### PR DESCRIPTION
## Description
This PR fixes Safe Mode target validation so it can’t be bypassed using hostnames or URL forms.

Key improvements:
- Safe mode now parses `http(s)://...` targets using proper URL parsing (no substring checks).
- URL IP literals (e.g. `http://8.8.8.8`) are treated the same as raw IP targets and correctly blocked in safe mode.
- Hostnames are resolved (A/AAAA) in safe mode and rejected if **any** resolved address is public (fail-safe).
- `settings.allowed_networks` is now enforced consistently in safe mode for IP/CIDR targets and resolved hostname targets, including basic wildcard patterns like `10.*.*.*`.

## Related Issues
Fixes #282

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- Ran backend unit tests for validation logic:

```bash
python -m pytest -q testing/backend/unit/test_validation.py

## Notes

- Added regression tests that mock DNS resolution to validate safe mode behavior for public hostnames and URL IP literals.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.