### PR TITLE
feat(scans): pause polling when tab is hidden (#95)

### DIFF
--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { API_BASE, deleteTask, clearAllTasks, bulkDeleteTasks } from "../api";
@@ -63,10 +63,40 @@ export default function Scans() {
   const [total, setTotal] = useState(0);
   const PAGE_LIMIT = 10;
 
+  // Ref so the visibilitychange handler always sees the current interval id
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  function startPolling() {
+    stopPolling();
+    intervalRef.current = setInterval(loadTasks, 5000);
+  }
+
+  function stopPolling() {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }
+
   useEffect(() => {
     loadTasks();
-    const interval = setInterval(loadTasks, 5000);
-    return () => clearInterval(interval);
+    startPolling();
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === "hidden") {
+        stopPolling();
+      } else {
+        loadTasks();   // immediate refresh when tab comes back
+        startPolling();
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      stopPolling();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
   }, [filter, page]);
 
   async function loadTasks() {
@@ -88,6 +118,7 @@ export default function Scans() {
       setLoading(false);
     }
   }
+
   function handleFilterChange(value: string) {
     setFilter(value);
     setPage(1);

--- a/frontend/testing/unit/pages/Scans.polling.test.tsx
+++ b/frontend/testing/unit/pages/Scans.polling.test.tsx
@@ -1,0 +1,152 @@
+import { render, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Scans from '../../../src/pages/Scans';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../../../src/api', () => ({
+  API_BASE: 'http://localhost',
+  deleteTask: vi.fn(),
+  clearAllTasks: vi.fn(),
+  bulkDeleteTasks: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+const EMPTY_RESPONSE = { tasks: [], pagination: { total_items: 0 } };
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchSpy = vi.fn().mockResolvedValue({
+    json: () => Promise.resolve(EMPTY_RESPONSE),
+  });
+  vi.stubGlobal('fetch', fetchSpy);
+
+  // Use fake timers; microtasks drained via Promise.resolve() chains in flush()/tickTime()
+  vi.useFakeTimers();
+
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => 'visible',
+  });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function renderScans() {
+  return render(
+    <MemoryRouter>
+      <Scans />
+    </MemoryRouter>,
+  );
+}
+
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+// Advance timers by ms then drain all pending microtasks (promise callbacks)
+async function tickTime(ms: number) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    
+  });
+}
+
+// Just drain microtasks without advancing time
+async function flush() {
+  await act(async () => {
+    
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Scans — visibility-aware polling', () => {
+  it('fires one fetch on mount', async () => {
+    renderScans();
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls every 5 s while the tab is visible', async () => {
+    renderScans();
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    await tickTime(5_000);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    await tickTime(5_000);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops polling entirely when the tab is hidden', async () => {
+    renderScans();
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    setVisibility('hidden');
+    await flush();
+
+    await tickTime(15_000);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes polling immediately when the tab becomes visible again', async () => {
+    renderScans();
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    setVisibility('hidden');
+    await tickTime(15_000);
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // still paused
+
+    setVisibility('visible');
+    await flush(); // immediate fetch on resume
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    await tickTime(5_000); // interval restarts
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not double-poll if tab was never hidden', async () => {
+    renderScans();
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    await tickTime(5_000);
+    await tickTime(5_000);
+    await tickTime(5_000);
+    // 1 mount + 3 ticks = exactly 4
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('cleans up the interval and listener on unmount', async () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+    const { unmount } = renderScans();
+    await flush();
+    const callsAfterMount = fetchSpy.mock.calls.length;
+
+    unmount();
+
+    await tickTime(15_000);
+    // No extra fetches after unmount
+    expect(fetchSpy).toHaveBeenCalledTimes(callsAfterMount);
+    expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+  });
+});

--- a/frontend/testing/unit/pages/Scans.polling.test.tsx
+++ b/frontend/testing/unit/pages/Scans.polling.test.tsx
@@ -58,18 +58,22 @@ function setVisibility(state: 'visible' | 'hidden') {
   document.dispatchEvent(new Event('visibilitychange'));
 }
 
-// Advance timers by ms then drain all pending microtasks (promise callbacks)
-async function tickTime(ms: number) {
+// Drain pending microtasks — works with Vitest 2.1.x.
+async function flush() {
   await act(async () => {
-    vi.advanceTimersByTime(ms);
-    
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
   });
 }
 
-// Just drain microtasks without advancing time
-async function flush() {
+// Advance fake timers then drain microtasks so fetch callbacks settle.
+async function tickTime(ms: number) {
   await act(async () => {
-    
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
   });
 }
 


### PR DESCRIPTION
## Description
Pauses polling entirely when the browser tab is hidden to reduce unnecessary backend traffic. Resumes with an immediate fetch when the tab becomes visible again. Normal 5s polling behaviour is unchanged while the tab is active.

## Related Issues
Closes #95

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Unit tests added at testing/unit/pages/Scans.polling.test.tsx using Vitest + jsdom with fake timers.
All 6 tests pass (npx vitest run Scans.polling):
-fires one fetch on mount
-polls every 5s while tab is visible
-stops polling entirely when tab is hidden
-resumes immediately when tab becomes visible again
-does not double-poll if tab was never hidden
-cleans up interval and listener on unmount



## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
