### PR TITLE
fix(ui): replace window.confirm dialogs with in-app confirmation modal

### DIFF
--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  danger?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmModal({
+  isOpen,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  danger = false,
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onCancel();
+      if (e.key === "Enter") onConfirm();
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [isOpen, onConfirm, onCancel]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center p-6"
+          style={{ backgroundColor: "rgba(0,0,0,0.75)" }}
+          onClick={onCancel}
+        >
+          <motion.div
+            initial={{ scale: 0.95, opacity: 0, y: 10 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.95, opacity: 0, y: 10 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+            className="bg-charcoal border-4 border-black shadow-[12px_12px_0px_0px_rgba(0,0,0,1)] w-full max-w-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className={`border-b-4 border-black px-8 py-6 ${danger ? "bg-rag-red/10" : "bg-charcoal-dark"}`}>
+              <div className="flex items-center gap-4">
+                <span className={`material-symbols-outlined text-2xl ${danger ? "text-rag-red" : "text-rag-amber"}`}>
+                  {danger ? "warning" : "info"}
+                </span>
+                <h2 className="text-sm font-black text-silver-bright uppercase tracking-widest italic">
+                  {title}
+                </h2>
+              </div>
+            </div>
+            <div className="px-8 py-8">
+              <p className="text-xs font-mono text-silver/60 leading-relaxed uppercase tracking-wide">
+                {message}
+              </p>
+            </div>
+            <div className="border-t-4 border-black px-8 py-6 flex items-center justify-end gap-4">
+              <button
+                onClick={onCancel}
+                className="px-6 py-3 text-[10px] font-black uppercase tracking-widest text-silver/40 hover:text-silver transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={onConfirm}
+                className={`px-8 py-3 text-[10px] font-black uppercase tracking-widest shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-3 italic ${
+                  danger ? "bg-rag-red text-black" : "bg-rag-blue text-black"
+                }`}
+              >
+                {confirmLabel}
+                <span className="material-symbols-outlined text-sm">
+                  {danger ? "delete_forever" : "check"}
+                </span>
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -9,6 +9,7 @@ import {
   formatLocaleTime,
 } from "../utils/date";
 import Pagination from "../components/Pagination";
+import ConfirmModal from "../components/ConfirmModal";
 
 interface Task {
   task_id: string;
@@ -25,7 +26,6 @@ interface Task {
   queue_position?: number;
   pending_count?: number;
 }
-
 const statusFilters = [
   { value: "all", label: "ALL_OPERATIONS" },
   { value: "running", label: "ACTIVE_EXECUTION" },
@@ -52,6 +52,8 @@ const itemVariants = {
   },
 } as const;
 
+type ModalType = "delete" | "clearAll" | "bulkDelete" | null;
+
 export default function Scans() {
   const navigate = useNavigate();
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -62,6 +64,10 @@ export default function Scans() {
   const [page, setPage] = useState(1);
   const [total, setTotal] = useState(0);
   const PAGE_LIMIT = 10;
+
+  // Modal state
+  const [modalType, setModalType] = useState<ModalType>(null);
+  const [pendingTaskId, setPendingTaskId] = useState<string | null>(null);
 
   useEffect(() => {
     loadTasks();
@@ -88,6 +94,7 @@ export default function Scans() {
       setLoading(false);
     }
   }
+
   function handleFilterChange(value: string) {
     setFilter(value);
     setPage(1);
@@ -114,19 +121,36 @@ export default function Scans() {
     }
   }
 
-  async function handleTaskDelete(taskId: string) {
-    if (
-      !window.confirm(
-        "Are you sure you want to delete this scan record? This will also remove associated findings and reports.",
-      )
-    ) {
-      return;
-    }
+  // ── Modal trigger helpers ──────────────────────────────────────────────────
 
+  function confirmTaskDelete(taskId: string) {
+    setPendingTaskId(taskId);
+    setModalType("delete");
+  }
+
+  function confirmClearAll() {
+    setModalType("clearAll");
+  }
+
+  function confirmBulkDelete() {
+    if (selectedIds.length === 0) return;
+    setModalType("bulkDelete");
+  }
+
+  function closeModal() {
+    setModalType(null);
+    setPendingTaskId(null);
+  }
+
+  // ── Actual action handlers (called after modal confirm) ───────────────────
+
+  async function handleTaskDelete() {
+    if (!pendingTaskId) return;
+    closeModal();
     try {
-      await deleteTask(taskId);
-      setTasks((prev) => prev.filter((t) => t.task_id !== taskId));
-      if (expandedId === taskId) setExpandedId(null);
+      await deleteTask(pendingTaskId);
+      setTasks((prev) => prev.filter((t) => t.task_id !== pendingTaskId));
+      if (expandedId === pendingTaskId) setExpandedId(null);
     } catch (err) {
       console.error("Failed to delete task:", err);
       alert("Failed to delete task. It might still be running.");
@@ -134,14 +158,7 @@ export default function Scans() {
   }
 
   async function handleClearAll() {
-    if (
-      !window.confirm(
-        "CRITICAL: Are you sure you want to PURGE ALL RECORDS? This will wipe all scan history, findings, assets, and reports. This action is irreversible.",
-      )
-    ) {
-      return;
-    }
-
+    closeModal();
     try {
       await clearAllTasks();
       setTasks([]);
@@ -154,15 +171,7 @@ export default function Scans() {
   }
 
   async function handleBulkDelete() {
-    if (selectedIds.length === 0) return;
-    if (
-      !window.confirm(
-        `Are you sure you want to delete ${selectedIds.length} selected scan records?`,
-      )
-    ) {
-      return;
-    }
-
+    closeModal();
     try {
       await bulkDeleteTasks(selectedIds);
       setTasks((prev) => prev.filter((t) => !selectedIds.includes(t.task_id)));
@@ -174,6 +183,41 @@ export default function Scans() {
       );
     }
   }
+
+  // ── Modal config per type ─────────────────────────────────────────────────
+
+  const modalConfig: Record<
+    NonNullable<ModalType>,
+    {
+      title: string;
+      message: string;
+      confirmLabel: string;
+      onConfirm: () => void;
+    }
+  > = {
+    delete: {
+      title: "Delete_Scan_Record",
+      message:
+        "Are you sure you want to delete this scan record? This will also remove associated findings and reports.",
+      confirmLabel: "Delete_Record",
+      onConfirm: handleTaskDelete,
+    },
+    clearAll: {
+      title: "Purge_All_Records",
+      message:
+        "CRITICAL: Are you sure you want to PURGE ALL RECORDS? This will wipe all scan history, findings, assets, and reports. This action is irreversible.",
+      confirmLabel: "Purge_All",
+      onConfirm: handleClearAll,
+    },
+    bulkDelete: {
+      title: "Bulk_Delete_Records",
+      message: `Are you sure you want to delete ${selectedIds.length} selected scan record${selectedIds.length !== 1 ? "s" : ""}?`,
+      confirmLabel: "Delete_Selected",
+      onConfirm: handleBulkDelete,
+    },
+  };
+
+  // ── Selection helpers ─────────────────────────────────────────────────────
 
   function toggleSelection(taskId: string, e: React.MouseEvent) {
     e.stopPropagation();
@@ -199,8 +243,23 @@ export default function Scans() {
     return `${Math.round(seconds / 3600)}h`;
   }
 
+  const activeModal = modalType ? modalConfig[modalType] : null;
+
   return (
     <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
+      {/* Confirmation Modal */}
+      {activeModal && (
+        <ConfirmModal
+          isOpen={!!modalType}
+          title={activeModal.title}
+          message={activeModal.message}
+          confirmLabel={activeModal.confirmLabel}
+          danger={true}
+          onConfirm={activeModal.onConfirm}
+          onCancel={closeModal}
+        />
+      )}
+
       {/* Neo-Brutalist Header */}
       <header className="relative flex flex-col md:flex-row justify-between items-start md:items-end gap-8 pb-12 border-b-4 border-silver-bright/10">
         <div className="space-y-4">
@@ -274,7 +333,7 @@ export default function Scans() {
         <div className="flex items-center gap-6">
           {tasks.length > 0 && (
             <button
-              onClick={handleClearAll}
+              onClick={confirmClearAll}
               className="px-6 py-3 text-[10px] font-black uppercase tracking-widest transition-all border-2 bg-rag-red/10 text-rag-red border-rag-red/20 hover:bg-rag-red hover:text-black hover:border-black flex items-center gap-2 italic"
             >
               Purge_All_Records
@@ -487,7 +546,7 @@ export default function Scans() {
                                     className="bg-rag-red/20 text-rag-red border-2 border-rag-red/20 hover:bg-rag-red hover:text-black hover:border-black px-6 py-4 text-[10px] font-black uppercase tracking-widest transition-all flex items-center gap-3 italic"
                                     onClick={(e) => {
                                       e.stopPropagation();
-                                      handleTaskDelete(task.task_id);
+                                      confirmTaskDelete(task.task_id);
                                     }}
                                   >
                                     Delete_Record
@@ -592,7 +651,7 @@ export default function Scans() {
                   Cancel
                 </button>
                 <button
-                  onClick={handleBulkDelete}
+                  onClick={confirmBulkDelete}
                   className="bg-rag-red text-black px-8 py-3 text-[10px] font-black uppercase tracking-widest shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-3 italic"
                 >
                   Prune_Selected_Records

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,11 +2,12 @@ import React, { useState, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useTheme } from '../components/ThemeContext'
 import { useToast } from '../components/ToastContext'
+import ConfirmModal from '../components/ConfirmModal'
 
 const itemVariants = {
   hidden: { opacity: 0, y: 20 },
-  visible: { 
-    opacity: 1, 
+  visible: {
+    opacity: 1,
     y: 0,
     transition: { type: 'spring', stiffness: 200, damping: 25 }
   }
@@ -15,8 +16,8 @@ const itemVariants = {
 const DEFAULT_CONFIG = {
     concurrentScans: 8,
     scanTimeout: 3600,
-    scanIntensity: 'standard', // 'low', 'standard', 'aggressive'
-    dataRetention: 30, // days
+    scanIntensity: 'standard',
+    dataRetention: 30,
     shodanKey: '',
     virustotalKey: '',
     ipWhitelist: '127.0.0.1\n10.0.0.0/8',
@@ -31,10 +32,12 @@ const DEFAULT_CONFIG = {
     }
 }
 
+type ModalType = 'reset' | 'nuclearPurge' | null
+
 export default function Settings() {
     const { theme, setTheme } = useTheme()
     const { addToast } = useToast()
-    
+
     const [config, setConfig] = useState(() => {
         const saved = localStorage.getItem('secuscan-config')
         if (saved) {
@@ -48,6 +51,7 @@ export default function Settings() {
     })
 
     const [systemTimezone, setSystemTimezone] = useState('Detecting...')
+    const [modalType, setModalType] = useState<ModalType>(null)
 
     useEffect(() => {
         try {
@@ -66,17 +70,22 @@ export default function Settings() {
     }
 
     const handleReset = () => {
-        if (window.confirm("Restore engine to factory specifications? All API keys and custom rules will be cleared.")) {
-            setConfig(DEFAULT_CONFIG)
-            localStorage.setItem('secuscan-config', JSON.stringify(DEFAULT_CONFIG))
-            addToast("Engine parameters reset to factory defaults", "info")
-        }
+        setConfig(DEFAULT_CONFIG)
+        localStorage.setItem('secuscan-config', JSON.stringify(DEFAULT_CONFIG))
+        addToast("Engine parameters reset to factory defaults", "info")
+        setModalType(null)
+    }
+
+    const handleNuclearPurge = () => {
+        localStorage.clear()
+        setModalType(null)
+        window.location.reload()
     }
 
     const handleExport = () => {
         const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(config, null, 2));
         const downloadAnchorNode = document.createElement('a');
-        downloadAnchorNode.setAttribute("href",     dataStr);
+        downloadAnchorNode.setAttribute("href", dataStr);
         downloadAnchorNode.setAttribute("download", `secuscan_config_${new Date().toISOString().split('T')[0]}.json`);
         document.body.appendChild(downloadAnchorNode);
         downloadAnchorNode.click();
@@ -84,13 +93,35 @@ export default function Settings() {
         addToast("Encryption export successful", "success")
     }
 
+    const modalConfig: Record<NonNullable<ModalType>, {
+        title: string
+        message: string
+        confirmLabel: string
+        onConfirm: () => void
+    }> = {
+        reset: {
+            title: 'Engine_Reset',
+            message: 'Restore engine to factory specifications? All API keys and custom rules will be cleared.',
+            confirmLabel: 'Reset_Engine',
+            onConfirm: handleReset,
+        },
+        nuclearPurge: {
+            title: 'Nuclear_Purge',
+            message: 'CRITICAL: THIS WILL PURGE ALL HISTORY AND ASSETS. THIS ACTION IS IRREVERSIBLE. PROCEED?',
+            confirmLabel: 'Purge_All',
+            onConfirm: handleNuclearPurge,
+        },
+    }
+
+    const activeModal = modalType ? modalConfig[modalType] : null
+
     const InputField = ({ label, description, type = "text", value, onChange, placeholder }: any) => (
         <div className="bg-charcoal border-4 border-black p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-[10px_10px_0px_0px_rgba(0,0,0,1)] transition-all group">
             <div className="space-y-2 mb-6">
                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] block italic group-hover:text-rag-blue transition-colors">{label}</label>
                 <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">{description}</p>
             </div>
-            <input 
+            <input
                 type={type}
                 value={value}
                 onChange={(e) => onChange(type === 'number' ? parseInt(e.target.value) || 0 : e.target.value)}
@@ -106,7 +137,7 @@ export default function Settings() {
                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] block italic group-hover:text-rag-blue transition-colors">{label}</label>
                 <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">{description}</p>
             </div>
-            <select 
+            <select
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-rag-blue font-bold focus:outline-none focus:border-rag-blue/50 transition-colors uppercase appearance-none"
@@ -119,7 +150,7 @@ export default function Settings() {
     )
 
     const Toggle = ({ checked, onChange, label, description }: any) => (
-        <button 
+        <button
             onClick={() => onChange(!checked)}
             className={`flex items-center justify-between p-8 bg-charcoal border-4 border-black transition-all group hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-0.5 ${
                 checked ? 'shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]' : 'shadow-none'
@@ -137,7 +168,19 @@ export default function Settings() {
 
     return (
         <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
-            
+
+            {activeModal && (
+                <ConfirmModal
+                    isOpen={!!modalType}
+                    title={activeModal.title}
+                    message={activeModal.message}
+                    confirmLabel={activeModal.confirmLabel}
+                    danger={true}
+                    onConfirm={activeModal.onConfirm}
+                    onCancel={() => setModalType(null)}
+                />
+            )}
+
             <header className="relative flex flex-col md:flex-row justify-between items-start md:items-end gap-8 pb-12 border-b-4 border-silver-bright/10 font-black">
                 <div className="space-y-4">
                   <div className="bg-rag-blue text-black px-4 py-1 text-xs uppercase tracking-widest inline-block shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] font-black">
@@ -150,7 +193,6 @@ export default function Settings() {
                     HARDWARE_TUNING // AUDIT_STRATEGY // SECTOR_ISOLATION
                   </p>
                 </div>
-
                 <div className="flex flex-col items-end gap-4">
                    <div className="bg-charcoal border-4 border-black px-8 py-4 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]">
                         <span className="text-[10px] font-black text-silver/20 uppercase tracking-[0.4em] block mb-1 italic">SYSTEM_TIMEZONE_SYNC</span>
@@ -161,15 +203,15 @@ export default function Settings() {
 
             <div className="grid grid-cols-1 xl:grid-cols-4 gap-12 pt-4">
                 <main className="xl:col-span-3 space-y-20">
-                    
+
                     <section className="space-y-8">
                         <div className="flex items-center gap-4">
                             <h3 className="text-xs font-black text-silver-bright uppercase tracking-[0.4em] italic">Engine_Parameters</h3>
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <SelectField 
-                                label="Scanner_Intensity" 
+                            <SelectField
+                                label="Scanner_Intensity"
                                 description="PACKET_DENSITY_PER_SECOND_THRESHOLD"
                                 value={config.scanIntensity}
                                 onChange={(val: string) => setConfig({...config, scanIntensity: val})}
@@ -179,8 +221,8 @@ export default function Settings() {
                                     { label: 'Aggressive (Intrusive)', value: 'aggressive' },
                                 ]}
                             />
-                            <SelectField 
-                                label="Retention_Cycle" 
+                            <SelectField
+                                label="Retention_Cycle"
                                 description="AUTOMATED_LOG_PURGE_STRATEGY"
                                 value={config.dataRetention}
                                 onChange={(val: number) => setConfig({...config, dataRetention: val})}
@@ -191,15 +233,15 @@ export default function Settings() {
                                     { label: 'Indefinite', value: 0 },
                                 ]}
                             />
-                            <InputField 
-                                label="Concurrent_Operations" 
+                            <InputField
+                                label="Concurrent_Operations"
                                 description="MAX_PARALLEL_TASK_EXECUTION"
                                 type="number"
                                 value={config.concurrentScans}
                                 onChange={(val: number) => setConfig({...config, concurrentScans: val})}
                             />
-                            <InputField 
-                                label="Execution_Timeout" 
+                            <InputField
+                                label="Execution_Timeout"
                                 description="THRESHOLD_IN_SECONDS_PER_NODE"
                                 type="number"
                                 value={config.scanTimeout}
@@ -214,8 +256,8 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <SelectField 
-                                label="Temporal_Logic" 
+                            <SelectField
+                                label="Temporal_Logic"
                                 description="UI_CHRONOS_ALIGNMENT"
                                 value={config.timezone}
                                 onChange={(val: string) => setConfig({...config, timezone: val})}
@@ -225,8 +267,8 @@ export default function Settings() {
                                     { label: 'Fixed (ZULU)', value: 'GMT' },
                                 ]}
                             />
-                            <SelectField 
-                                label="Visual_Spectrum" 
+                            <SelectField
+                                label="Visual_Spectrum"
                                 description="OPERATIONAL_AESTHETIC_MODE"
                                 value={config.theme}
                                 onChange={(val: string) => setConfig({...config, theme: val})}
@@ -244,16 +286,16 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <InputField 
-                                label="Shodan_Enclave" 
+                            <InputField
+                                label="Shodan_Enclave"
                                 description="RECON_TELEMETRY_STREAM_TOKEN"
                                 placeholder="SHODAN_SECRET"
                                 type="password"
                                 value={config.shodanKey}
                                 onChange={(val: string) => setConfig({...config, shodanKey: val})}
                             />
-                            <InputField 
-                                label="VirusTotal_Enclave" 
+                            <InputField
+                                label="VirusTotal_Enclave"
                                 description="MALWARE_INTEL_ACCESS_HASH"
                                 placeholder="VT_SECRET_HASH"
                                 type="password"
@@ -273,7 +315,7 @@ export default function Settings() {
                                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-widest block italic">Authorized_Ingress_Vectors</label>
                                 <p className="text-[10px] text-silver/40 uppercase font-bold italic mb-6 leading-relaxed">Line-delimited IP/CIDR whitelist for high-privilege access</p>
                             </div>
-                            <textarea 
+                            <textarea
                                 value={config.ipWhitelist}
                                 onChange={(e) => setConfig({...config, ipWhitelist: e.target.value})}
                                 rows={4}
@@ -288,20 +330,20 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                            <Toggle 
-                                label="System_Signals" 
+                            <Toggle
+                                label="System_Signals"
                                 description="CRITICAL_RX_TELEMETRY"
                                 checked={config.notifications.systemAlerts}
                                 onChange={(val: boolean) => setConfig({...config, notifications: {...config.notifications, systemAlerts: val}})}
                             />
-                            <Toggle 
-                                label="Auto_Rescan" 
+                            <Toggle
+                                label="Auto_Rescan"
                                 description="TRIGGER_NEW_SCAN_ON_CRITICAL"
                                 checked={config.autoRescanCritical}
                                 onChange={(val: boolean) => setConfig({...config, autoRescanCritical: val})}
                             />
-                             <Toggle 
-                                label="Garbage_Collection" 
+                            <Toggle
+                                label="Garbage_Collection"
                                 description="AUTO_PURGE_FAILED_SESSIONS"
                                 checked={config.autoPurgeFailed}
                                 onChange={(val: boolean) => setConfig({...config, autoPurgeFailed: val})}
@@ -310,7 +352,7 @@ export default function Settings() {
                     </section>
 
                     <section className="pt-12">
-                        <button 
+                        <button
                             onClick={handleSave}
                             className="bg-rag-blue text-black px-12 py-6 text-xs font-black uppercase tracking-[0.3em] shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-4 italic group"
                         >
@@ -324,26 +366,21 @@ export default function Settings() {
                     <section className="bg-charcoal border-4 border-black p-10 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-6">
                         <h3 className="text-[11px] font-black text-silver-bright uppercase tracking-[0.5em] italic mb-8">Management_Tools</h3>
                         <div className="space-y-4">
-                            <button 
+                            <button
                                 onClick={handleExport}
                                 className="w-full py-4 bg-charcoal-dark border-4 border-black text-[10px] font-black text-silver/40 uppercase tracking-[0.3em] hover:bg-black hover:text-white transition-all italic"
                             >
                                 TELEMETRY_EXPORT
                             </button>
-                            <button 
-                                onClick={handleReset}
+                            <button
+                                onClick={() => setModalType('reset')}
                                 className="w-full py-4 bg-rag-amber border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all italic"
                             >
                                 ENGINE_RESET
                             </button>
-                            <button 
+                            <button
+                                onClick={() => setModalType('nuclearPurge')}
                                 className="w-full py-4 bg-rag-red border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-1 transition-all italic"
-                                onClick={() => {
-                                    if (window.confirm("CRITICAL: THIS WILL PURGE ALL HISTORY AND ASSETS. PROCEED?")) {
-                                        localStorage.clear();
-                                        window.location.reload();
-                                    }
-                                }}
                             >
                                 NUCLEAR_PURGE
                             </button>

--- a/frontend/testing/unit/components/ConfirmModal.test.tsx
+++ b/frontend/testing/unit/components/ConfirmModal.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ConfirmModal from '../../../src/components/ConfirmModal'
+
+describe('ConfirmModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    title: 'Delete_Record',
+    message: 'Are you sure you want to delete this record?',
+    confirmLabel: 'Delete',
+    danger: true,
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders modal when isOpen is true', () => {
+    render(<ConfirmModal {...defaultProps} />)
+    expect(screen.getByText('Delete_Record')).toBeInTheDocument()
+    expect(screen.getByText('Are you sure you want to delete this record?')).toBeInTheDocument()
+  })
+
+  it('does not render modal when isOpen is false', () => {
+    render(<ConfirmModal {...defaultProps} isOpen={false} />)
+    expect(screen.queryByText('Delete_Record')).not.toBeInTheDocument()
+  })
+
+  it('calls onConfirm when confirm button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<ConfirmModal {...defaultProps} />)
+    await user.click(screen.getByRole('button', { name: /Delete/i }))
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when cancel button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<ConfirmModal {...defaultProps} />)
+    await user.click(screen.getByRole('button', { name: /Cancel/i }))
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when backdrop is clicked', async () => {
+    const user = userEvent.setup()
+    render(<ConfirmModal {...defaultProps} />)
+    await user.click(document.querySelector('.fixed.inset-0')!)
+    expect(defaultProps.onCancel).toHaveBeenCalled()
+  })
+
+  it('calls onCancel when Escape key is pressed', async () => {
+    const user = userEvent.setup()
+    render(<ConfirmModal {...defaultProps} />)
+    await user.keyboard('{Escape}')
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onConfirm when Enter key is pressed', async () => {
+    const user = userEvent.setup()
+    render(<ConfirmModal {...defaultProps} />)
+    await user.keyboard('{Enter}')
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onConfirm when cancel is clicked', async () => {
+    const user = userEvent.setup()
+    render(<ConfirmModal {...defaultProps} />)
+    await user.click(screen.getByRole('button', { name: /Cancel/i }))
+    expect(defaultProps.onConfirm).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #33

## Changes
- Extracted a reusable `ConfirmModal` component to `components/ConfirmModal.tsx`
- Replaced 3 `window.confirm()` calls in `Scans.tsx` (delete record, bulk delete, purge all)
- Replaced 2 `window.confirm()` calls in `Settings.tsx` (engine reset, nuclear purge)
- Modal matches the existing neo-brutalist design system
- Supports keyboard navigation — Escape to cancel, Enter to confirm

## Testing
Tested locally — all 5 confirm dialogs now show the in-app modal correctly.