### PR TITLE
Add keyboard shortAdd keyboard shortcut tests for useShortcuts hookcut hook tests

### DIFF
--- a/frontend/testing/unit/hooks/useShortcuts.test.tsx
+++ b/frontend/testing/unit/hooks/useShortcuts.test.tsx
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useShortcuts } from '../../../src/hooks/useShortcuts'
+import { routes } from '../../../src/routes'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+describe('useShortcuts', () => {
+  afterEach(() => {
+    mockNavigate.mockClear()
+    vi.clearAllMocks()
+  })
+
+  it('navigates when a registered shortcut is pressed', () => {
+    renderHook(() => useShortcuts())
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'd' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith(routes.dashboard)
+  })
+
+  it('cleans up keydown listener on unmount', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+
+    const { unmount } = renderHook(() => useShortcuts())
+
+    expect(addSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
+
+    unmount()
+
+    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
+  })
+
+  it('ignores shortcuts while typing in an input', () => {
+    renderHook(() => useShortcuts())
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'g',
+        bubbles: true,
+      })
+    )
+
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'd',
+        bubbles: true,
+      })
+    )
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+
+    document.body.removeChild(input)
+  })
+
+  it('blurs editable input when Escape is pressed', () => {
+    renderHook(() => useShortcuts())
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+      })
+    )
+
+    expect(document.activeElement).not.toBe(input)
+
+    document.body.removeChild(input)
+  })
+})


### PR DESCRIPTION
## Description

Added focused unit tests for the existing `useShortcuts` hook to validate keyboard shortcut behavior, cleanup, and editable input handling.

## Related Issues

Closes #89

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## How Has This Been Tested?

* Ran `npm run test` inside the frontend directory
* Verified keyboard shortcut navigation behavior
* Verified cleanup of keydown event listeners on unmount
* Verified shortcuts are ignored while typing in editable inputs
* Verified Escape key blurs focused input fields

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
