### PR TITLE
fix: treat naive DB datetime as UTC in _should_run to prevent TypeError crash

### DIFF
--- a/backend/secuscan/workflows.py
+++ b/backend/secuscan/workflows.py
@@ -69,6 +69,12 @@ class WorkflowScheduler:
         if not last_run_at:
             return True
         last = datetime.fromisoformat(last_run_at.replace("Z", "+00:00"))
+        # SQLite's datetime('now') produces "2026-05-25 08:02:28" — no Z and
+        # no +00:00 suffix — so fromisoformat() returns a naive datetime.
+        # Subtracting a naive datetime from an aware one raises TypeError.
+        # Treat any naive timestamp from the DB as UTC.
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=timezone.utc)
         elapsed = (now - last).total_seconds()
         return elapsed >= schedule_seconds
 

--- a/testing/backend/unit/test_workflows_scheduler.py
+++ b/testing/backend/unit/test_workflows_scheduler.py
@@ -1,0 +1,89 @@
+"""
+Tests for WorkflowScheduler._should_run()
+
+Covers the timezone-naive/aware datetime bug where SQLite's datetime('now')
+produces strings without a timezone suffix, causing TypeError on subtraction.
+"""
+
+from datetime import datetime, timezone, timedelta
+import pytest
+
+from backend.secuscan.workflows import WorkflowScheduler
+
+
+@pytest.fixture
+def scheduler():
+    return WorkflowScheduler()
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Core behaviour
+# ---------------------------------------------------------------------------
+
+def test_should_run_when_no_last_run(scheduler):
+    """First-ever run: last_run_at is None → always run."""
+    assert scheduler._should_run(_now(), None, 3600) is True
+
+
+def test_should_run_when_elapsed_exceeds_schedule(scheduler):
+    """Last run was longer ago than schedule_seconds → run."""
+    last = (_now() - timedelta(seconds=7200)).isoformat()
+    assert scheduler._should_run(_now(), last, 3600) is True
+
+
+def test_should_not_run_when_elapsed_below_schedule(scheduler):
+    """Last run was recent → do not run."""
+    last = (_now() - timedelta(seconds=60)).isoformat()
+    assert scheduler._should_run(_now(), last, 3600) is False
+
+
+def test_should_run_at_exact_boundary(scheduler):
+    """Exactly at schedule_seconds elapsed → run."""
+    last = (_now() - timedelta(seconds=3600)).isoformat()
+    assert scheduler._should_run(_now(), last, 3600) is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: SQLite naive datetime string must not raise TypeError
+# ---------------------------------------------------------------------------
+
+def test_sqlite_naive_datetime_does_not_raise(scheduler):
+    """
+    Regression: SQLite datetime('now') produces '2026-05-25 08:02:28' —
+    no Z, no +00:00 suffix. fromisoformat() returns a naive datetime.
+    Subtracting naive from aware raises TypeError.
+    This test fails on the unfixed code and passes after the fix.
+    """
+    sqlite_format = "2026-05-25 08:02:28"   # exact format SQLite produces
+    now = datetime.now(timezone.utc)
+
+    # Must not raise TypeError
+    try:
+        result = scheduler._should_run(now, sqlite_format, 3600)
+        assert isinstance(result, bool)
+    except TypeError as e:
+        pytest.fail(
+            f"_should_run raised TypeError on SQLite naive datetime: {e}\n"
+            "Fix: add 'if last.tzinfo is None: last = last.replace(tzinfo=timezone.utc)'"
+        )
+
+
+def test_z_suffix_still_works(scheduler):
+    """ISO strings ending in Z (UTC marker) must still be handled correctly."""
+    last = (_now() - timedelta(seconds=7200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert scheduler._should_run(_now(), last, 3600) is True
+
+
+def test_offset_aware_iso_string_still_works(scheduler):
+    """Full ISO strings with +00:00 suffix must still be handled correctly."""
+    last = (_now() - timedelta(seconds=7200)).isoformat()
+    assert scheduler._should_run(_now(), last, 3600) is True
+
+
+def test_empty_string_treated_as_no_last_run(scheduler):
+    """Empty string last_run_at should behave like None → run."""
+    assert scheduler._should_run(_now(), "", 3600) is True


### PR DESCRIPTION
## Problem

`WorkflowScheduler._should_run()` crashed with `TypeError` on every scheduler tick after the first workflow run.

```python
# workflows.py — broken
last = datetime.fromisoformat(last_run_at.replace("Z", "+00:00"))
elapsed = (now - last).total_seconds()   # TypeError if last is naive
```

`now` is `datetime.now(timezone.utc)` — timezone-aware.
`last_run_at` comes from `datetime('now')` written by SQLite, which produces `"2026-05-25 08:02:28"` — no `Z`, no `+00:00`.
The `.replace("Z", "+00:00")` does nothing for this format.
`fromisoformat()` returns a naive datetime.
Python 3.8+ raises `TypeError: can't subtract offset-naive and offset-aware datetimes`.

**Reproducer:**
```python
from datetime import datetime, timezone
last = datetime.fromisoformat("2026-05-25 08:02:28")  # naive
now = datetime.now(timezone.utc)                       # aware
(now - last).total_seconds()                           # TypeError
```

## Fix

After parsing `last`, treat it as UTC if it has no timezone info:

```python
last = datetime.fromisoformat(last_run_at.replace("Z", "+00:00"))
if last.tzinfo is None:
    last = last.replace(tzinfo=timezone.utc)
elapsed = (now - last).total_seconds()
```

All timestamps written by the scheduler use `datetime('now')` which is UTC — treating naive values as UTC is correct.

## Changes

- `backend/secuscan/workflows.py` — 2 lines added to `_should_run()`
- `testing/backend/unit/test_workflows_scheduler.py` — new file, 8 tests

## Tests

| Test | Covers |
|---|---|
| `test_should_run_when_no_last_run` | `None` last_run_at → always run |
| `test_should_run_when_elapsed_exceeds_schedule` | elapsed > schedule → run |
| `test_should_not_run_when_elapsed_below_schedule` | elapsed < schedule → skip |
| `test_should_run_at_exact_boundary` | exactly at boundary → run |
| `test_sqlite_naive_datetime_does_not_raise` | **regression** — SQLite format must not raise TypeError |
| `test_z_suffix_still_works` | Z-suffix strings unaffected |
| `test_offset_aware_iso_string_still_works` | +00:00 strings unaffected |
| `test_empty_string_treated_as_no_last_run` | empty string → run |

## No breaking changes
Two lines added, nothing removed. No API or schema changes.

Closes #304