### PR TITLE
Production-Grade Target Validation Before Outbound Scans #204

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,5 @@ python-multipart>=0.0.9
 xhtml2pdf>=0.2.17
 aiosqlite>=0.20.0
 python-whois>=0.9.4
+dnspython>=2.6.0
+httpx>=0.25.0

--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -39,6 +39,24 @@ class Settings(BaseSettings):
     require_consent: bool = True
     allow_loopback_scans: bool = True
     allowed_networks: List[str] = ["127.0.0.1", "192.168.*.*", "10.*.*.*", "172.16.*.*"]
+    
+    # Network policy settings for target validation
+    allow_private_ips: bool = False  # Disable private IPs by default in permissive mode
+    allow_loopback: bool = True      # Allow 127.0.0.1 for local debugging
+
+    # Configurable allowlist/denylist as CIDR notation
+    network_allowlist: List[str] = []  # e.g., ["192.168.1.0/24", "10.0.0.0/8"]
+    network_denylist: List[str] = []   # e.g., ["169.254.169.254/32"]
+
+    # Hostname resolution behavior
+    dns_timeout_seconds: int = 2
+    max_redirect_hops: int = 5
+    resolve_hostname_before_scan: bool = True
+
+    # Audit/logging
+    log_blocked_targets: bool = True
+    blocked_target_log_file: str = str(PROJECT_ROOT / "logs" / "blocked_targets.log")
+
     cors_allowed_origins: List[str] = [
         "http://localhost:5173",
         "http://127.0.0.1:5173",
@@ -95,7 +113,7 @@ class Settings(BaseSettings):
         env_prefix = "SECUSCAN_"
         case_sensitive = False
 
-    @field_validator("cors_allowed_origins", "cors_allowed_methods", "cors_allowed_headers", "trusted_proxies", mode="before")
+    @field_validator("cors_allowed_origins", "cors_allowed_methods", "cors_allowed_headers", "trusted_proxies", "network_allowlist", "network_denylist", mode="before")
     @classmethod
     def parse_csv_or_list(cls, value: Any) -> Any:
         """Allow comma-separated env values in addition to JSON arrays."""

--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -4,7 +4,9 @@ Configuration management for SecuScan backend
 
 from pathlib import Path
 from typing import Any, List, Optional
+# pyrefly: ignore [missing-import]
 from pydantic import field_validator
+# pyrefly: ignore [missing-import]
 from pydantic_settings import BaseSettings
 import base64
 import hashlib
@@ -39,7 +41,7 @@ class Settings(BaseSettings):
     require_consent: bool = True
     allow_loopback_scans: bool = True
     allowed_networks: List[str] = ["127.0.0.1", "192.168.*.*", "10.*.*.*", "172.16.*.*"]
-    
+
     # Network policy settings for target validation
     allow_private_ips: bool = False  # Disable private IPs by default in permissive mode
     allow_loopback: bool = True      # Allow 127.0.0.1 for local debugging

--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -7,7 +7,7 @@ import json
 import sqlite3
 from pathlib import Path
 from typing import Any, Optional, List, Dict
-
+# pyrefly: ignore [missing-import]
 import aiosqlite
 from .config import settings
 

--- a/backend/secuscan/main.py
+++ b/backend/secuscan/main.py
@@ -7,10 +7,14 @@ import sys
 import shutil
 from pathlib import Path
 from contextlib import asynccontextmanager
+# pyrefly: ignore [missing-import]
 from .request_middleware import RequestIDMiddleware
 
+# pyrefly: ignore [missing-import]
 from fastapi import FastAPI
+# pyrefly: ignore [missing-import]
 from fastapi.middleware.cors import CORSMiddleware
+# pyrefly: ignore [missing-import]
 from fastapi.staticfiles import StaticFiles
 
 from .config import settings
@@ -92,16 +96,19 @@ app = FastAPI(
 
 @app.get("/api/docs", include_in_schema=False)
 async def redirect_api_docs():
+    # pyrefly: ignore [missing-import]
     from fastapi.responses import RedirectResponse
     return RedirectResponse(url="/docs")
 
 @app.get("/api/redoc", include_in_schema=False)
 async def redirect_api_redoc():
+    # pyrefly: ignore [missing-import]
     from fastapi.responses import RedirectResponse
     return RedirectResponse(url="/redoc")
 
 @app.get("/api/openapi.json", include_in_schema=False)
 async def redirect_api_openapi():
+    # pyrefly: ignore [missing-import]
     from fastapi.responses import RedirectResponse
     return RedirectResponse(url="/openapi.json")
 
@@ -159,6 +166,7 @@ async def root():
 
 def main():
     """Main entry point"""
+    # pyrefly: ignore [missing-import]
     import uvicorn
     
     logger.info("""

--- a/backend/secuscan/models.py
+++ b/backend/secuscan/models.py
@@ -4,6 +4,7 @@ Pydantic models for API requests and responses
 
 from typing import Optional, Dict, Any, List
 from datetime import datetime
+# pyrefly: ignore [missing-import]
 from pydantic import BaseModel, Field
 from enum import Enum
 

--- a/backend/secuscan/ratelimit.py
+++ b/backend/secuscan/ratelimit.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from typing import Tuple, Dict, List
 import asyncio
 
+# pyrefly: ignore [missing-import]
 from fastapi import Request, Response, HTTPException
 from .config import settings
 

--- a/backend/secuscan/reporting.py
+++ b/backend/secuscan/reporting.py
@@ -9,7 +9,9 @@ from datetime import datetime
 from functools import lru_cache
 from typing import Any, Dict, List
 
+# pyrefly: ignore [missing-import]
 from PIL import Image, ImageDraw
+# pyrefly: ignore [missing-import]
 from xhtml2pdf import pisa
 
 

--- a/backend/secuscan/request_middleware.py
+++ b/backend/secuscan/request_middleware.py
@@ -1,4 +1,6 @@
+# pyrefly: ignore [missing-import]
 from starlette.middleware.base import BaseHTTPMiddleware
+# pyrefly: ignore [missing-import]
 from fastapi import Request
 from .request_context import set_request_id
 

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -231,7 +231,7 @@ async def start_task(
         should_validate_target = plugin.category != "code" and not is_filesystem_target(target_str)
 
         if should_validate_target:
-            is_valid, error_msg = validate_target(target_str, safe_mode)
+            is_valid, error_msg = await validate_target(target_str, safe_mode)
 
             if not is_valid:
                 logger.warning(f"Task start failed: Target validation failed for '{target}': {error_msg}")

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -2,7 +2,9 @@
 API routes for SecuScan backend
 """
 
+# pyrefly: ignore [missing-import]
 from fastapi import APIRouter, HTTPException, BackgroundTasks, Response, Request, Depends
+# pyrefly: ignore [missing-import]
 from fastapi.responses import JSONResponse
 from typing import Any, Optional, List, Dict, Callable
 import json
@@ -81,6 +83,7 @@ from .reporting import reporting
 from .vault import VaultCrypto
 from .workflows import scheduler
 
+# pyrefly: ignore [missing-import]
 from sse_starlette.sse import EventSourceResponse
 
 router = APIRouter(prefix="/api/v1")

--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -104,22 +104,23 @@ def _validate_ip_network(net: ipaddress.IPv4Network | ipaddress.IPv6Network, saf
 
 async def resolve_hostname(hostname: str, timeout: int = 2) -> List[str]:
     """Resolve a hostname to IP addresses with timeout protection."""
+    # pyrefly: ignore [missing-import]
     import dns.resolver
-    
+
     ips = []
     loop = asyncio.get_event_loop()
-    
+
     for record_type in ('A', 'AAAA'):
         try:
             resolver = dns.resolver.Resolver()
             resolver.timeout = float(timeout)
             resolver.lifetime = float(timeout)
-            
+
             answer = await loop.run_in_executor(None, resolver.resolve, hostname, record_type)
             ips.extend([str(rdata) for rdata in answer])
         except Exception:
             pass
-            
+
     return list(set(ips))
 
 
@@ -127,7 +128,7 @@ def _log_blocked_target(target: str, reason: str) -> None:
     """Log a blocked target to the audit log."""
     if not settings.log_blocked_targets:
         return
-        
+
     import json
     from datetime import datetime
     import os
@@ -233,10 +234,10 @@ async def _validate_target_internal(
             else:
                 # No IPs returned
                 if safe_mode:
-                    return False, f"Failed to resolve hostname '{hostname_to_validate}'"
+                    return False, "Failed to resolve hostname"
         except Exception as e:
             if safe_mode:
-                return False, f"Failed to resolve hostname '{hostname_to_validate}': {e}"
+                return False, "Failed to resolve hostname"
             else:
                 logger.warning(f"DNS resolution failed for {hostname_to_validate}: {e}")
 
@@ -245,8 +246,9 @@ async def _validate_target_internal(
         max_hops = settings.max_redirect_hops
         if _redirect_depth >= max_hops:
             return False, f"Redirect chain exceeded maximum of {max_hops} hops"
-            
+
         try:
+            # pyrefly: ignore [missing-import]
             import httpx
             from urllib.parse import urljoin
             

--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -248,10 +248,9 @@ async def _validate_target_internal(
             return False, f"Redirect chain exceeded maximum of {max_hops} hops"
 
         try:
-            # pyrefly: ignore [missing-import]
             import httpx
             from urllib.parse import urljoin
-            
+
             # HEAD request with manual redirect following
             async with httpx.AsyncClient(follow_redirects=False, timeout=3.0) as client:
                 response = await client.head(target)

--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -4,42 +4,177 @@ Input validation and security checks
 
 import re
 import ipaddress
-from typing import Any, Dict, Tuple
+import logging
+import asyncio
+from typing import Any, Dict, Tuple, List, Optional
 from fnmatch import fnmatch
 
 from .config import settings
 
+logger = logging.getLogger(__name__)
 
-# Blocked network ranges
+# Blocked network ranges (RFC 5735, RFC 6890, RFC 1122, RFC 3927)
 BLOCKED_NETWORKS = [
-    ipaddress.ip_network("0.0.0.0/8"),       # Broadcast
-    ipaddress.ip_network("169.254.0.0/16"),  # Link-local
-    ipaddress.ip_network("224.0.0.0/4"),     # Multicast
+    ipaddress.ip_network("0.0.0.0/8"),           # This network
+    ipaddress.ip_network("169.254.0.0/16"),      # Link-local IPv4
+    ipaddress.ip_network("192.0.2.0/24"),        # TEST-NET-1
+    ipaddress.ip_network("198.18.0.0/15"),       # Benchmarking
+    ipaddress.ip_network("198.51.100.0/24"),     # TEST-NET-2
+    ipaddress.ip_network("203.0.113.0/24"),      # TEST-NET-3
+    ipaddress.ip_network("224.0.0.0/4"),         # Multicast
+    ipaddress.ip_network("240.0.0.0/4"),         # Reserved
+    ipaddress.ip_network("255.255.255.255/32"),  # Limited Broadcast
+    # IPv6 Special-Use Ranges (RFC 5156, RFC 4291)
+    ipaddress.ip_network("fe80::/10"),           # Link-local IPv6
+    ipaddress.ip_network("ff00::/8"),            # Multicast IPv6
 ]
 
-# Allowed private IP ranges
+# Allowed private IP ranges (RFC 1918)
 ALLOWED_PRIVATE = [
     ipaddress.ip_network("10.0.0.0/8"),
     ipaddress.ip_network("172.16.0.0/12"),
     ipaddress.ip_network("192.168.0.0/16"),
     ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),  # IPv6 loopback
 ]
 
 # Blocked TLDs in safe mode
 BLOCKED_TLDS = [".mil", ".gov"]
 
 
-def validate_target(target: str, safe_mode: bool = True) -> Tuple[bool, str]:
-    """
-    Validate scan target address (IP, Hostname, URL, or CIDR).
+def _parse_network(cidr: str) -> Optional[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    """Helper to parse a CIDR string safely without strict boundaries."""
+    try:
+        return ipaddress.ip_network(cidr.strip(), strict=False)
+    except ValueError:
+        return None
+
+
+def _validate_ip_network(net: ipaddress.IPv4Network | ipaddress.IPv6Network, safe_mode: bool) -> Tuple[bool, str]:
+    """Validate a network range (or single IP) against all active policies."""
+    # Check loopback (IPv4/IPv6 loopback)
+    is_loopback = net.is_loopback or net.overlaps(ipaddress.ip_network("127.0.0.0/8")) or net.overlaps(ipaddress.ip_network("::1/128"))
+
+    # Check private networks
+    is_private = any(
+        (net.version == pvt.version and (net.subnet_of(pvt) or net.overlaps(pvt)))
+        for pvt in ALLOWED_PRIVATE
+    )
+
+    # Safe mode check: public IPs/networks are never allowed under safe mode, even if in allowlist!
+    if safe_mode and not is_private and not is_loopback:
+        return False, "Public IPs/networks not allowed in safe mode (SecuScan Guardrail)"
+
+    # 1. Check explicit denylist first (highest priority)
+    denied_cidrs = [_parse_network(c) for c in settings.network_denylist if c]
+    for denied in denied_cidrs:
+        if denied and net.overlaps(denied):
+            return False, "Target overlaps with denied network range"
+
+    # 2. Check explicit allowlist
+    allowed_cidrs = [_parse_network(c) for c in settings.network_allowlist if c]
+    for allowed in allowed_cidrs:
+        if allowed and net.subnet_of(allowed):
+            return True, ""
+
+    # 3. Check loopback setting
+    if is_loopback:
+        allow_lb = settings.allow_loopback and settings.allow_loopback_scans
+        if not allow_lb:
+            return False, "Loopback scans are disabled in global settings"
+        return True, ""
+
+    # 4. Check system blocked networks
+    for blocked in BLOCKED_NETWORKS:
+        if net.overlaps(blocked):
+            return False, "Target overlaps with blocked network range"
+
+    # 5. Check private networks permission
+    if is_private:
+        if safe_mode:
+            return True, ""
+        else:
+            if settings.allow_private_ips:
+                return True, ""
+            else:
+                return False, "Private IP ranges are blocked in permissive mode unless explicitly allowed"
+
+    return True, ""
+
+
+async def resolve_hostname(hostname: str, timeout: int = 2) -> List[str]:
+    """Resolve a hostname to IP addresses with timeout protection."""
+    import dns.resolver
     
-    Args:
-        target: IP address, hostname, or network range to validate
-        safe_mode: Whether to enforce safe mode restrictions
+    ips = []
+    loop = asyncio.get_event_loop()
     
-    Returns:
-        Tuple of (is_valid, error_message)
+    for record_type in ('A', 'AAAA'):
+        try:
+            resolver = dns.resolver.Resolver()
+            resolver.timeout = float(timeout)
+            resolver.lifetime = float(timeout)
+            
+            answer = await loop.run_in_executor(None, resolver.resolve, hostname, record_type)
+            ips.extend([str(rdata) for rdata in answer])
+        except Exception:
+            pass
+            
+    return list(set(ips))
+
+
+def _log_blocked_target(target: str, reason: str) -> None:
+    """Log a blocked target to the audit log."""
+    if not settings.log_blocked_targets:
+        return
+        
+    import json
+    from datetime import datetime
+    import os
+    
+    log_file = settings.blocked_target_log_file
+    try:
+        os.makedirs(os.path.dirname(log_file), exist_ok=True)
+        log_entry = {
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "target": target,
+            "reason": reason
+        }
+        with open(log_file, "a") as f:
+            f.write(json.dumps(log_entry) + "\n")
+    except Exception as e:
+        logger.error(f"Failed to write to blocked targets log: {e}")
+
+
+async def validate_target(
+    target: str,
+    safe_mode: bool = True,
+    resolve_dns: bool = True,
+    follow_redirects: bool = True,
+    allowed_networks: Optional[List[str]] = None,
+    denied_networks: Optional[List[str]] = None,
+    _redirect_depth: int = 0
+) -> Tuple[bool, str]:
     """
+    Validate scan target address (IP, Hostname, URL, or CIDR) asynchronously.
+    """
+    is_valid, reason = await _validate_target_internal(
+        target, safe_mode, resolve_dns, follow_redirects, allowed_networks, denied_networks, _redirect_depth
+    )
+    if not is_valid and _redirect_depth == 0:
+        _log_blocked_target(target, reason)
+    return is_valid, reason
+
+
+async def _validate_target_internal(
+    target: str,
+    safe_mode: bool,
+    resolve_dns: bool,
+    follow_redirects: bool,
+    allowed_networks: Optional[List[str]],
+    denied_networks: Optional[List[str]],
+    _redirect_depth: int
+) -> Tuple[bool, str]:
     target = target.strip()
     if not target:
         return False, "Target cannot be empty"
@@ -47,37 +182,16 @@ def validate_target(target: str, safe_mode: bool = True) -> Tuple[bool, str]:
     # Try parsing as IP network (handles single IP and CIDR)
     try:
         net = ipaddress.ip_network(target, strict=False)
-        
-        # Check blocked networks (Broadcast, Link-local, Multicast)
-        if any(net.overlaps(blocked) for blocked in BLOCKED_NETWORKS):
-            return False, "Target overlaps with blocked network range"
-
-        # Check for loopback even in non-safe mode if desired (usually allowed for local debugging)
-        if net.is_loopback and not settings.allow_loopback_scans:
-            return False, "Loopback scans are disabled in global settings"
-
-        # Safe mode: only allow private IPs
-        if safe_mode:
-            is_private = any(
-                (net.version == allowed.version and (net.subnet_of(allowed) or net.overlaps(allowed)))
-                for allowed in ALLOWED_PRIVATE
-            )
-            if not is_private:
-                return False, "Public IPs/networks not allowed in safe mode (SecuScan Guardrail)"
-
-        return True, ""
-
+        return _validate_ip_network(net, safe_mode)
     except ValueError:
-        # Not an IP address or network, treat as hostname/URL
+        # Not a direct IP address or network, treat as hostname or URL
         pass
 
-    # Handle URLs
+    # Extract hostname
     hostname_to_validate = target
     if target.startswith(("http://", "https://")):
-        # Extract host:port or host (handle IPv6 literals in brackets)
         host_part = target.split("://", 1)[1].split("/", 1)[0]
         if host_part.startswith("["):
-            # IPv6 literal like [::1]:8080 or [::1] for ipv6
             hostname_to_validate = host_part.split("]")[0][1:]
         else:
             hostname_to_validate = host_part.split(":", 1)[0]
@@ -92,7 +206,73 @@ def validate_target(target: str, safe_mode: bool = True) -> Tuple[bool, str]:
             if hostname_to_validate.lower().endswith(tld):
                 return False, f"Domains ending in {tld} are blocked in safe mode"
 
+    # Check if the extracted hostname is actually a literal IP address!
+    is_literal_ip = False
+    try:
+        ip_net = ipaddress.ip_network(hostname_to_validate, strict=False)
+        is_literal_ip = True
+        is_valid, reason = _validate_ip_network(ip_net, safe_mode)
+        if not is_valid:
+            return False, reason
+    except ValueError:
+        pass
+
+    # DNS Resolution Check (only if not a literal IP)
+    if not is_literal_ip and resolve_dns and settings.resolve_hostname_before_scan:
+        try:
+            resolved_ips = await resolve_hostname(hostname_to_validate, timeout=settings.dns_timeout_seconds)
+            if resolved_ips:
+                for ip_str in resolved_ips:
+                    try:
+                        ip_net = ipaddress.ip_network(ip_str, strict=False)
+                        is_valid, reason = _validate_ip_network(ip_net, safe_mode)
+                        if not is_valid:
+                            return False, f"Hostname '{hostname_to_validate}' resolves to blocked IP {ip_str}: {reason}"
+                    except ValueError:
+                        continue
+            else:
+                # No IPs returned
+                if safe_mode:
+                    return False, f"Failed to resolve hostname '{hostname_to_validate}'"
+        except Exception as e:
+            if safe_mode:
+                return False, f"Failed to resolve hostname '{hostname_to_validate}': {e}"
+            else:
+                logger.warning(f"DNS resolution failed for {hostname_to_validate}: {e}")
+
+    # Follow redirects if target is URL
+    if target.startswith(("http://", "https://")) and follow_redirects:
+        max_hops = settings.max_redirect_hops
+        if _redirect_depth >= max_hops:
+            return False, f"Redirect chain exceeded maximum of {max_hops} hops"
+            
+        try:
+            import httpx
+            from urllib.parse import urljoin
+            
+            # HEAD request with manual redirect following
+            async with httpx.AsyncClient(follow_redirects=False, timeout=3.0) as client:
+                response = await client.head(target)
+                if response.status_code in (301, 302, 303, 307, 308):
+                    location = response.headers.get("location")
+                    if location:
+                        redirect_url = urljoin(target, location)
+                        # Recursively validate the redirect URL
+                        return await validate_target(
+                            redirect_url,
+                            safe_mode=safe_mode,
+                            resolve_dns=resolve_dns,
+                            follow_redirects=follow_redirects,
+                            allowed_networks=allowed_networks,
+                            denied_networks=denied_networks,
+                            _redirect_depth=_redirect_depth + 1
+                        )
+        except Exception as e:
+            # Failed to follow redirect, log and continue as original target was valid
+            logger.warning(f"Failed to follow redirect for {target}: {e}")
+
     return True, ""
+
 
 
 def validate_port(port: int) -> Tuple[bool, str]:

--- a/backend/secuscan/vault.py
+++ b/backend/secuscan/vault.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import os
 
+# pyrefly: ignore [missing-import]
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 

--- a/testing/backend/integration/test_phase2_plugins.py
+++ b/testing/backend/integration/test_phase2_plugins.py
@@ -88,7 +88,7 @@ def test_all_scantools_have_backend_plugins(test_client):
 
 def test_subdomain_discovery(test_client):
     mock_out = "admin.example.com\ndev.example.com\napi.example.com"
-    result = run_plugin_test(test_client, "subdomain_discovery", {"target": "example.com"}, mock_out)
+    result = run_plugin_test(test_client, "subdomain_discovery", {"target": "example.com", "safe_mode": False}, mock_out)
     assert len(result["structured"]["findings"]) > 0
     assert "admin.example.com" in result["raw_output_excerpt"]
 
@@ -135,11 +135,11 @@ def test_ssh_runner(test_client):
 
 def test_whois_lookup(test_client):
     mock_out = "Registrar: SafeNames Ltd.\nRegistry Expiry Date: 2026-01-01\nName Server: NS1.EXAMPLE.COM"
-    result = run_plugin_test(test_client, "whois_lookup", {"target": "example.com"}, mock_out)
+    result = run_plugin_test(test_client, "whois_lookup", {"target": "example.com", "safe_mode": False}, mock_out)
     assert result["structured"]["detail"]["registrar"] == "SafeNames Ltd."
 
 def test_dns_enum(test_client):
     mock_out = "[*] A example.com 93.184.216.34\n[*] MX mail.example.com 10"
-    result = run_plugin_test(test_client, "dns_enum", {"target": "example.com"}, mock_out)
+    result = run_plugin_test(test_client, "dns_enum", {"target": "example.com", "safe_mode": False}, mock_out)
     assert result["structured"]["count"] >= 2
     assert any(r["type"] == "MX" for r in result["structured"]["records"])

--- a/testing/backend/integration/test_phase3_plugins.py
+++ b/testing/backend/integration/test_phase3_plugins.py
@@ -70,7 +70,7 @@ def test_wpscan(test_client):
     result = run_plugin_test(
         test_client,
         "wpscan",
-        {"target": "https://wp.lab", "enumerate": "vp"},
+        {"target": "https://wp.lab", "enumerate": "vp", "safe_mode": False},
         mock_out,
     )
     assert any("WordPress Plugin Vulnerability" in f["title"] for f in result["structured"]["findings"])
@@ -78,13 +78,13 @@ def test_wpscan(test_client):
 
 def test_joomscan(test_client):
     mock_out = "[+] Vulnerable to: CVE-2015-8562\n[+] Joomla! version: 3.4.5"
-    result = run_plugin_test(test_client, "joomscan", {"target": "https://joomla.lab"}, mock_out)
+    result = run_plugin_test(test_client, "joomscan", {"target": "https://joomla.lab", "safe_mode": False}, mock_out)
     assert any("Joomla Vulnerability" in f["title"] for f in result["structured"]["findings"])
 
 
 def test_droopescan(test_client):
     mock_out = '{"vulnerabilities":[{"description":"CVE-2025-0001"}],"interesting urls":[{"description":"/admin"}]}'
-    result = run_plugin_test(test_client, "droopescan", {"target": "https://drupal.lab"}, mock_out)
+    result = run_plugin_test(test_client, "droopescan", {"target": "https://drupal.lab", "safe_mode": False}, mock_out)
     assert any("DroopeScan vulnerabilities" in f["title"] for f in result["structured"]["findings"])
 
 
@@ -141,7 +141,7 @@ def test_sqli_checker(test_client):
     result = run_plugin_test(
         test_client,
         "sqli_checker",
-        {"target": "https://api.lab/user?id=1", "level": 1, "risk": 1, "technique": "BEUSTQ"},
+        {"target": "https://api.lab/user?id=1", "level": 1, "risk": 1, "technique": "BEUSTQ", "safe_mode": False},
         mock_out,
     )
     findings = result["structured"]["findings"]

--- a/testing/backend/unit/test_cli.py
+++ b/testing/backend/unit/test_cli.py
@@ -1,5 +1,6 @@
 import sys
 from unittest.mock import patch, MagicMock, AsyncMock
+# pyrefly: ignore [missing-import]
 import pytest
 from backend.secuscan.cli import run_scan, main
 

--- a/testing/backend/unit/test_concurrent_limiter.py
+++ b/testing/backend/unit/test_concurrent_limiter.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 import asyncio
+# pyrefly: ignore [missing-import]
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 

--- a/testing/backend/unit/test_endpoint_rate_limiter.py
+++ b/testing/backend/unit/test_endpoint_rate_limiter.py
@@ -1,7 +1,10 @@
 import asyncio
 from datetime import datetime, timedelta
+# pyrefly: ignore [missing-import]
 import pytest
+# pyrefly: ignore [missing-import]
 from fastapi import Request, Response, HTTPException
+# pyrefly: ignore [missing-import]
 from fastapi.testclient import TestClient
 
 from backend.secuscan.config import settings

--- a/testing/backend/unit/test_executor.py
+++ b/testing/backend/unit/test_executor.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import uuid
 
+# pyrefly: ignore [missing-import]
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/testing/backend/unit/test_models.py
+++ b/testing/backend/unit/test_models.py
@@ -1,4 +1,6 @@
+# pyrefly: ignore [missing-import]
 import pytest
+# pyrefly: ignore [missing-import]
 from pydantic import ValidationError
 from backend.secuscan.models import TaskCreateRequest, PluginField, PluginFieldType
 

--- a/testing/backend/unit/test_target_validation_advanced.py
+++ b/testing/backend/unit/test_target_validation_advanced.py
@@ -1,0 +1,228 @@
+import pytest
+import asyncio
+import ipaddress
+from unittest.mock import AsyncMock, patch, MagicMock
+from backend.secuscan.validation import (
+    validate_target,
+    resolve_hostname,
+)
+from backend.secuscan.config import settings
+
+
+@pytest.mark.asyncio
+class TestDNSResolution:
+    """Test DNS resolution with SSRF prevention"""
+
+    @pytest.mark.asyncio
+    async def test_public_hostname_resolves_and_passes(self):
+        """Valid public hostname should resolve and pass"""
+        with patch("backend.secuscan.validation.resolve_hostname", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = ["8.8.8.8"]
+            is_valid, error = await validate_target(
+                "google.com",
+                safe_mode=False,
+                resolve_dns=True
+            )
+            assert is_valid
+            assert error == ""
+            mock_resolve.assert_called_once_with("google.com", timeout=settings.dns_timeout_seconds)
+
+    @pytest.mark.asyncio
+    async def test_hostname_resolving_to_private_ip_blocked(self):
+        """Hostname resolving to private IP should be blocked to prevent SSRF"""
+        with patch("backend.secuscan.validation.resolve_hostname", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = ["192.168.1.1"]
+            is_valid, error = await validate_target(
+                "internal.corp",
+                safe_mode=False,
+                resolve_dns=True
+            )
+            assert not is_valid
+            assert "resolves to blocked IP 192.168.1.1" in error
+
+    @pytest.mark.asyncio
+    async def test_hostname_resolving_to_aws_metadata_blocked(self):
+        """Hostname resolving to AWS metadata endpoint (link-local) should be blocked"""
+        with patch("backend.secuscan.validation.resolve_hostname", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = ["169.254.169.254"]
+            is_valid, error = await validate_target(
+                "aws-metadata.local",
+                safe_mode=False,
+                resolve_dns=True
+            )
+            assert not is_valid
+            assert "resolves to blocked IP 169.254.169.254" in error
+
+    @pytest.mark.asyncio
+    async def test_dns_timeout_or_failure_in_safe_mode(self):
+        """DNS resolution failure in safe mode should fail-closed"""
+        with patch("backend.secuscan.validation.resolve_hostname", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.side_effect = Exception("DNS Resolution Timeout")
+            is_valid, error = await validate_target(
+                "slow-dns.example.com",
+                safe_mode=True,
+                resolve_dns=True
+            )
+            assert not is_valid
+            assert "Failed to resolve hostname" in error
+
+    @pytest.mark.asyncio
+    async def test_dns_timeout_or_failure_in_permissive_mode(self):
+        """DNS resolution failure in permissive mode should fail-open"""
+        with patch("backend.secuscan.validation.resolve_hostname", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.side_effect = Exception("DNS Resolution Timeout")
+            is_valid, error = await validate_target(
+                "slow-dns.example.com",
+                safe_mode=False,
+                resolve_dns=True
+            )
+            assert is_valid
+            assert error == ""
+
+
+@pytest.mark.asyncio
+class TestHTTPRedirects:
+    """Test HTTP redirect validation"""
+
+    @pytest.mark.asyncio
+    async def test_redirect_to_public_url_allowed(self):
+        """Redirect to public URL should be allowed"""
+        mock_response_1 = MagicMock()
+        mock_response_1.status_code = 302
+        mock_response_1.headers = {"location": "https://final-destination.com"}
+
+        mock_response_2 = MagicMock()
+        mock_response_2.status_code = 200
+
+        with patch("httpx.AsyncClient.head") as mock_head, \
+             patch("backend.secuscan.validation.resolve_hostname", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = ["8.8.8.8"]
+            mock_head.side_effect = [mock_response_1, mock_response_2]
+
+            is_valid, error = await validate_target(
+                "https://short.link/123",
+                safe_mode=False,
+                follow_redirects=True,
+                resolve_dns=True
+            )
+            assert is_valid
+            assert error == ""
+
+    @pytest.mark.asyncio
+    async def test_redirect_to_private_ip_blocked(self):
+        """Redirect to private IP should be blocked"""
+        mock_response_1 = MagicMock()
+        mock_response_1.status_code = 302
+        mock_response_1.headers = {"location": "http://192.168.1.1:8080"}
+
+        with patch("httpx.AsyncClient.head") as mock_head, \
+             patch("backend.secuscan.validation.resolve_hostname", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = ["8.8.8.8"]
+            mock_head.return_value = mock_response_1
+
+            is_valid, error = await validate_target(
+                "https://attacker.com/redirect",
+                safe_mode=False,
+                follow_redirects=True,
+                resolve_dns=True
+            )
+            assert not is_valid
+            assert "Private IP ranges are blocked" in error or "Target overlaps with blocked network range" in error
+
+    @pytest.mark.asyncio
+    async def test_redirect_chain_exceeds_max_hops(self):
+        """Redirect chain exceeding max hops should fail"""
+        mock_response = MagicMock()
+        mock_response.status_code = 302
+        mock_response.headers = {"location": "https://attacker.com/infinite"}
+
+        with patch("httpx.AsyncClient.head", return_value=mock_response), \
+             patch("backend.secuscan.validation.resolve_hostname", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = ["8.8.8.8"]
+
+            # Use settings max hops (5)
+            is_valid, error = await validate_target(
+                "https://attacker.com/infinite",
+                safe_mode=False,
+                follow_redirects=True,
+                resolve_dns=True
+            )
+            assert not is_valid
+            assert "Redirect chain exceeded" in error
+
+
+@pytest.mark.asyncio
+class TestIPv6Handling:
+    """Test IPv6 target validation"""
+
+    @pytest.mark.asyncio
+    async def test_ipv6_public_address_allowed_in_permissive_mode(self):
+        """Public IPv6 address should be allowed in permissive mode"""
+        is_valid, error = await validate_target(
+            "2001:4860:4860::8888",  # Google Public DNS IPv6
+            safe_mode=False
+        )
+        assert is_valid
+        assert error == ""
+
+    @pytest.mark.asyncio
+    async def test_ipv6_loopback_blocked(self):
+        """IPv6 loopback should be blocked by default unless enabled"""
+        # Set loopback scans setting to false temporarily to verify
+        with patch.object(settings, "allow_loopback", False), \
+             patch.object(settings, "allow_loopback_scans", False):
+            is_valid, error = await validate_target(
+                "::1",
+                safe_mode=False
+            )
+            assert not is_valid
+            assert "Loopback scans are disabled" in error
+
+    @pytest.mark.asyncio
+    async def test_ipv6_link_local_blocked(self):
+        """IPv6 link-local (fe80::/10) should be blocked"""
+        is_valid, error = await validate_target(
+            "fe80::1",
+            safe_mode=False
+        )
+        assert not is_valid
+        assert "blocked network range" in error
+
+
+@pytest.mark.asyncio
+class TestOperatorPolicies:
+    """Test allowlist and denylist overrides"""
+
+    @pytest.mark.asyncio
+    async def test_allowlist_permits_private_ip(self):
+        """Allowlist overrides permissive mode private IP blocking"""
+        with patch.object(settings, "network_allowlist", ["10.0.0.0/8"]):
+            is_valid, error = await validate_target(
+                "10.5.5.5",
+                safe_mode=False
+            )
+            assert is_valid
+            assert error == ""
+
+    @pytest.mark.asyncio
+    async def test_denylist_takes_precedence_over_allowlist(self):
+        """Denylist takes absolute precedence over allowlist"""
+        with patch.object(settings, "network_allowlist", ["10.0.0.0/8"]), \
+             patch.object(settings, "network_denylist", ["10.1.1.0/24"]):
+            is_valid, error = await validate_target(
+                "10.1.1.5",
+                safe_mode=False
+            )
+            assert not is_valid
+            assert "denied network range" in error
+
+    @pytest.mark.asyncio
+    async def test_safe_mode_unaffected_by_allowlist(self):
+        """Safe mode still blocks public networks even if they are in allowlist"""
+        with patch.object(settings, "network_allowlist", ["8.8.8.0/24"]):
+            is_valid, error = await validate_target(
+                "8.8.8.8",
+                safe_mode=True
+            )
+            assert not is_valid
+            assert "Public IPs/networks not allowed in safe mode" in error

--- a/testing/backend/unit/test_validation.py
+++ b/testing/backend/unit/test_validation.py
@@ -5,20 +5,21 @@ from backend.secuscan.validation import (
 )
 
 
-def test_validate_target():
+@pytest.mark.asyncio
+async def test_validate_target():
     # Valid IP target
-    assert validate_target("192.168.1.1", safe_mode=True) == (True, "")
+    assert await validate_target("192.168.1.1", safe_mode=True) == (True, "")
 
     # Valid hostname target
-    assert validate_target("example.com", safe_mode=False) == (True, "")
+    assert await validate_target("example.com", safe_mode=False) == (True, "")
 
     # Safe mode restrictions
-    assert validate_target("8.8.8.8", safe_mode=True)[0] is False  # Public IP blocked in safe mode
-    assert validate_target("military.mil", safe_mode=True)[0] is False  # Blocked TLD
+    assert (await validate_target("8.8.8.8", safe_mode=True))[0] is False  # Public IP blocked in safe mode
+    assert (await validate_target("military.mil", safe_mode=True))[0] is False  # Blocked TLD
 
     # Invalid targets
-    assert validate_target("10.0.0.0/24")[0] is True  # Private CIDR ranges are allowed in safe mode
-    assert validate_target("not!a!valid!hostname")[0] is False
+    assert (await validate_target("10.0.0.0/24"))[0] is True  # Private CIDR ranges are allowed in safe mode
+    assert (await validate_target("not!a!valid!hostname"))[0] is False
 
 
 def test_validate_port():


### PR DESCRIPTION
Closes #204 

## Description
Implemented production-grade target validation and SSRF protections for outbound scans in SecuScan.

## Changes
 - Added async target validation with DNS resolution and timeout handling
 - Extended blocked network coverage for IPv4/IPv6, including link-local, loopback, multicast, and metadata ranges
 - Added hostname resolution checks to block DNS-based SSRF attempts
 - Implemented redirect validation with hop limits and recursive re-validation
 - Added configurable CIDR allowlist/denylist support with clear precedence rules
 - Added audit logging for blocked targets
 - Integrated async validation into /task/start
 - Added dnspython and httpx dependencies

##Testing

Added and updated async test coverage for:

 - Direct IPv4 and IPv6 validation
 - Hostnames resolving to private/metadata IPs
 - DNS timeout handling
 - Redirect validation and hop limits
 - Allowlist/denylist override behavior

All existing tests continue to pass and new security-sensitive negative tests were added.
