### PR TITLE
fix(workflows): align API contract with frontend

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -30,6 +30,32 @@ def parse_json_fields(rows: List[Dict], fields: List[str]) -> List[Dict]:
     return parsed
 
 
+def _parse_workflow_steps(raw_steps: Any) -> List[Dict[str, Any]]:
+    if isinstance(raw_steps, list):
+        return raw_steps
+    if not raw_steps:
+        return []
+    try:
+        parsed = json.loads(raw_steps)
+    except (TypeError, json.JSONDecodeError):
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def _serialize_workflow(row: Dict[str, Any], queued_task_ids: Optional[List[str]] = None) -> Dict[str, Any]:
+    """Return the workflow shape consumed by the frontend."""
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "schedule_seconds": row.get("schedule_seconds"),
+        "enabled": bool(row.get("enabled")),
+        "steps": _parse_workflow_steps(row.get("steps_json")),
+        "created_at": row.get("created_at"),
+        "last_run_at": row.get("last_run_at"),
+        "queued_task_ids": queued_task_ids or [],
+    }
+
+
 def is_filesystem_target(target: str) -> bool:
     """Best-effort detection for path-based targets that should bypass host validation."""
     if target.startswith(("/", "./", "../", "~")):
@@ -952,7 +978,8 @@ async def delete_vault_secret(name: str):
 async def list_workflows():
     db = await get_db()
     rows = await db.fetchall("SELECT * FROM workflows ORDER BY created_at DESC")
-    return {"workflows": parse_json_fields(rows, ["steps_json"]), "total": len(rows)}
+    workflows = [_serialize_workflow(row) for row in rows]
+    return {"workflows": workflows, "total": len(workflows)}
 
 
 @router.post("/workflows")
@@ -982,7 +1009,8 @@ async def create_workflow(payload: Dict[str, Any]):
             json.dumps(steps),
         ),
     )
-    return {"id": workflow_id, "created": True}
+    row = await db.fetchone("SELECT * FROM workflows WHERE id = ?", (workflow_id,))
+    return _serialize_workflow(row) if row else {"id": workflow_id, "created": True}
 
 
 @router.post("/workflows/{workflow_id}/run")
@@ -1003,7 +1031,11 @@ async def run_workflow_once(workflow_id: str):
         asyncio.create_task(executor.execute_task(task_id))
         created_task_ids.append(task_id)
     await db.execute("UPDATE workflows SET last_run_at = datetime('now') WHERE id = ?", (workflow_id,))
-    return {"workflow_id": workflow_id, "queued_tasks": created_task_ids}
+    return {
+        "workflow_id": workflow_id,
+        "queued_task_ids": created_task_ids,
+        "queued_tasks": created_task_ids,
+    }
 
 
 @router.patch("/workflows/{workflow_id}")
@@ -1034,7 +1066,8 @@ async def update_workflow(workflow_id: str, payload: Dict[str, Any]):
 
     params.append(workflow_id)
     await db.execute(f"UPDATE workflows SET {', '.join(updates)} WHERE id = ?", tuple(params))
-    return {"workflow_id": workflow_id, "updated": True}
+    updated = await db.fetchone("SELECT * FROM workflows WHERE id = ?", (workflow_id,))
+    return _serialize_workflow(updated) if updated else {"workflow_id": workflow_id, "updated": True}
 
 
 @router.delete("/workflows/{workflow_id}")

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -187,7 +187,7 @@ export interface WorkflowStep {
 export interface Workflow {
   id: string
   name: string
-  schedule_interval: string
+  schedule_seconds: number | null
   enabled: boolean
   steps: WorkflowStep[]
   last_run_at?: string | null
@@ -197,43 +197,94 @@ export interface Workflow {
 
 export interface WorkflowCreatePayload {
   name: string
-  schedule_interval: string
+  schedule_seconds?: number | null
   enabled: boolean
   steps: WorkflowStep[]
 }
 
 export interface WorkflowUpdatePayload {
   name?: string
-  schedule_interval?: string
+  schedule_seconds?: number | null
   enabled?: boolean
   steps?: WorkflowStep[]
 }
 
-export function getWorkflows(): Promise<Workflow[]> {
-  return request<Workflow[]>('/workflows')
+interface WorkflowListResponse {
+  workflows: unknown[]
+  total: number
 }
 
-export function createWorkflow(data: WorkflowCreatePayload): Promise<Workflow> {
-  return request<Workflow>('/workflows', {
+function parseWorkflowSteps(value: unknown): WorkflowStep[] {
+  if (Array.isArray(value)) return value as WorkflowStep[]
+  if (typeof value !== 'string' || value.trim() === '') return []
+
+  try {
+    const parsed = JSON.parse(value)
+    return Array.isArray(parsed) ? parsed as WorkflowStep[] : []
+  } catch {
+    return []
+  }
+}
+
+function parseScheduleSeconds(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function normalizeWorkflow(raw: any): Workflow {
+  return {
+    id: String(raw.id),
+    name: String(raw.name ?? ''),
+    schedule_seconds: parseScheduleSeconds(raw.schedule_seconds),
+    enabled: Boolean(raw.enabled),
+    steps: parseWorkflowSteps(raw.steps ?? raw.steps_json),
+    last_run_at: raw.last_run_at ?? null,
+    queued_task_ids: Array.isArray(raw.queued_task_ids)
+      ? raw.queued_task_ids
+      : Array.isArray(raw.queued_tasks)
+        ? raw.queued_tasks
+        : [],
+    created_at: raw.created_at,
+  }
+}
+
+export async function getWorkflows(): Promise<Workflow[]> {
+  const data = await request<WorkflowListResponse | unknown[]>('/workflows')
+  const workflows = Array.isArray(data) ? data : data.workflows
+  return Array.isArray(workflows) ? workflows.map(normalizeWorkflow) : []
+}
+
+export async function createWorkflow(data: WorkflowCreatePayload): Promise<Workflow> {
+  const workflow = await request<unknown>('/workflows', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
+  return normalizeWorkflow(workflow)
 }
 
-export function runWorkflow(workflowId: string): Promise<{ queued_task_ids: string[] }> {
-  return request<{ queued_task_ids: string[] }>(`/workflows/${workflowId}/run`, {
+export async function runWorkflow(workflowId: string): Promise<{ queued_task_ids: string[] }> {
+  const result: any = await request(`/workflows/${workflowId}/run`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
   })
+  return {
+    queued_task_ids: Array.isArray(result.queued_task_ids)
+      ? result.queued_task_ids
+      : Array.isArray(result.queued_tasks)
+        ? result.queued_tasks
+        : [],
+  }
 }
 
-export function updateWorkflow(workflowId: string, data: WorkflowUpdatePayload): Promise<Workflow> {
-  return request<Workflow>(`/workflows/${workflowId}`, {
+export async function updateWorkflow(workflowId: string, data: WorkflowUpdatePayload): Promise<Workflow> {
+  const workflow = await request<unknown>(`/workflows/${workflowId}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
+  return normalizeWorkflow(workflow)
 }
 
 export function deleteWorkflow(workflowId: string): Promise<{ deleted: boolean }> {

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -34,6 +34,28 @@ function timeAgo(iso?: string | null) {
   return `${Math.floor(hrs / 24)}d ago`
 }
 
+function formatSchedule(scheduleSeconds?: number | null) {
+  if (!scheduleSeconds || scheduleSeconds <= 0) return 'Manual'
+  if (scheduleSeconds < 60) return `Every ${scheduleSeconds}s`
+
+  const minutes = scheduleSeconds / 60
+  if (Number.isInteger(minutes) && minutes < 60) {
+    return `Every ${minutes}m`
+  }
+
+  const hours = scheduleSeconds / 3600
+  if (Number.isInteger(hours) && hours < 24) {
+    return `Every ${hours}h`
+  }
+
+  const days = scheduleSeconds / 86400
+  if (Number.isInteger(days)) {
+    return `Every ${days}d`
+  }
+
+  return `Every ${scheduleSeconds}s`
+}
+
 interface DeleteDialogProps {
   name: string
   onConfirm: () => void
@@ -79,7 +101,7 @@ interface CreateSheetProps {
 
 function CreateSheet({ onClose, onCreated }: CreateSheetProps) {
   const [name, setName] = useState('')
-  const [interval, setInterval] = useState('0 * * * *')
+  const [scheduleSeconds, setScheduleSeconds] = useState('3600')
   const [enabled, setEnabled] = useState(true)
   const [stepsJson, setStepsJson] = useState(JSON.stringify(emptySteps, null, 2))
   const [jsonError, setJsonError] = useState<string | null>(null)
@@ -99,9 +121,19 @@ function CreateSheet({ onClose, onCreated }: CreateSheetProps) {
       return
     }
 
+    const trimmedSchedule = scheduleSeconds.trim()
+    const parsedSchedule = trimmedSchedule === '' ? null : Number(trimmedSchedule)
+    if (
+      parsedSchedule !== null &&
+      (!Number.isInteger(parsedSchedule) || parsedSchedule <= 0)
+    ) {
+      setError('Schedule must be a positive whole number of seconds')
+      return
+    }
+
     setLoading(true)
     try {
-      const payload: WorkflowCreatePayload = { name, schedule_interval: interval, enabled, steps }
+      const payload: WorkflowCreatePayload = { name, schedule_seconds: parsedSchedule, enabled, steps }
       const created = await createWorkflow(payload)
       onCreated(created)
     } catch {
@@ -134,12 +166,12 @@ function CreateSheet({ onClose, onCreated }: CreateSheetProps) {
           </div>
 
           <div className="space-y-2">
-            <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em]">Schedule (cron)</label>
+            <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em]">Schedule (seconds)</label>
             <input
-              required
-              value={interval}
-              onChange={e => setInterval(e.target.value)}
-              placeholder="0 * * * *"
+              value={scheduleSeconds}
+              onChange={e => setScheduleSeconds(e.target.value)}
+              placeholder="3600"
+              inputMode="numeric"
               className="w-full bg-charcoal-dark border-4 border-black px-4 py-3 text-sm text-silver-bright font-mono placeholder:text-silver/30 focus:outline-none focus:border-rag-red transition-colors"
             />
           </div>
@@ -211,7 +243,7 @@ function WorkflowCard({ workflow, onToggle, onRun, onDelete, running, toggling }
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1 min-w-0">
             <h3 className="text-xl font-black text-silver-bright uppercase tracking-tight truncate">{workflow.name}</h3>
-            <p className="text-[10px] font-mono text-silver/40 uppercase tracking-widest">{workflow.schedule_interval}</p>
+            <p className="text-[10px] font-mono text-silver/40 uppercase tracking-widest">{formatSchedule(workflow.schedule_seconds)}</p>
           </div>
           <span className={`shrink-0 px-2 py-1 text-[9px] font-black uppercase tracking-widest border-2 border-black ${workflow.enabled ? 'bg-rag-green text-black' : 'bg-charcoal-dark text-silver/40'}`}>
             {workflow.enabled ? 'Enabled' : 'Disabled'}
@@ -289,7 +321,7 @@ export default function Workflows() {
     setError(null)
     try {
       const data = await getWorkflows()
-      setWorkflows(Array.isArray(data) ? data : [])
+      setWorkflows(data)
     } catch {
       setError('Failed to load workflows')
     } finally {

--- a/frontend/testing/unit/api.workflows.test.ts
+++ b/frontend/testing/unit/api.workflows.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createWorkflow, getWorkflows, runWorkflow, updateWorkflow } from '../../src/api'
+
+function mockJsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(body),
+  } as Response)
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('workflow API helpers', () => {
+  it('normalizes backend workflow list responses', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(mockJsonResponse({
+      workflows: [
+        {
+          id: 'wf-001',
+          name: 'Nightly Scan',
+          schedule_seconds: '3600',
+          enabled: 1,
+          steps_json: '[{"plugin_id":"nmap","inputs":{}}]',
+          last_run_at: null,
+        },
+      ],
+      total: 1,
+    })))
+
+    const workflows = await getWorkflows()
+
+    expect(workflows).toEqual([
+      {
+        id: 'wf-001',
+        name: 'Nightly Scan',
+        schedule_seconds: 3600,
+        enabled: true,
+        steps: [{ plugin_id: 'nmap', inputs: {} }],
+        last_run_at: null,
+        queued_task_ids: [],
+        created_at: undefined,
+      },
+    ])
+  })
+
+  it('sends schedule_seconds when creating workflows', async () => {
+    const fetchMock = vi.fn().mockReturnValue(mockJsonResponse({
+      id: 'wf-002',
+      name: 'Hourly Scan',
+      schedule_seconds: 3600,
+      enabled: true,
+      steps: [{ plugin_id: 'http_inspector', inputs: {} }],
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await createWorkflow({
+      name: 'Hourly Scan',
+      schedule_seconds: 3600,
+      enabled: true,
+      steps: [{ plugin_id: 'http_inspector', inputs: {} }],
+    })
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(JSON.parse(init.body)).toMatchObject({
+      name: 'Hourly Scan',
+      schedule_seconds: 3600,
+      enabled: true,
+    })
+  })
+
+  it('normalizes queued_tasks from workflow run responses', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(mockJsonResponse({
+      workflow_id: 'wf-001',
+      queued_tasks: ['task-001'],
+    })))
+
+    await expect(runWorkflow('wf-001')).resolves.toEqual({
+      queued_task_ids: ['task-001'],
+    })
+  })
+
+  it('normalizes updated workflow responses', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(mockJsonResponse({
+      id: 'wf-001',
+      name: 'Nightly Scan',
+      schedule_seconds: 7200,
+      enabled: 0,
+      steps_json: '[]',
+    })))
+
+    await expect(updateWorkflow('wf-001', { enabled: false })).resolves.toMatchObject({
+      id: 'wf-001',
+      schedule_seconds: 7200,
+      enabled: false,
+      steps: [],
+    })
+  })
+})

--- a/frontend/testing/unit/pages/Workflows.test.tsx
+++ b/frontend/testing/unit/pages/Workflows.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import Workflows from '../../../src/pages/Workflows'
-import { getWorkflows, runWorkflow, updateWorkflow, deleteWorkflow } from '../../../src/api'
+import { getWorkflows, createWorkflow, runWorkflow, updateWorkflow, deleteWorkflow } from '../../../src/api'
 
 vi.mock('../../../src/api', () => ({
   getWorkflows: vi.fn(),
@@ -15,7 +15,7 @@ vi.mock('../../../src/api', () => ({
 const mockWorkflow = {
   id: 'wf-001',
   name: 'Nightly Scan',
-  schedule_interval: '0 0 * * *',
+  schedule_seconds: 3600,
   enabled: true,
   steps: [{ plugin_id: 'nmap', inputs: {} }],
   last_run_at: null,
@@ -99,13 +99,39 @@ describe('Workflows — listing', () => {
   it('shows schedule interval', async () => {
     renderPage()
     await screen.findByText('Nightly Scan')
-    expect(screen.getAllByText('0 0 * * *').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Every 1h').length).toBeGreaterThan(0)
   })
 
   it('shows step count', async () => {
     renderPage()
     await screen.findByText('Nightly Scan')
     expect(screen.getAllByText('1').length).toBeGreaterThan(0)
+  })
+})
+
+describe('Workflows — create action', () => {
+  beforeEach(() => {
+    vi.mocked(getWorkflows).mockResolvedValue([])
+    vi.mocked(createWorkflow).mockResolvedValue(mockWorkflow)
+  })
+
+  it('creates workflow with schedule_seconds payload', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByText(/No Workflows/i)
+
+    await user.click(screen.getAllByRole('button', { name: /New Workflow/i })[0])
+    await user.type(screen.getByPlaceholderText('My Workflow'), 'Nightly Scan')
+    await user.clear(screen.getByPlaceholderText('3600'))
+    await user.type(screen.getByPlaceholderText('3600'), '7200')
+    await user.click(screen.getByRole('button', { name: /^Create$/i }))
+
+    expect(vi.mocked(createWorkflow)).toHaveBeenCalledWith({
+      name: 'Nightly Scan',
+      schedule_seconds: 7200,
+      enabled: true,
+      steps: [{ plugin_id: '', inputs: {} }],
+    })
   })
 })
 

--- a/testing/backend/integration/test_workflows_contract.py
+++ b/testing/backend/integration/test_workflows_contract.py
@@ -1,0 +1,60 @@
+from unittest.mock import AsyncMock, patch
+
+
+def _workflow_payload(name: str = "Nightly Scan"):
+    return {
+        "name": name,
+        "schedule_seconds": 3600,
+        "enabled": True,
+        "steps": [{"plugin_id": "http_inspector", "inputs": {"url": "http://127.0.0.1:8000"}}],
+    }
+
+
+def test_workflow_create_list_update_contract(test_client):
+    create_response = test_client.post("/api/v1/workflows", json=_workflow_payload())
+    assert create_response.status_code == 200
+    created = create_response.json()
+
+    assert created["id"]
+    assert created["name"] == "Nightly Scan"
+    assert created["schedule_seconds"] == 3600
+    assert created["enabled"] is True
+    assert created["steps"] == [{"plugin_id": "http_inspector", "inputs": {"url": "http://127.0.0.1:8000"}}]
+    assert created["queued_task_ids"] == []
+    assert "steps_json" not in created
+
+    list_response = test_client.get("/api/v1/workflows")
+    assert list_response.status_code == 200
+    listed = list_response.json()
+    assert listed["total"] == 1
+    assert listed["workflows"][0]["id"] == created["id"]
+    assert listed["workflows"][0]["schedule_seconds"] == 3600
+    assert listed["workflows"][0]["steps"] == created["steps"]
+    assert "steps_json" not in listed["workflows"][0]
+
+    update_response = test_client.patch(
+        f"/api/v1/workflows/{created['id']}",
+        json={"schedule_seconds": 7200, "enabled": False},
+    )
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["id"] == created["id"]
+    assert updated["schedule_seconds"] == 7200
+    assert updated["enabled"] is False
+    assert updated["steps"] == created["steps"]
+
+
+def test_workflow_run_uses_queued_task_ids_contract(test_client):
+    create_response = test_client.post("/api/v1/workflows", json=_workflow_payload("Run Contract"))
+    workflow_id = create_response.json()["id"]
+
+    with (
+        patch("backend.secuscan.routes.executor.create_task", new=AsyncMock(return_value="task-001")),
+        patch("backend.secuscan.routes.executor.execute_task", new=AsyncMock()),
+    ):
+        run_response = test_client.post(f"/api/v1/workflows/{workflow_id}/run")
+
+    assert run_response.status_code == 200
+    data = run_response.json()
+    assert data["workflow_id"] == workflow_id
+    assert data["queued_task_ids"] == ["task-001"]


### PR DESCRIPTION
## Description

Aligns the workflow API contract between the FastAPI backend and React frontend so the Workflows page can render backend responses reliably.

This PR updates workflow list/create/update/run handling to use the backend `schedule_seconds` model, returns normalized workflow objects from backend write routes, and keeps frontend API normalization tolerant of the older `steps_json` and `queued_tasks` shapes.

I am contributing this under GSSoC.

## Related Issues

Closes #379

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] `npm test -- --run testing/unit/pages/Workflows.test.tsx testing/unit/api.workflows.test.ts`
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `.venv/bin/python -m py_compile backend/secuscan/routes.py testing/backend/integration/test_workflows_contract.py`

Backend pytest note: I added integration coverage for the workflow contract, but local backend pytest execution is blocked in this environment because installing `xhtml2pdf` requires native Cairo development packages. The repo CI already installs `libcairo2-dev pkg-config`, so CI should be able to run it.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
