### PR TITLE
feat: Export findings directly to Jira and GitHub Issues (#377)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ python-multipart>=0.0.9
 xhtml2pdf>=0.2.17
 aiosqlite>=0.20.0
 python-whois>=0.9.4
+httpx>=0.27.0

--- a/backend/secuscan/integrations.py
+++ b/backend/secuscan/integrations.py
@@ -1,0 +1,115 @@
+import httpx
+import logging
+from typing import Dict, Any
+from .models import Finding
+
+logger = logging.getLogger(__name__)
+
+async def create_jira_ticket(finding: Finding, config: Dict[str, str]) -> Dict[str, Any]:
+    url = config.get("jiraUrl", "").rstrip("/")
+    email = config.get("jiraEmail")
+    token = config.get("jiraToken")
+    project_key = config.get("jiraProject")
+
+    if not all([url, email, token, project_key]):
+        raise ValueError("Missing Jira configuration parameters")
+
+    api_url = f"{url}/rest/api/2/issue"
+    
+    description = f"""
+*Target:* {finding.target}
+*Severity:* {finding.severity}
+*Category:* {finding.category}
+*Discovered At:* {finding.discovered_at}
+
+*Description:*
+{finding.description}
+
+*Remediation:*
+{finding.remediation}
+"""
+    if finding.cve:
+        description += f"\n*CVE:* {finding.cve}"
+
+    payload = {
+        "fields": {
+            "project": {
+                "key": project_key
+            },
+            "summary": f"[{finding.severity.upper()}] {finding.title}",
+            "description": description,
+            "issuetype": {
+                "name": "Bug"
+            }
+        }
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            api_url,
+            json=payload,
+            auth=(email, token),
+            headers={"Content-Type": "application/json"}
+        )
+        
+        if response.status_code >= 400:
+            logger.error(f"Jira API error: {response.text}")
+            raise Exception(f"Failed to create Jira ticket: {response.status_code} {response.text}")
+            
+        data = response.json()
+        return {
+            "ticket_id": data.get("key"),
+            "ticket_url": f"{url}/browse/{data.get('key')}"
+        }
+
+
+async def create_github_issue(finding: Finding, config: Dict[str, str]) -> Dict[str, Any]:
+    token = config.get("githubToken")
+    repo = config.get("githubRepo")
+
+    if not all([token, repo]):
+        raise ValueError("Missing GitHub configuration parameters")
+
+    api_url = f"https://api.github.com/repos/{repo}/issues"
+    
+    body = f"""
+**Target:** `{finding.target}`
+**Severity:** {finding.severity.upper()}
+**Category:** {finding.category}
+**Discovered At:** {finding.discovered_at}
+
+### Description
+{finding.description}
+
+### Remediation
+{finding.remediation}
+"""
+    if finding.cve:
+        body += f"\n**CVE:** {finding.cve}"
+
+    payload = {
+        "title": f"[{finding.severity.upper()}] {finding.title}",
+        "body": body,
+        "labels": ["bug", "security"]
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            api_url,
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github.v3+json",
+                "X-GitHub-Api-Version": "2022-11-28"
+            }
+        )
+        
+        if response.status_code >= 400:
+            logger.error(f"GitHub API error: {response.text}")
+            raise Exception(f"Failed to create GitHub issue: {response.status_code} {response.text}")
+            
+        data = response.json()
+        return {
+            "ticket_id": str(data.get("number")),
+            "ticket_url": data.get("html_url")
+        }

--- a/backend/secuscan/integrations.py
+++ b/backend/secuscan/integrations.py
@@ -15,7 +15,7 @@ async def create_jira_ticket(finding: Finding, config: Dict[str, str]) -> Dict[s
         raise ValueError("Missing Jira configuration parameters")
 
     api_url = f"{url}/rest/api/2/issue"
-    
+
     description = f"""
 *Target:* {finding.target}
 *Severity:* {finding.severity}
@@ -51,11 +51,11 @@ async def create_jira_ticket(finding: Finding, config: Dict[str, str]) -> Dict[s
             auth=(email, token),
             headers={"Content-Type": "application/json"}
         )
-        
+
         if response.status_code >= 400:
             logger.error(f"Jira API error: {response.text}")
             raise Exception(f"Failed to create Jira ticket: {response.status_code} {response.text}")
-            
+
         data = response.json()
         return {
             "ticket_id": data.get("key"),
@@ -71,7 +71,7 @@ async def create_github_issue(finding: Finding, config: Dict[str, str]) -> Dict[
         raise ValueError("Missing GitHub configuration parameters")
 
     api_url = f"https://api.github.com/repos/{repo}/issues"
-    
+
     body = f"""
 **Target:** `{finding.target}`
 **Severity:** {finding.severity.upper()}
@@ -103,11 +103,11 @@ async def create_github_issue(finding: Finding, config: Dict[str, str]) -> Dict[
                 "X-GitHub-Api-Version": "2022-11-28"
             }
         )
-        
+
         if response.status_code >= 400:
             logger.error(f"GitHub API error: {response.text}")
             raise Exception(f"Failed to create GitHub issue: {response.status_code} {response.text}")
-            
+
         data = response.json()
         return {
             "ticket_id": str(data.get("number")),

--- a/backend/secuscan/models.py
+++ b/backend/secuscan/models.py
@@ -161,3 +161,16 @@ class ErrorResponse(BaseModel):
     message: str
     field: Optional[str] = None
     details: Optional[Dict[str, Any]] = None
+
+
+class TicketCreateRequest(BaseModel):
+    """Request to create a ticket in an external integration"""
+    provider: str  # "jira" or "github"
+    finding: Finding
+    config: Dict[str, str]  # credentials and config for the integration
+
+
+class TicketResponse(BaseModel):
+    """Response after creating a ticket"""
+    ticket_id: str
+    ticket_url: str

--- a/backend/secuscan/models.py
+++ b/backend/secuscan/models.py
@@ -170,11 +170,15 @@ class ErrorResponse(BaseModel):
     details: Optional[Dict[str, Any]] = None
 
 
+class BulkDeleteRequest(RootModel[Annotated[List[str], Field(max_length=MAX_BULK_DELETE)]]):
+    """Accepts a JSON array of task IDs directly. Max 500 per request."""
+    pass
+
+
 class TicketCreateRequest(BaseModel):
     """Request to create a ticket in an external integration"""
     provider: str  # "jira" or "github"
     finding: Finding
-    config: Dict[str, str]  # credentials and config for the integration
 
 
 class TicketResponse(BaseModel):

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -30,6 +30,32 @@ def parse_json_fields(rows: List[Dict], fields: List[str]) -> List[Dict]:
     return parsed
 
 
+def _parse_workflow_steps(raw_steps: Any) -> List[Dict[str, Any]]:
+    if isinstance(raw_steps, list):
+        return raw_steps
+    if not raw_steps:
+        return []
+    try:
+        parsed = json.loads(raw_steps)
+    except (TypeError, json.JSONDecodeError):
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def _serialize_workflow(row: Dict[str, Any], queued_task_ids: Optional[List[str]] = None) -> Dict[str, Any]:
+    """Return the workflow shape consumed by the frontend."""
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "schedule_seconds": row.get("schedule_seconds"),
+        "enabled": bool(row.get("enabled")),
+        "steps": _parse_workflow_steps(row.get("steps_json")),
+        "created_at": row.get("created_at"),
+        "last_run_at": row.get("last_run_at"),
+        "queued_task_ids": queued_task_ids or [],
+    }
+
+
 def is_filesystem_target(target: str) -> bool:
     """Best-effort detection for path-based targets that should bypass host validation."""
     if target.startswith(("/", "./", "../", "~")):
@@ -65,8 +91,10 @@ logger = logging.getLogger(__name__)
 from .cache import get_cache
 from .models import (
     TaskCreateRequest, TaskResponse, TaskResult,
-    PluginListResponse, ErrorResponse, TicketCreateRequest, TicketResponse
+    PluginListResponse, ErrorResponse, BulkDeleteRequest,
+    TicketCreateRequest, TicketResponse
 )
+from .integrations import create_jira_ticket, create_github_issue
 from .config import settings
 from .database import get_db
 from .plugins import get_plugin_manager, init_plugins
@@ -80,7 +108,6 @@ from .validation import validate_target, validate_task_start_payload
 from .reporting import reporting
 from .vault import VaultCrypto
 from .workflows import scheduler
-from .integrations import create_jira_ticket, create_github_issue
 
 from sse_starlette.sse import EventSourceResponse
 
@@ -630,13 +657,20 @@ async def get_dashboard_summary():
         recent_rows = await db.fetchall(
             """
             SELECT id, title, category, severity, target, description,
-                remediation, proof, cvss, cve, discovered_at, metadata_json
+                remediation, proof, cvss, cve, discovered_at,
+                risk_score, risk_factors_json, metadata_json
             FROM findings
             ORDER BY discovered_at DESC
             LIMIT 5
             """
         )
         recent_findings: List[Dict] = parse_json_fields(recent_rows, ["metadata_json"])
+
+        risk_scores = [
+            f.get("risk_score") for f in recent_findings
+            if isinstance(f.get("risk_score"), (int, float))
+        ]
+        avg_risk_score = round(sum(risk_scores) / len(risk_scores), 1) if risk_scores else None
 
         return {
             "total_findings": total_findings,
@@ -645,6 +679,7 @@ async def get_dashboard_summary():
             "medium_findings": medium_findings,
             "low_findings": low_findings,
             "info_findings": info_findings,
+            "avg_risk_score": avg_risk_score,
             "last_scan_time": recent_findings[0].get("discovered_at") if recent_findings else None,
             "recent_findings": recent_findings,
             "scan_activity": {
@@ -676,7 +711,11 @@ async def get_findings():
     async def build():
         db = await get_db()
         rows = await db.fetchall("SELECT * FROM findings ORDER BY discovered_at DESC")
-        return {"findings": parse_json_fields(rows, ["metadata_json"])}
+        findings = parse_json_fields(rows, ["metadata_json", "risk_factors_json"])
+        for f in findings:
+            if "risk_factors_json" in f:
+                f["risk_factors"] = f.pop("risk_factors_json")
+        return {"findings": findings}
 
     return await get_or_set_cached("findings:list", build)
 
@@ -764,28 +803,47 @@ async def list_tasks(
             "per_page": per_page,
             "total_pages": total_pages,
             "total_items": total,
-            "next": build_page_url(next_page),      # ← NEW
-            "previous": build_page_url(prev_page)    # ← NEW
+            "next": build_page_url(next_page),
+            "previous": build_page_url(prev_page)
         }
     }
 
 
+SQLITE_CHUNK_SIZE = 500  # safely under SQLITE_LIMIT_VARIABLE_NUMBER = 999
+
 async def delete_task_records(task_ids: List[str]):
-    """Helper to delete database records and files for multiple tasks."""
+    """Helper to delete database records and files for multiple tasks.
+
+    Processes IDs in chunks of SQLITE_CHUNK_SIZE to stay under
+    SQLite's SQLITE_LIMIT_VARIABLE_NUMBER = 999 limit.
+    """
+    if not task_ids:
+        return
+
     db = await get_db()
 
-    # Get raw output paths for file cleanup
-    placeholders = ",".join(["?"] * len(task_ids))
-    task_rows = await db.fetchall(f"SELECT raw_output_path FROM tasks WHERE id IN ({placeholders})", tuple(task_ids))
+    # Collect all raw_output_paths across chunks for file cleanup
+    all_task_rows = []
+    for i in range(0, len(task_ids), SQLITE_CHUNK_SIZE):
+        chunk = task_ids[i : i + SQLITE_CHUNK_SIZE]
+        placeholders = ",".join(["?"] * len(chunk))
+        rows = await db.fetchall(
+            f"SELECT raw_output_path FROM tasks WHERE id IN ({placeholders})",
+            tuple(chunk)
+        )
+        all_task_rows.extend(rows)
 
-    # Delete associated data
-    await db.execute(f"DELETE FROM findings WHERE task_id IN ({placeholders})", tuple(task_ids))
-    await db.execute(f"DELETE FROM reports WHERE task_id IN ({placeholders})", tuple(task_ids))
-    await db.execute(f"DELETE FROM audit_log WHERE task_id IN ({placeholders})", tuple(task_ids))
-    await db.execute(f"DELETE FROM tasks WHERE id IN ({placeholders})", tuple(task_ids))
+    # Delete associated records in chunks
+    for i in range(0, len(task_ids), SQLITE_CHUNK_SIZE):
+        chunk = task_ids[i : i + SQLITE_CHUNK_SIZE]
+        placeholders = ",".join(["?"] * len(chunk))
+        await db.execute(f"DELETE FROM findings   WHERE task_id IN ({placeholders})", tuple(chunk))
+        await db.execute(f"DELETE FROM reports    WHERE task_id IN ({placeholders})", tuple(chunk))
+        await db.execute(f"DELETE FROM audit_log  WHERE task_id IN ({placeholders})", tuple(chunk))
+        await db.execute(f"DELETE FROM tasks      WHERE id       IN ({placeholders})", tuple(chunk))
 
     # Cleanup files on disk
-    for row in task_rows:
+    for row in all_task_rows:
         if row and row["raw_output_path"]:
             try:
                 path = Path(row["raw_output_path"])
@@ -814,13 +872,21 @@ async def delete_task(task_id: str):
 
 
 @router.delete("/tasks/bulk")
-async def bulk_delete_tasks(task_ids: List[str]):
-    """Delete multiple tasks at once"""
+async def bulk_delete_tasks(request: BulkDeleteRequest):
+    """Delete multiple tasks at once (max 500 IDs per request)"""
+    task_ids = request.root  # RootModel exposes data via .root
     db = await get_db()
 
-    # Check if any tasks are running
+    # Empty list — return early cleanly (test requires 200, not 422)
+    if not task_ids:
+        return {"deleted_count": 0, "success": True}
+
+    # Check running tasks — safe: len(task_ids) <= 500 guaranteed by Pydantic
     placeholders = ",".join(["?"] * len(task_ids))
-    running_tasks = await db.fetchone(f"SELECT id FROM tasks WHERE id IN ({placeholders}) AND status = 'running' LIMIT 1", tuple(task_ids))
+    running_tasks = await db.fetchone(
+        f"SELECT id FROM tasks WHERE id IN ({placeholders}) AND status = 'running' LIMIT 1",
+        tuple(task_ids)
+    )
     if running_tasks:
         raise HTTPException(status_code=400, detail="Cannot delete running tasks. Abort them first.")
 
@@ -831,7 +897,6 @@ async def bulk_delete_tasks(task_ids: List[str]):
         "deleted_count": len(task_ids),
         "success": True
     }
-
 
 @router.delete("/tasks/clear")
 async def clear_all_tasks():
@@ -953,7 +1018,8 @@ async def delete_vault_secret(name: str):
 async def list_workflows():
     db = await get_db()
     rows = await db.fetchall("SELECT * FROM workflows ORDER BY created_at DESC")
-    return {"workflows": parse_json_fields(rows, ["steps_json"]), "total": len(rows)}
+    workflows = [_serialize_workflow(row) for row in rows]
+    return {"workflows": workflows, "total": len(workflows)}
 
 
 @router.post("/workflows")
@@ -983,7 +1049,8 @@ async def create_workflow(payload: Dict[str, Any]):
             json.dumps(steps),
         ),
     )
-    return {"id": workflow_id, "created": True}
+    row = await db.fetchone("SELECT * FROM workflows WHERE id = ?", (workflow_id,))
+    return _serialize_workflow(row) if row else {"id": workflow_id, "created": True}
 
 
 @router.post("/workflows/{workflow_id}/run")
@@ -1004,7 +1071,11 @@ async def run_workflow_once(workflow_id: str):
         asyncio.create_task(executor.execute_task(task_id))
         created_task_ids.append(task_id)
     await db.execute("UPDATE workflows SET last_run_at = datetime('now') WHERE id = ?", (workflow_id,))
-    return {"workflow_id": workflow_id, "queued_tasks": created_task_ids}
+    return {
+        "workflow_id": workflow_id,
+        "queued_task_ids": created_task_ids,
+        "queued_tasks": created_task_ids,
+    }
 
 
 @router.patch("/workflows/{workflow_id}")
@@ -1035,7 +1106,8 @@ async def update_workflow(workflow_id: str, payload: Dict[str, Any]):
 
     params.append(workflow_id)
     await db.execute(f"UPDATE workflows SET {', '.join(updates)} WHERE id = ?", tuple(params))
-    return {"workflow_id": workflow_id, "updated": True}
+    updated = await db.fetchone("SELECT * FROM workflows WHERE id = ?", (workflow_id,))
+    return _serialize_workflow(updated) if updated else {"workflow_id": workflow_id, "updated": True}
 
 
 @router.delete("/workflows/{workflow_id}")
@@ -1076,6 +1148,13 @@ async def get_finding_details(finding_id: str):
         except json.JSONDecodeError:
             metadata = {}
 
+    risk_factors = []
+    if finding_row.get("risk_factors_json"):
+        try:
+            risk_factors = json.loads(finding_row["risk_factors_json"])
+        except (json.JSONDecodeError, TypeError):
+            risk_factors = []
+
     return {
         "id": finding_row["id"],
         "task_id": finding_row["task_id"],
@@ -1091,7 +1170,12 @@ async def get_finding_details(finding_id: str):
         "cvss": finding_row["cvss"],
         "cve": finding_row["cve"],
         "discovered_at": finding_row["discovered_at"],
-        "metadata": metadata
+        "metadata": metadata,
+        "exploitability": finding_row.get("exploitability"),
+        "confidence": finding_row.get("confidence"),
+        "asset_exposure": finding_row.get("asset_exposure"),
+        "risk_score": finding_row.get("risk_score"),
+        "risk_factors": risk_factors,
     }
 
 
@@ -1153,15 +1237,30 @@ async def get_assets():
 @router.post("/integrations/ticket", response_model=TicketResponse)
 async def create_ticket(request: TicketCreateRequest):
     """Create a ticket in an external issue tracker"""
+    db = await get_db()
+    crypto = VaultCrypto(settings.resolved_vault_key)
+    
+    config = {}
+    if request.provider == "jira":
+        keys = ["jiraUrl", "jiraEmail", "jiraToken", "jiraProject"]
+    elif request.provider == "github":
+        keys = ["githubToken", "githubRepo"]
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported provider")
+
+    for key in keys:
+        row = await db.fetchone("SELECT encrypted_value FROM credential_vault WHERE name = ?", (key,))
+        if not row:
+            raise HTTPException(status_code=400, detail=f"Missing integration configuration: {key}")
+        config[key] = crypto.decrypt(row["encrypted_value"])
+
     try:
         if request.provider == "jira":
-            result = await create_jira_ticket(request.finding, request.config)
+            result = await create_jira_ticket(request.finding, config)
             return TicketResponse(**result)
         elif request.provider == "github":
-            result = await create_github_issue(request.finding, request.config)
+            result = await create_github_issue(request.finding, config)
             return TicketResponse(**result)
-        else:
-            raise HTTPException(status_code=400, detail="Unsupported provider")
     except Exception as e:
         logger.exception("Ticket creation failed")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -1239,7 +1239,7 @@ async def create_ticket(request: TicketCreateRequest):
     """Create a ticket in an external issue tracker"""
     db = await get_db()
     crypto = VaultCrypto(settings.resolved_vault_key)
-    
+
     config = {}
     if request.provider == "jira":
         keys = ["jiraUrl", "jiraEmail", "jiraToken", "jiraProject"]

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -65,7 +65,7 @@ logger = logging.getLogger(__name__)
 from .cache import get_cache
 from .models import (
     TaskCreateRequest, TaskResponse, TaskResult,
-    PluginListResponse, ErrorResponse
+    PluginListResponse, ErrorResponse, TicketCreateRequest, TicketResponse
 )
 from .config import settings
 from .database import get_db
@@ -80,6 +80,7 @@ from .validation import validate_target, validate_task_start_payload
 from .reporting import reporting
 from .vault import VaultCrypto
 from .workflows import scheduler
+from .integrations import create_jira_ticket, create_github_issue
 
 from sse_starlette.sse import EventSourceResponse
 
@@ -1147,3 +1148,20 @@ async def get_assets():
     rows = await db.fetchall("SELECT DISTINCT target FROM tasks UNION SELECT DISTINCT target FROM findings")
     assets = [{"id": str(uuid.uuid4()), "name": row["target"]} for row in rows]
     return {"assets": assets}
+
+
+@router.post("/integrations/ticket", response_model=TicketResponse)
+async def create_ticket(request: TicketCreateRequest):
+    """Create a ticket in an external issue tracker"""
+    try:
+        if request.provider == "jira":
+            result = await create_jira_ticket(request.finding, request.config)
+            return TicketResponse(**result)
+        elif request.provider == "github":
+            result = await create_github_issue(request.finding, request.config)
+            return TicketResponse(**result)
+        else:
+            raise HTTPException(status_code=400, detail="Unsupported provider")
+    except Exception as e:
+        logger.exception("Ticket creation failed")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/frontend/src/__tests__/Findings.test.tsx
+++ b/frontend/src/__tests__/Findings.test.tsx
@@ -24,7 +24,7 @@ describe('Export Flow', () => {
     await createTicket('jira', finding)
 
     expect(createTicket).toHaveBeenCalledWith('jira', finding)
-    // We expect it to be called with exactly 2 arguments (provider, finding), 
+    // We expect it to be called with exactly 2 arguments (provider, finding),
     // ensuring no credentials object is passed from the frontend.
     expect(createTicket).toHaveBeenCalledTimes(1)
   })

--- a/frontend/src/__tests__/Findings.test.tsx
+++ b/frontend/src/__tests__/Findings.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createTicket } from '../api'
+
+// Mock the global request function by mocking the module
+vi.mock('../api', async () => {
+  const actual = await vi.importActual('../api')
+  return {
+    ...actual,
+    createTicket: vi.fn().mockResolvedValue({ ticket_id: 'TEST-123', ticket_url: 'http://example.com/TEST-123' }),
+    upsertVaultSecret: vi.fn().mockResolvedValue({}),
+  }
+})
+
+describe('Export Flow', () => {
+  it('calls createTicket without config object (backend handles secrets)', async () => {
+    const finding = {
+      id: '123',
+      title: 'Test Finding',
+      severity: 'high',
+      status: 'new'
+    }
+
+    // Call the exported mocked function directly to verify it works without config
+    await createTicket('jira', finding)
+
+    expect(createTicket).toHaveBeenCalledWith('jira', finding)
+    // We expect it to be called with exactly 2 arguments (provider, finding), 
+    // ensuring no credentials object is passed from the frontend.
+    expect(createTicket).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -293,10 +293,18 @@ export function deleteWorkflow(workflowId: string): Promise<{ deleted: boolean }
   })
 }
 
-export function createTicket(provider: string, finding: any, config: Record<string, string>): Promise<{ ticket_id: string; ticket_url: string }> {
+export function createTicket(provider: string, finding: any): Promise<{ ticket_id: string; ticket_url: string }> {
   return request<{ ticket_id: string; ticket_url: string }>('/integrations/ticket', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ provider, finding, config }),
+    body: JSON.stringify({ provider, finding }),
+  })
+}
+
+export function upsertVaultSecret(name: string, payload: Record<string, string>) {
+  return request(`/vault/${name}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
   })
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -241,3 +241,11 @@ export function deleteWorkflow(workflowId: string): Promise<{ deleted: boolean }
     method: 'DELETE',
   })
 }
+
+export function createTicket(provider: string, finding: any, config: Record<string, string>): Promise<{ ticket_id: string; ticket_url: string }> {
+  return request<{ ticket_id: string; ticket_url: string }>('/integrations/ticket', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ provider, finding, config }),
+  })
+}

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -3,6 +3,17 @@ import { motion } from 'framer-motion'
 import { getFindings, createTicket } from '../api'
 import { formatLocaleDate, parseDateSafe, getCurrentTimeZone } from '../utils/date'
 import { useToast } from '../components/ToastContext'
+
+export interface RiskFactor {
+  factor: string
+  label: string
+  value: string | number
+  score: number
+  weight: number
+  contribution: number
+  detail: string
+}
+
 type Finding = {
   id: string
   severity: string

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -325,11 +325,8 @@ export default function Findings() {
 
   async function exportToTracker(finding: Finding & { status: FindingStatus }, provider: 'jira' | 'github') {
     try {
-      const savedConfig = localStorage.getItem('secuscan-config')
-      const config = savedConfig ? JSON.parse(savedConfig) : {}
-
       addToast(`Exporting to ${provider.toUpperCase()}...`, 'info')
-      const result = await createTicket(provider, finding, config)
+      const result = await createTicket(provider, finding)
       addToast(`Successfully created ${provider.toUpperCase()} ticket: ${result.ticket_id}`, 'success')
       window.open(result.ticket_url, '_blank', 'noopener,noreferrer')
     } catch (error: any) {

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { motion } from 'framer-motion'
-import { getFindings } from '../api'
+import { getFindings, createTicket } from '../api'
 import { formatLocaleDate, parseDateSafe, getCurrentTimeZone } from '../utils/date'
+import { useToast } from '../components/ToastContext'
 type Finding = {
   id: string
   severity: string
@@ -91,6 +92,7 @@ const filterControlClass =
 type SortMode = 'severity' | 'newest' | 'oldest' | 'target'
 
 export default function Findings() {
+  const { addToast } = useToast()
   const [findings, setFindings] = useState<Finding[]>([])
   const [loading, setLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState('')
@@ -313,6 +315,20 @@ export default function Findings() {
       window.setTimeout(() => setCopiedFindingId((current) => (current === finding.id ? null : current)), 1600)
     } catch {
       setCopiedFindingId(null)
+    }
+  }
+
+  async function exportToTracker(finding: Finding & { status: FindingStatus }, provider: 'jira' | 'github') {
+    try {
+      const savedConfig = localStorage.getItem('secuscan-config')
+      const config = savedConfig ? JSON.parse(savedConfig) : {}
+
+      addToast(`Exporting to ${provider.toUpperCase()}...`, 'info')
+      const result = await createTicket(provider, finding, config)
+      addToast(`Successfully created ${provider.toUpperCase()} ticket: ${result.ticket_id}`, 'success')
+      window.open(result.ticket_url, '_blank', 'noopener,noreferrer')
+    } catch (error: any) {
+      addToast(`Failed to create ${provider.toUpperCase()} ticket: ${error.message}`, 'error')
     }
   }
 
@@ -723,6 +739,22 @@ export default function Findings() {
                         className="border border-rag-blue/25 bg-rag-blue/10 px-4 py-3 text-[10px] font-black uppercase tracking-[0.18em] text-rag-blue"
                       >
                         {copiedFindingId === selectedFinding.id ? 'Copied' : 'Copy Brief'}
+                      </button>
+                    </div>
+                    <div className="grid gap-2 sm:grid-cols-2 mt-2">
+                      <button
+                        type="button"
+                        onClick={() => exportToTracker(selectedFinding, 'jira')}
+                        className="border border-[#0052CC]/25 bg-[#0052CC]/10 px-4 py-3 text-[10px] font-black uppercase tracking-[0.18em] text-[#2684FF]"
+                      >
+                        Export to Jira
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => exportToTracker(selectedFinding, 'github')}
+                        className="border border-white/25 bg-white/10 px-4 py-3 text-[10px] font-black uppercase tracking-[0.18em] text-white"
+                      >
+                        Export to GitHub
                       </button>
                     </div>
                   </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -19,6 +19,12 @@ const DEFAULT_CONFIG = {
     dataRetention: 30, // days
     shodanKey: '',
     virustotalKey: '',
+    jiraUrl: '',
+    jiraEmail: '',
+    jiraToken: '',
+    jiraProject: '',
+    githubToken: '',
+    githubRepo: '',
     ipWhitelist: '127.0.0.1\n10.0.0.0/8',
     autoPurgeFailed: false,
     autoRescanCritical: true,
@@ -259,6 +265,63 @@ export default function Settings() {
                                 type="password"
                                 value={config.virustotalKey}
                                 onChange={(val: string) => setConfig({...config, virustotalKey: val})}
+                            />
+                        </div>
+                    </section>
+
+                    <section className="space-y-8">
+                        <div className="flex items-center gap-4">
+                            <h3 className="text-xs font-black text-silver-bright uppercase tracking-[0.4em] italic">External_Integrations</h3>
+                            <div className="h-0.5 flex-1 bg-black/10"></div>
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                            <InputField 
+                                label="Jira_URL" 
+                                description="JIRA_INSTANCE_ENDPOINT"
+                                placeholder="https://your-domain.atlassian.net"
+                                type="text"
+                                value={config.jiraUrl}
+                                onChange={(val: string) => setConfig({...config, jiraUrl: val})}
+                            />
+                            <InputField 
+                                label="Jira_Email" 
+                                description="JIRA_AUTH_EMAIL"
+                                placeholder="admin@example.com"
+                                type="text"
+                                value={config.jiraEmail}
+                                onChange={(val: string) => setConfig({...config, jiraEmail: val})}
+                            />
+                            <InputField 
+                                label="Jira_API_Token" 
+                                description="JIRA_ACCESS_TOKEN"
+                                placeholder="JIRA_API_TOKEN"
+                                type="password"
+                                value={config.jiraToken}
+                                onChange={(val: string) => setConfig({...config, jiraToken: val})}
+                            />
+                            <InputField 
+                                label="Jira_Project_Key" 
+                                description="JIRA_TARGET_PROJECT"
+                                placeholder="SEC"
+                                type="text"
+                                value={config.jiraProject}
+                                onChange={(val: string) => setConfig({...config, jiraProject: val})}
+                            />
+                            <InputField 
+                                label="GitHub_Token" 
+                                description="GH_PERSONAL_ACCESS_TOKEN"
+                                placeholder="github_pat_..."
+                                type="password"
+                                value={config.githubToken}
+                                onChange={(val: string) => setConfig({...config, githubToken: val})}
+                            />
+                            <InputField 
+                                label="GitHub_Repository" 
+                                description="GH_TARGET_REPO"
+                                placeholder="owner/repo"
+                                type="text"
+                                value={config.githubRepo}
+                                onChange={(val: string) => setConfig({...config, githubRepo: val})}
                             />
                         </div>
                     </section>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { upsertVaultSecret } from '../api'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useTheme } from '../components/ThemeContext'
 import { useToast } from '../components/ToastContext'
@@ -63,11 +64,30 @@ export default function Settings() {
         }
     }, [])
 
-    const handleSave = () => {
-        localStorage.setItem('secuscan-config', JSON.stringify(config))
-        addToast("Operational parameters synchronized", "success")
-        if (config.theme !== theme) {
-            setTheme(config.theme)
+    const handleSave = async () => {
+        try {
+            // Save integration secrets to backend vault
+            const secrets = ['shodanKey', 'virustotalKey', 'jiraToken', 'jiraUrl', 'jiraEmail', 'jiraProject', 'githubToken', 'githubRepo']
+            for (const key of secrets) {
+                const val = config[key as keyof typeof config] as string
+                if (val && val !== '********') {
+                    await upsertVaultSecret(key, { payload: val })
+                }
+            }
+
+            // Remove secrets from local storage config
+            const localConfig = { ...config }
+            for (const key of secrets) {
+                localConfig[key as keyof typeof config] = (localConfig[key as keyof typeof config] ? '********' : '') as never
+            }
+
+            localStorage.setItem('secuscan-config', JSON.stringify(localConfig))
+            addToast("Operational parameters synchronized", "success")
+            if (config.theme !== theme) {
+                setTheme(config.theme)
+            }
+        } catch (e: any) {
+            addToast(`Failed to synchronize parameters: ${e.message}`, "error")
         }
     }
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -6,8 +6,8 @@ import { useToast } from '../components/ToastContext'
 
 const itemVariants = {
   hidden: { opacity: 0, y: 20 },
-  visible: { 
-    opacity: 1, 
+  visible: {
+    opacity: 1,
     y: 0,
     transition: { type: 'spring', stiffness: 200, damping: 25 }
   }
@@ -41,7 +41,7 @@ const DEFAULT_CONFIG = {
 export default function Settings() {
     const { theme, setTheme } = useTheme()
     const { addToast } = useToast()
-    
+
     const [config, setConfig] = useState(() => {
         const saved = localStorage.getItem('secuscan-config')
         if (saved) {
@@ -116,7 +116,7 @@ export default function Settings() {
                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] block italic group-hover:text-rag-blue transition-colors">{label}</label>
                 <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">{description}</p>
             </div>
-            <input 
+            <input
                 type={type}
                 value={value}
                 onChange={(e) => onChange(type === 'number' ? parseInt(e.target.value) || 0 : e.target.value)}
@@ -132,7 +132,7 @@ export default function Settings() {
                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] block italic group-hover:text-rag-blue transition-colors">{label}</label>
                 <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">{description}</p>
             </div>
-            <select 
+            <select
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-rag-blue font-bold focus:outline-none focus:border-rag-blue/50 transition-colors uppercase appearance-none"
@@ -145,7 +145,7 @@ export default function Settings() {
     )
 
     const Toggle = ({ checked, onChange, label, description }: any) => (
-        <button 
+        <button
             onClick={() => onChange(!checked)}
             className={`flex items-center justify-between p-8 bg-charcoal border-4 border-black transition-all group hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-0.5 ${
                 checked ? 'shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]' : 'shadow-none'
@@ -163,7 +163,7 @@ export default function Settings() {
 
     return (
         <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
-            
+
             <header className="relative flex flex-col md:flex-row justify-between items-start md:items-end gap-8 pb-12 border-b-4 border-silver-bright/10 font-black">
                 <div className="space-y-4">
                   <div className="bg-rag-blue text-black px-4 py-1 text-xs uppercase tracking-widest inline-block shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] font-black">
@@ -187,15 +187,15 @@ export default function Settings() {
 
             <div className="grid grid-cols-1 xl:grid-cols-4 gap-12 pt-4">
                 <main className="xl:col-span-3 space-y-20">
-                    
+
                     <section className="space-y-8">
                         <div className="flex items-center gap-4">
                             <h3 className="text-xs font-black text-silver-bright uppercase tracking-[0.4em] italic">Engine_Parameters</h3>
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <SelectField 
-                                label="Scanner_Intensity" 
+                            <SelectField
+                                label="Scanner_Intensity"
                                 description="PACKET_DENSITY_PER_SECOND_THRESHOLD"
                                 value={config.scanIntensity}
                                 onChange={(val: string) => setConfig({...config, scanIntensity: val})}
@@ -205,8 +205,8 @@ export default function Settings() {
                                     { label: 'Aggressive (Intrusive)', value: 'aggressive' },
                                 ]}
                             />
-                            <SelectField 
-                                label="Retention_Cycle" 
+                            <SelectField
+                                label="Retention_Cycle"
                                 description="AUTOMATED_LOG_PURGE_STRATEGY"
                                 value={config.dataRetention}
                                 onChange={(val: number) => setConfig({...config, dataRetention: val})}
@@ -217,15 +217,15 @@ export default function Settings() {
                                     { label: 'Indefinite', value: 0 },
                                 ]}
                             />
-                            <InputField 
-                                label="Concurrent_Operations" 
+                            <InputField
+                                label="Concurrent_Operations"
                                 description="MAX_PARALLEL_TASK_EXECUTION"
                                 type="number"
                                 value={config.concurrentScans}
                                 onChange={(val: number) => setConfig({...config, concurrentScans: val})}
                             />
-                            <InputField 
-                                label="Execution_Timeout" 
+                            <InputField
+                                label="Execution_Timeout"
                                 description="THRESHOLD_IN_SECONDS_PER_NODE"
                                 type="number"
                                 value={config.scanTimeout}
@@ -240,8 +240,8 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <SelectField 
-                                label="Temporal_Logic" 
+                            <SelectField
+                                label="Temporal_Logic"
                                 description="UI_CHRONOS_ALIGNMENT"
                                 value={config.timezone}
                                 onChange={(val: string) => setConfig({...config, timezone: val})}
@@ -251,8 +251,8 @@ export default function Settings() {
                                     { label: 'Fixed (ZULU)', value: 'GMT' },
                                 ]}
                             />
-                            <SelectField 
-                                label="Visual_Spectrum" 
+                            <SelectField
+                                label="Visual_Spectrum"
                                 description="OPERATIONAL_AESTHETIC_MODE"
                                 value={config.theme}
                                 onChange={(val: string) => setConfig({...config, theme: val})}
@@ -270,16 +270,16 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <InputField 
-                                label="Shodan_Enclave" 
+                            <InputField
+                                label="Shodan_Enclave"
                                 description="RECON_TELEMETRY_STREAM_TOKEN"
                                 placeholder="SHODAN_SECRET"
                                 type="password"
                                 value={config.shodanKey}
                                 onChange={(val: string) => setConfig({...config, shodanKey: val})}
                             />
-                            <InputField 
-                                label="VirusTotal_Enclave" 
+                            <InputField
+                                label="VirusTotal_Enclave"
                                 description="MALWARE_INTEL_ACCESS_HASH"
                                 placeholder="VT_SECRET_HASH"
                                 type="password"
@@ -295,48 +295,48 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <InputField 
-                                label="Jira_URL" 
+                            <InputField
+                                label="Jira_URL"
                                 description="JIRA_INSTANCE_ENDPOINT"
                                 placeholder="https://your-domain.atlassian.net"
                                 type="text"
                                 value={config.jiraUrl}
                                 onChange={(val: string) => setConfig({...config, jiraUrl: val})}
                             />
-                            <InputField 
-                                label="Jira_Email" 
+                            <InputField
+                                label="Jira_Email"
                                 description="JIRA_AUTH_EMAIL"
                                 placeholder="admin@example.com"
                                 type="text"
                                 value={config.jiraEmail}
                                 onChange={(val: string) => setConfig({...config, jiraEmail: val})}
                             />
-                            <InputField 
-                                label="Jira_API_Token" 
+                            <InputField
+                                label="Jira_API_Token"
                                 description="JIRA_ACCESS_TOKEN"
                                 placeholder="JIRA_API_TOKEN"
                                 type="password"
                                 value={config.jiraToken}
                                 onChange={(val: string) => setConfig({...config, jiraToken: val})}
                             />
-                            <InputField 
-                                label="Jira_Project_Key" 
+                            <InputField
+                                label="Jira_Project_Key"
                                 description="JIRA_TARGET_PROJECT"
                                 placeholder="SEC"
                                 type="text"
                                 value={config.jiraProject}
                                 onChange={(val: string) => setConfig({...config, jiraProject: val})}
                             />
-                            <InputField 
-                                label="GitHub_Token" 
+                            <InputField
+                                label="GitHub_Token"
                                 description="GH_PERSONAL_ACCESS_TOKEN"
                                 placeholder="github_pat_..."
                                 type="password"
                                 value={config.githubToken}
                                 onChange={(val: string) => setConfig({...config, githubToken: val})}
                             />
-                            <InputField 
-                                label="GitHub_Repository" 
+                            <InputField
+                                label="GitHub_Repository"
                                 description="GH_TARGET_REPO"
                                 placeholder="owner/repo"
                                 type="text"
@@ -356,7 +356,7 @@ export default function Settings() {
                                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-widest block italic">Authorized_Ingress_Vectors</label>
                                 <p className="text-[10px] text-silver/40 uppercase font-bold italic mb-6 leading-relaxed">Line-delimited IP/CIDR whitelist for high-privilege access</p>
                             </div>
-                            <textarea 
+                            <textarea
                                 value={config.ipWhitelist}
                                 onChange={(e) => setConfig({...config, ipWhitelist: e.target.value})}
                                 rows={4}
@@ -371,20 +371,20 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                            <Toggle 
-                                label="System_Signals" 
+                            <Toggle
+                                label="System_Signals"
                                 description="CRITICAL_RX_TELEMETRY"
                                 checked={config.notifications.systemAlerts}
                                 onChange={(val: boolean) => setConfig({...config, notifications: {...config.notifications, systemAlerts: val}})}
                             />
-                            <Toggle 
-                                label="Auto_Rescan" 
+                            <Toggle
+                                label="Auto_Rescan"
                                 description="TRIGGER_NEW_SCAN_ON_CRITICAL"
                                 checked={config.autoRescanCritical}
                                 onChange={(val: boolean) => setConfig({...config, autoRescanCritical: val})}
                             />
-                             <Toggle 
-                                label="Garbage_Collection" 
+                             <Toggle
+                                label="Garbage_Collection"
                                 description="AUTO_PURGE_FAILED_SESSIONS"
                                 checked={config.autoPurgeFailed}
                                 onChange={(val: boolean) => setConfig({...config, autoPurgeFailed: val})}
@@ -393,7 +393,7 @@ export default function Settings() {
                     </section>
 
                     <section className="pt-12">
-                        <button 
+                        <button
                             onClick={handleSave}
                             className="bg-rag-blue text-black px-12 py-6 text-xs font-black uppercase tracking-[0.3em] shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-4 italic group"
                         >
@@ -407,19 +407,19 @@ export default function Settings() {
                     <section className="bg-charcoal border-4 border-black p-10 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-6">
                         <h3 className="text-[11px] font-black text-silver-bright uppercase tracking-[0.5em] italic mb-8">Management_Tools</h3>
                         <div className="space-y-4">
-                            <button 
+                            <button
                                 onClick={handleExport}
                                 className="w-full py-4 bg-charcoal-dark border-4 border-black text-[10px] font-black text-silver/40 uppercase tracking-[0.3em] hover:bg-black hover:text-white transition-all italic"
                             >
                                 TELEMETRY_EXPORT
                             </button>
-                            <button 
+                            <button
                                 onClick={handleReset}
                                 className="w-full py-4 bg-rag-amber border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all italic"
                             >
                                 ENGINE_RESET
                             </button>
-                            <button 
+                            <button
                                 className="w-full py-4 bg-rag-red border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-1 transition-all italic"
                                 onClick={() => {
                                     if (window.confirm("CRITICAL: THIS WILL PURGE ALL HISTORY AND ASSETS. PROCEED?")) {

--- a/frontend/testing/unit/AppRoutes.test.tsx
+++ b/frontend/testing/unit/AppRoutes.test.tsx
@@ -63,7 +63,11 @@ describe('App route fallback', () => {
   it('renders the loaded dashboard summary', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <AppRoutes />
+        <ThemeProvider>
+          <ToastProvider>
+            <AppRoutes />
+          </ToastProvider>
+        </ThemeProvider>
       </MemoryRouter>,
     )
 
@@ -74,7 +78,11 @@ describe('App route fallback', () => {
   it('renders the findings workspace', async () => {
     render(
       <MemoryRouter initialEntries={['/findings']}>
-        <AppRoutes />
+        <ThemeProvider>
+          <ToastProvider>
+            <AppRoutes />
+          </ToastProvider>
+        </ThemeProvider>
       </MemoryRouter>,
     )
 

--- a/frontend/testing/unit/AppRoutes.test.tsx
+++ b/frontend/testing/unit/AppRoutes.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, useLocation } from 'react-router-dom'
+import { ThemeProvider } from '../../src/components/ThemeContext'
+import { ToastProvider } from '../../src/components/ToastContext'
 import { AppRoutes } from '../../src/App'
 
 vi.mock('../../src/api', () => ({
@@ -44,8 +46,12 @@ describe('App route fallback', () => {
   it('redirects unknown routes to dashboard', async () => {
     render(
       <MemoryRouter initialEntries={['/not-a-real-route']}>
-        <AppRoutes />
-        <PathProbe />
+        <ThemeProvider>
+          <ToastProvider>
+            <AppRoutes />
+            <PathProbe />
+          </ToastProvider>
+        </ThemeProvider>
       </MemoryRouter>,
     )
 

--- a/frontend/testing/unit/pages/Findings.test.tsx
+++ b/frontend/testing/unit/pages/Findings.test.tsx
@@ -55,11 +55,15 @@ const allFindings = [criticalFinding, highFinding, mediumFinding]
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+import { ToastProvider } from '../../../src/components/ToastContext'
+
 function renderFindings() {
   return render(
-    <MemoryRouter>
-      <Findings />
-    </MemoryRouter>,
+    <ToastProvider>
+      <MemoryRouter>
+        <Findings />
+      </MemoryRouter>
+    </ToastProvider>,
   )
 }
 

--- a/testing/backend/unit/test_integrations.py
+++ b/testing/backend/unit/test_integrations.py
@@ -15,12 +15,12 @@ async def test_create_ticket_missing_provider(client: AsyncClient):
         "category": "Injection",
         "target": "http://example.com"
     }
-    
+
     response = await client.post("/api/v1/integrations/ticket", json={
         "provider": "unknown_provider",
         "finding": finding
     })
-    
+
     assert response.status_code == 400
     assert "Unsupported provider" in response.text
 
@@ -36,11 +36,11 @@ async def test_create_ticket_missing_credentials(client: AsyncClient):
         "category": "Injection",
         "target": "http://example.com"
     }
-    
+
     response = await client.post("/api/v1/integrations/ticket", json={
         "provider": "jira",
         "finding": finding
     })
-    
+
     assert response.status_code == 400
     assert "Missing integration configuration" in response.text

--- a/testing/backend/unit/test_integrations.py
+++ b/testing/backend/unit/test_integrations.py
@@ -1,0 +1,46 @@
+import pytest
+from httpx import AsyncClient
+from backend.secuscan.models import Finding
+from typing import Dict, Any
+
+@pytest.mark.asyncio
+async def test_create_ticket_missing_provider(client: AsyncClient):
+    finding = {
+        "id": "123",
+        "task_id": "task-1",
+        "title": "SQL Injection",
+        "description": "Found SQLi",
+        "remediation": "Use prepared statements",
+        "severity": "critical",
+        "category": "Injection",
+        "target": "http://example.com"
+    }
+    
+    response = await client.post("/api/v1/integrations/ticket", json={
+        "provider": "unknown_provider",
+        "finding": finding
+    })
+    
+    assert response.status_code == 400
+    assert "Unsupported provider" in response.text
+
+@pytest.mark.asyncio
+async def test_create_ticket_missing_credentials(client: AsyncClient):
+    finding = {
+        "id": "123",
+        "task_id": "task-1",
+        "title": "SQL Injection",
+        "description": "Found SQLi",
+        "remediation": "Use prepared statements",
+        "severity": "critical",
+        "category": "Injection",
+        "target": "http://example.com"
+    }
+    
+    response = await client.post("/api/v1/integrations/ticket", json={
+        "provider": "jira",
+        "finding": finding
+    })
+    
+    assert response.status_code == 400
+    assert "Missing integration configuration" in response.text

--- a/testing/backend/unit/test_integrations.py
+++ b/testing/backend/unit/test_integrations.py
@@ -3,8 +3,7 @@ from httpx import AsyncClient
 from backend.secuscan.models import Finding
 from typing import Dict, Any
 
-@pytest.mark.asyncio
-async def test_create_ticket_missing_provider(client: AsyncClient):
+def test_create_ticket_missing_provider(test_client):
     finding = {
         "id": "123",
         "task_id": "task-1",
@@ -16,7 +15,7 @@ async def test_create_ticket_missing_provider(client: AsyncClient):
         "target": "http://example.com"
     }
 
-    response = await client.post("/api/v1/integrations/ticket", json={
+    response = test_client.post("/api/v1/integrations/ticket", json={
         "provider": "unknown_provider",
         "finding": finding
     })
@@ -24,8 +23,7 @@ async def test_create_ticket_missing_provider(client: AsyncClient):
     assert response.status_code == 400
     assert "Unsupported provider" in response.text
 
-@pytest.mark.asyncio
-async def test_create_ticket_missing_credentials(client: AsyncClient):
+def test_create_ticket_missing_credentials(test_client):
     finding = {
         "id": "123",
         "task_id": "task-1",
@@ -37,7 +35,7 @@ async def test_create_ticket_missing_credentials(client: AsyncClient):
         "target": "http://example.com"
     }
 
-    response = await client.post("/api/v1/integrations/ticket", json={
+    response = test_client.post("/api/v1/integrations/ticket", json={
         "provider": "jira",
         "finding": finding
     })


### PR DESCRIPTION
**Fixes:** #377 

## 🚀 Description
This PR bridges the gap between vulnerability discovery and remediation by allowing users to export findings directly from the dashboard into Jira tickets or GitHub Issues.

## 🛠️ Changes Made
* **Backend:**
  * Added `httpx` to `requirements.txt` for making asynchronous API calls.
  * Added a new `POST /api/v1/integrations/ticket` endpoint to handle ticket creation requests.
  * Implemented `create_jira_ticket` and `create_github_issue` logic in `integrations.py`, properly mapping the vulnerability data (Title, Severity, Description, Target, Remediation) into the respective issue formats.
* **Frontend:**
  * Updated the **Settings** page to include an "External Integrations" section where users can configure their Jira (URL, Email, Token, Project) and GitHub (Token, Repository) credentials.
  * Added "Export to Jira" and "Export to GitHub" buttons to the Workflow Actions section within the Finding Details view.
  * Added `createTicket` to the API layer and integrated toast notifications for success/error handling when creating a ticket.

## ✅ How to Test
1. Set up your Jira and/or GitHub API credentials in the **Settings** tab under External Integrations.
2. Go to the **Findings** page and select any vulnerability.
3. Scroll down to the Workflow Actions and click **Export to Jira** or **Export to GitHub**.
4. Verify a success toast appears and that a new tab opens redirecting you directly to the newly created ticket on Jira/GitHub.
