### PR TITLE
feat(audit): add audit log API routes and frontend Audit Log page, fixes #327

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -297,6 +297,15 @@ async def start_task(
     background_tasks.add_task(executor.execute_task, task_id)
     await invalidate_view_cache()
 
+    db = await get_db()
+    await db.log_audit(
+        "scan_created",
+        f"Scan task created for plugin {request.plugin_id} against {request.inputs.get('target', 'unknown')}",
+        context={"plugin_id": request.plugin_id, "preset": request.preset},
+        task_id=task_id,
+        plugin_id=request.plugin_id,
+    )
+
     return {
         "task_id": task_id,
         "status": "queued",
@@ -606,6 +615,13 @@ async def cancel_task(task_id: str):
 
     if not cancelled:
         raise HTTPException(status_code=404, detail="Task not found or not running")
+
+    db = await get_db()
+    await db.log_audit(
+        "scan_cancelled",
+        f"Task {task_id} was cancelled by user",
+        task_id=task_id,
+    )
 
     return {
         "task_id": task_id,
@@ -1221,6 +1237,155 @@ async def get_attack_surface():
 
     return {"entries": entries}
 
+
+# ── Audit Log ─────────────────────────────────────────────────────────────────
+
+@router.get("/audit")
+async def get_audit_log(
+    event_type: Optional[str] = None,
+    plugin_id: Optional[str] = None,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    page: int = 1,
+    per_page: int = 50,
+):
+    """Return paginated audit log entries, filterable by event_type, plugin_id, and date range."""
+    db = await get_db()
+
+    where_clauses = []
+    params: List[Any] = []
+
+    if event_type:
+        where_clauses.append("event_type = ?")
+        params.append(event_type)
+    if plugin_id:
+        where_clauses.append("plugin_id = ?")
+        params.append(plugin_id)
+    if date_from:
+        where_clauses.append("timestamp >= ?")
+        params.append(date_from)
+    if date_to:
+        where_clauses.append("timestamp <= ?")
+        params.append(date_to)
+
+    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+    count_row = await db.fetchone(
+        f"SELECT COUNT(*) as total FROM audit_log {where_sql}",
+        tuple(params),
+    )
+    total = int(count_row["total"]) if count_row else 0
+
+    rows = await db.fetchall(
+        f"""
+        SELECT id, timestamp, event_type, severity, message,
+               context_json, task_id, plugin_id
+        FROM audit_log {where_sql}
+        ORDER BY timestamp DESC
+        LIMIT ? OFFSET ?
+        """,
+        tuple(params + [per_page, (page - 1) * per_page]),
+    )
+
+    entries = []
+    for row in rows:
+        entry = dict(row)
+        if entry.get("context_json"):
+            try:
+                entry["context"] = json.loads(entry["context_json"])
+            except Exception:
+                entry["context"] = {}
+        else:
+            entry["context"] = {}
+        del entry["context_json"]
+        entries.append(entry)
+
+    total_pages = (total + per_page - 1) // per_page if per_page > 0 else 0
+
+    return {
+        "entries": entries,
+        "pagination": {
+            "page": page,
+            "per_page": per_page,
+            "total_items": total,
+            "total_pages": total_pages,
+        },
+    }
+
+
+@router.get("/audit/export")
+async def export_audit_log(
+    format: str = "json",
+    event_type: Optional[str] = None,
+    plugin_id: Optional[str] = None,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+):
+    """Export the full filtered audit log as JSON or CSV."""
+    db = await get_db()
+
+    where_clauses = []
+    params: List[Any] = []
+
+    if event_type:
+        where_clauses.append("event_type = ?")
+        params.append(event_type)
+    if plugin_id:
+        where_clauses.append("plugin_id = ?")
+        params.append(plugin_id)
+    if date_from:
+        where_clauses.append("timestamp >= ?")
+        params.append(date_from)
+    if date_to:
+        where_clauses.append("timestamp <= ?")
+        params.append(date_to)
+
+    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+    rows = await db.fetchall(
+        f"""
+        SELECT id, timestamp, event_type, severity, message,
+               context_json, task_id, plugin_id
+        FROM audit_log {where_sql}
+        ORDER BY timestamp DESC
+        """,
+        tuple(params),
+    )
+
+    entries = []
+    for row in rows:
+        entry = dict(row)
+        if entry.get("context_json"):
+            try:
+                entry["context"] = json.loads(entry["context_json"])
+            except Exception:
+                entry["context"] = {}
+        else:
+            entry["context"] = {}
+        del entry["context_json"]
+        entries.append(entry)
+
+    if format == "csv":
+        import csv, io
+        output = io.StringIO()
+        writer = csv.DictWriter(
+            output,
+            fieldnames=["id", "timestamp", "event_type", "severity", "message", "task_id", "plugin_id"],
+            extrasaction="ignore",
+        )
+        writer.writeheader()
+        writer.writerows(entries)
+        return Response(
+            content=output.getvalue(),
+            media_type="text/csv",
+            headers={"Content-Disposition": 'attachment; filename="secuscan_audit_log.csv"'},
+        )
+
+    return Response(
+        content=json.dumps({"entries": entries}, indent=2),
+        media_type="application/json",
+        headers={"Content-Disposition": 'attachment; filename="secuscan_audit_log.json"'},
+    )
 
 @router.get("/assets")
 async def get_assets():

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import Settings from './pages/Settings'
 import Scans from './pages/Scans'
 import TaskDetails from './pages/TaskDetails'
 import Workflows from './pages/Workflows'
+import AuditLog from './pages/AuditLog'
 
 import { ThemeProvider } from './components/ThemeContext'
 import { ToastProvider, ToastContainer } from './components/ToastContext'
@@ -27,6 +28,7 @@ export function AppRoutes() {
       <Route path={routes.reports} element={<Reports />} />
       <Route path={routes.workflows} element={<Workflows />} />
       <Route path={routes.settings} element={<Settings />} />
+      <Route path="/audit" element={<AuditLog />} />
       <Route path={routes.task} element={<TaskDetails />} />
 
       <Route path="*" element={<Navigate to={routes.dashboard} replace />} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -292,3 +292,36 @@ export function deleteWorkflow(workflowId: string): Promise<{ deleted: boolean }
     method: 'DELETE',
   })
 }
+
+// ── Audit Log ─────────────────────────────────────────────────────────────────
+
+export interface AuditEntry {
+  id: number
+  timestamp: string
+  event_type: string
+  severity: string
+  message: string
+  context: Record<string, any>
+  task_id: string | null
+  plugin_id: string | null
+}
+
+export interface AuditLogResponse {
+  entries: AuditEntry[]
+  pagination: {
+    page: number
+    per_page: number
+    total_items: number
+    total_pages: number
+  }
+}
+
+export function getAuditLog(params?: URLSearchParams): Promise<AuditLogResponse> {
+  const suffix = params ? `?${params.toString()}` : ''
+  return request<AuditLogResponse>(`/audit${suffix}`)
+}
+
+export function exportAuditLog(format: 'json' | 'csv', params?: URLSearchParams): void {
+  const base = params ? `?${params.toString()}&format=${format}` : `?format=${format}`
+  window.open(`${API_BASE}/audit/export${base}`)
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -161,6 +161,7 @@ export default function Sidebar() {
                 <NavSection label="Monitor" isExpanded={isExpanded} />
                 <NavItem to={routes.dashboard} icon="monitoring" label="Dashboard" isExpanded={isExpanded} />
                 <NavItem to={routes.scans} icon="history" label="Registry" isExpanded={isExpanded} />
+                <NavItem to="/audit" icon="receipt_long" label="Audit Log" isExpanded={isExpanded} />
 
                 <NavSection label="Analyze" isExpanded={isExpanded} />
                 <NavItem to={routes.findings} icon="emergency_home" label="Findings" isExpanded={isExpanded} />

--- a/frontend/src/pages/AuditLog.tsx
+++ b/frontend/src/pages/AuditLog.tsx
@@ -1,0 +1,307 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { getAuditLog, exportAuditLog, AuditEntry } from '../api'
+import { formatDateLong } from '../utils/date'
+
+const EVENT_TYPES = [
+  'scan_created', 'scan_cancelled',
+  'report_downloaded', 'task_deleted',
+]
+
+const severityTone = (severity: string) => {
+  switch (severity) {
+    case 'critical': return 'text-rag-red border-rag-red/30 bg-rag-red/10'
+    case 'high':     return 'text-rag-amber border-rag-amber/30 bg-rag-amber/10'
+    case 'warning':  return 'text-rag-amber border-rag-amber/30 bg-rag-amber/10'
+    case 'info':     return 'text-rag-blue border-rag-blue/30 bg-rag-blue/10'
+    default:         return 'text-silver/60 border-white/10 bg-white/[0.02]'
+  }
+}
+
+const eventTone = (event_type: string) => {
+  if (event_type.includes('cancel') || event_type.includes('delete') || event_type.includes('clear'))
+    return 'text-rag-red'
+  if (event_type.includes('created') || event_type.includes('completed'))
+    return 'text-rag-green'
+  if (event_type.includes('download') || event_type.includes('report'))
+    return 'text-rag-blue'
+  return 'text-silver/60'
+}
+
+export default function AuditLog() {
+  const [entries, setEntries] = useState<AuditEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [totalItems, setTotalItems] = useState(0)
+  const [expandedId, setExpandedId] = useState<number | null>(null)
+
+  // Filters
+  const [filterEvent, setFilterEvent] = useState('')
+  const [filterPlugin, setFilterPlugin] = useState('')
+  const [filterDateFrom, setFilterDateFrom] = useState('')
+  const [filterDateTo, setFilterDateTo] = useState('')
+
+  const buildParams = useCallback((overridePage?: number) => {
+    const p = new URLSearchParams()
+    p.set('page', String(overridePage ?? page))
+    p.set('per_page', '50')
+    if (filterEvent)    p.set('event_type', filterEvent)
+    if (filterPlugin)   p.set('plugin_id', filterPlugin)
+    if (filterDateFrom) p.set('date_from', filterDateFrom)
+    if (filterDateTo)   p.set('date_to', filterDateTo)
+    return p
+  }, [page, filterEvent, filterPlugin, filterDateFrom, filterDateTo])
+
+  const load = useCallback(async (overridePage?: number) => {
+    setLoading(true)
+    try {
+      const data = await getAuditLog(buildParams(overridePage))
+      setEntries(data.entries)
+      setTotalPages(data.pagination.total_pages)
+      setTotalItems(data.pagination.total_items)
+    } catch (err) {
+      console.error('Failed to load audit log', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [buildParams])
+
+  useEffect(() => { load() }, [page])
+
+  const handleFilter = () => {
+    setPage(1)
+    load(1)
+  }
+
+  const handleReset = () => {
+    setFilterEvent('')
+    setFilterPlugin('')
+    setFilterDateFrom('')
+    setFilterDateTo('')
+    setPage(1)
+    setTimeout(() => load(1), 0)
+  }
+
+  return (
+    <div className="min-h-screen bg-charcoal-dark text-silver px-3 py-6 md:px-4 xl:px-5 md:py-8 space-y-8">
+
+      {/* Header */}
+      <header className="border-b border-white/8 pb-6">
+        <div className="space-y-3">
+          <span className="bg-rag-blue text-black px-3 py-1 text-[10px] uppercase tracking-[0.3em] inline-block font-black">
+            System_Audit_Trail
+          </span>
+          <h1 className="text-4xl md:text-6xl text-silver-bright uppercase tracking-tight leading-none italic font-black">
+            Audit <span className="text-transparent" style={{ WebkitTextStroke: '1.5px var(--accent-silver-bright)' }}>Log</span>
+          </h1>
+          <p className="text-sm text-silver/50 font-mono">
+            Append-only record of all scan lifecycle events
+          </p>
+        </div>
+      </header>
+
+      {/* Stats bar */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[
+          { label: 'Total Events', value: totalItems },
+          { label: 'Current Page', value: page },
+          { label: 'Total Pages', value: totalPages },
+          { label: 'Per Page', value: 50 },
+        ].map(({ label, value }) => (
+          <div key={label} className="bg-charcoal border border-white/5 p-4">
+            <p className="text-[10px] font-black text-silver/30 uppercase tracking-[0.28em] mb-2">{label}</p>
+            <p className="text-2xl font-black text-silver-bright italic">{value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Filters */}
+      <div className="border border-white/8 bg-charcoal p-5 space-y-4">
+        <div className="flex items-center gap-4">
+          <h3 className="text-xs font-black text-silver-bright uppercase tracking-[0.36em] italic">Filters</h3>
+          <div className="h-px flex-1 bg-white/8" />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">
+          <select
+            value={filterEvent}
+            onChange={e => setFilterEvent(e.target.value)}
+            className="bg-black/30 border border-white/10 px-3 py-2 text-sm text-silver-bright outline-none"
+          >
+            <option value="">All Event Types</option>
+            {EVENT_TYPES.map(e => (
+              <option key={e} value={e}>{e}</option>
+            ))}
+          </select>
+          <input
+            value={filterPlugin}
+            onChange={e => setFilterPlugin(e.target.value)}
+            placeholder="Filter by plugin ID..."
+            className="bg-black/30 border border-white/10 px-3 py-2 text-sm text-silver-bright outline-none placeholder:text-silver/30"
+          />
+          <input
+            type="date"
+            value={filterDateFrom}
+            onChange={e => setFilterDateFrom(e.target.value)}
+            className="bg-black/30 border border-white/10 px-3 py-2 text-sm text-silver-bright outline-none"
+          />
+          <input
+            type="date"
+            value={filterDateTo}
+            onChange={e => setFilterDateTo(e.target.value)}
+            className="bg-black/30 border border-white/10 px-3 py-2 text-sm text-silver-bright outline-none"
+          />
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            onClick={handleFilter}
+            className="bg-rag-blue text-black px-5 py-2 text-[10px] font-black uppercase tracking-[0.26em] italic hover:brightness-110 transition-all"
+          >
+            Apply_Filters
+          </button>
+          <button
+            onClick={handleReset}
+            className="border border-white/10 text-silver/75 px-5 py-2 text-[10px] font-black uppercase tracking-[0.26em] italic hover:bg-white/[0.04] transition-all"
+          >
+            Reset
+          </button>
+          <div className="ml-auto flex gap-2">
+            <button
+              onClick={() => exportAuditLog('csv', buildParams())}
+              className="border border-white/10 text-silver/75 px-4 py-2 text-[10px] font-black uppercase tracking-[0.2em] hover:bg-white/[0.04] transition-all"
+            >
+              Export CSV
+            </button>
+            <button
+              onClick={() => exportAuditLog('json', buildParams())}
+              className="border border-white/10 text-silver/75 px-4 py-2 text-[10px] font-black uppercase tracking-[0.2em] hover:bg-white/[0.04] transition-all"
+            >
+              Export JSON
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="border border-white/8 bg-charcoal p-5 space-y-4">
+        <div className="flex items-center gap-4">
+          <h3 className="text-xs font-black text-silver-bright uppercase tracking-[0.36em] italic">Events</h3>
+          <div className="h-px flex-1 bg-white/8" />
+          <span className="text-[10px] uppercase tracking-[0.24em] text-silver/40">{entries.length} shown</span>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <div className="w-12 h-12 border-4 border-silver-bright/10 border-t-rag-blue animate-spin" />
+          </div>
+        ) : entries.length === 0 ? (
+          <p className="text-sm text-silver/40 italic py-12 text-center">No audit events found for the selected filters.</p>
+        ) : (
+          <div className="relative overflow-x-auto border border-white/6 bg-black/20">
+            <table className="w-full text-left text-[11px] font-mono border-collapse">
+              <thead>
+                <tr className="border-b border-white/10 text-silver/40 uppercase tracking-[0.22em] bg-[#0c0c0f]">
+                  <th className="px-4 py-3 font-black w-[180px]">Timestamp</th>
+                  <th className="px-4 py-3 font-black w-[160px]">Event</th>
+                  <th className="px-4 py-3 font-black w-[80px]">Severity</th>
+                  <th className="px-4 py-3 font-black">Message</th>
+                  <th className="px-4 py-3 font-black w-[120px]">Task ID</th>
+                  <th className="px-4 py-3 font-black w-[40px]" />
+                </tr>
+              </thead>
+              <tbody>
+                <AnimatePresence>
+                  {entries.map((entry) => (
+                    <React.Fragment key={entry.id}>
+                      <motion.tr
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        className="border-b border-white/5 last:border-0 hover:bg-white/[0.03] transition-colors cursor-pointer"
+                        onClick={() => setExpandedId(expandedId === entry.id ? null : entry.id)}
+                      >
+                        <td className="px-4 py-3 text-silver/50 whitespace-nowrap">
+                          {formatDateLong(entry.timestamp)}
+                        </td>
+                        <td className={`px-4 py-3 font-black uppercase tracking-wider ${eventTone(entry.event_type)}`}>
+                          {entry.event_type}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`px-2 py-0.5 text-[9px] font-black uppercase border ${severityTone(entry.severity)}`}>
+                            {entry.severity}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-silver/75 max-w-xs truncate">
+                          {entry.message}
+                        </td>
+                        <td className="px-4 py-3 text-rag-blue/70 font-mono text-[10px] truncate">
+                          {entry.task_id ? entry.task_id.split('-')[0].toUpperCase() : '—'}
+                        </td>
+                        <td className="px-4 py-3 text-silver/30 text-center">
+                          {expandedId === entry.id ? '▲' : '▼'}
+                        </td>
+                      </motion.tr>
+
+                      {/* Expanded context row */}
+                      <AnimatePresence>
+                        {expandedId === entry.id && (
+                          <motion.tr
+                            key={`expanded-${entry.id}`}
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                          >
+                            <td colSpan={6} className="px-6 py-4 bg-black/30 border-b border-white/5">
+                              <div className="space-y-2">
+                                <p className="text-[10px] font-black text-silver/30 uppercase tracking-[0.3em]">Context</p>
+                                <pre className="text-[11px] font-mono text-rag-blue/80 whitespace-pre-wrap break-words leading-6">
+                                  {JSON.stringify(entry.context, null, 2)}
+                                </pre>
+                                {entry.plugin_id && (
+                                  <p className="text-[10px] text-silver/40 font-mono">
+                                    Plugin: <span className="text-silver/70">{entry.plugin_id}</span>
+                                  </p>
+                                )}
+                                {entry.task_id && (
+                                  <p className="text-[10px] text-silver/40 font-mono">
+                                    Task ID: <span className="text-rag-blue/70">{entry.task_id}</span>
+                                  </p>
+                                )}
+                              </div>
+                            </td>
+                          </motion.tr>
+                        )}
+                      </AnimatePresence>
+                    </React.Fragment>
+                  ))}
+                </AnimatePresence>
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between pt-2">
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage(p => p - 1)}
+              className="border border-white/10 px-4 py-2 text-[10px] font-black uppercase tracking-[0.2em] text-silver/75 disabled:opacity-30 hover:bg-white/[0.04] transition-all"
+            >
+              ← Prev
+            </button>
+            <span className="text-[10px] text-silver/40 uppercase tracking-[0.2em]">
+              Page {page} of {totalPages}
+            </span>
+            <button
+              disabled={page >= totalPages}
+              onClick={() => setPage(p => p + 1)}
+              className="border border-white/10 px-4 py-2 text-[10px] font-black uppercase tracking-[0.2em] text-silver/75 disabled:opacity-30 hover:bg-white/[0.04] transition-all"
+            >
+              Next →
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Implements the structured audit log feature end-to-end. The `audit_log`

table already existed in the schema; this PR adds the query/export API

routes and the full frontend Audit Log page. Closes #327.

## Changes

### Backend (`backend/secuscan/routes.py`)

- `GET /audit` — paginated audit log with filters:

  `event_type`, `plugin_id`, `date_from`, `date_to`

- `GET /audit/export?format=csv|json` — streams the filtered

  log as a downloadable file (no size limit)

- Added `scan_created` audit event to `POST /task/start`

- Added `scan_cancelled` audit event to `POST /task/{id}/cancel`

### Frontend

- `frontend/src/api.ts` — added `getAuditLog()`,

  `exportAuditLog()`, and `AuditEntry` / `AuditLogResponse` types

- `frontend/src/pages/AuditLog.tsx` (new) — full audit log page:

  - Stats bar (total events, page, total pages)

  - Filter panel: event type dropdown, plugin ID input, date range

  - Paginated table with per-row expandable context panel

  - Export CSV / Export JSON buttons

  - Color-coded event types and severity badges

- `frontend/src/App.tsx` — registered `/audit` route

- `frontend/src/components/Sidebar.tsx` — added Audit Log nav item

## How to test

1. Run a scan — check `GET /api/v1/audit` returns a `scan_created` entry

2. Cancel a task — confirm `scan_cancelled` entry appears

3. Download a report — confirm `report_downloaded` entry appears

4. Open `/audit` in the UI — confirm the table loads with all events

5. Apply `event_type=scan_created` filter — confirm only create events show

6. Click Export CSV — confirm file downloads with correct headers/rows

7. Click Export JSON — confirm valid JSON file downloads

8. Navigate pages — confirm pagination works correctly

## Notes

- The `audit_log` table is append-only at the API layer —

  no DELETE or PATCH routes are exposed for audit entries

- The `actor` field defaults to `local` in the existing

  `log_audit()` DB method — ready for future user ID support

  without a schema change

- No new dependencies added

Closes #327