### PR TITLE
fix(stream): chunk completed task raw output replay

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -110,6 +110,7 @@ from .workflows import scheduler
 from sse_starlette.sse import EventSourceResponse
 
 router = APIRouter(prefix="/api/v1")
+SSE_RAW_OUTPUT_CHUNK_SIZE = 64 * 1024
 
 
 async def get_or_set_cached(key: str, builder):
@@ -129,6 +130,16 @@ async def invalidate_view_cache():
     cache = await get_cache()
     for prefix in ["summary:", "findings:", "reports:", "tasks:"]:
         await cache.delete_prefix(prefix)
+
+
+def iter_raw_output_chunks(path: str, chunk_size: int = SSE_RAW_OUTPUT_CHUNK_SIZE):
+    """Yield raw output in bounded chunks for completed-task SSE replay."""
+    with open(path, "r", encoding="utf-8", errors="replace") as output_file:
+        while True:
+            chunk = output_file.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
 
 
 def _report_generation_error_response(task_id: str, report_format: str) -> JSONResponse:
@@ -336,13 +347,13 @@ async def stream_task_output(task_id: str):
                 db = await get_db()
                 task_row = await db.fetchone("SELECT raw_output_path FROM tasks WHERE id = ?", (task_id,))
                 if task_row and task_row["raw_output_path"]:
-                    with open(task_row["raw_output_path"], "r") as f:
+                    for chunk in iter_raw_output_chunks(task_row["raw_output_path"]):
                         yield {
                             "event": "output",
-                            "data": json.dumps({"chunk": f.read()})
+                            "data": json.dumps({"chunk": chunk})
                         }
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning("Failed to replay raw output for task %s: %s", task_id, exc)
             return
 
         # Otherwise, subscribe to the live task events

--- a/testing/backend/integration/test_task_cleanup.py
+++ b/testing/backend/integration/test_task_cleanup.py
@@ -5,6 +5,7 @@ Issue #30 — Add backend tests for task cancellation and cleanup endpoints.
 Test file location: testing/backend/integration/test_task_cleanup.py
 """
 
+import json
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -246,6 +247,40 @@ async def test_delete_task_removes_raw_output_file(app_client, tmp_path):
     assert resp.status_code == 200, resp.text
 
     assert not raw_file.exists(), "raw_output_path file should have been deleted from disk"
+
+
+@pytest.mark.asyncio
+async def test_completed_task_stream_replays_raw_output_in_chunks(app_client, tmp_path):
+    """Completed-task SSE must not read and send the full raw output in one event."""
+    from backend.secuscan.routes import SSE_RAW_OUTPUT_CHUNK_SIZE
+
+    raw_output = "a" * SSE_RAW_OUTPUT_CHUNK_SIZE + "tail"
+    raw_file = tmp_path / "large_scan_output.txt"
+    raw_file.write_text(raw_output)
+
+    task_id = await insert_task(
+        app_client._db,
+        status="completed",
+        raw_output_path=str(raw_file),
+    )
+    app_client._mock_executor.get_task_status = AsyncMock(
+        return_value={"status": "completed"}
+    )
+
+    resp = await app_client.get(f"/api/v1/task/{task_id}/stream")
+
+    assert resp.status_code == 200, resp.text
+    event_name = None
+    output_chunks = []
+    for line in resp.text.splitlines():
+        if line.startswith("event: "):
+            event_name = line.removeprefix("event: ")
+        elif line.startswith("data: ") and event_name == "output":
+            output_chunks.append(json.loads(line.removeprefix("data: "))["chunk"])
+
+    assert len(output_chunks) == 2
+    assert all(len(chunk) <= SSE_RAW_OUTPUT_CHUNK_SIZE for chunk in output_chunks)
+    assert "".join(output_chunks) == raw_output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes the completed-task SSE replay path so raw scan output is sent in bounded chunks instead of loading the entire raw output file into memory with one `f.read()` call.

This keeps the existing SSE `output` event contract intact while reducing memory pressure for large completed scan logs. I am contributing this under GSSoC.

## Related Issues

Closes #405

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] `.venv/bin/python -m py_compile backend/secuscan/routes.py testing/backend/integration/test_task_cleanup.py`
- [x] `git diff --check`
- [ ] `.venv/bin/python -m pytest testing/backend/integration/test_task_cleanup.py -k completed_task_stream_replays_raw_output_in_chunks`

Local pytest note: this environment could not run the targeted pytest because the local `.venv` dependency install failed before installing `pytest`; the install is blocked by native Cairo development packages required by `xhtml2pdf`. The upstream CI environment installs those native packages, so CI should run the backend tests normally.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
