### PR TITLE
fix: resolve pre-existing test-infrastructure bugs (Closes #365)

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -4,3 +4,4 @@ httpx>=0.28.1
 ruff>=0.15.12
 pytest-asyncio>=0.24.0
 anyio>=4.0.0
+trio>=0.27.0

--- a/testing/backend/conftest.py
+++ b/testing/backend/conftest.py
@@ -5,6 +5,11 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
 # Add repo root to sys.path so package imports work (backend.*)
 repo_root = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(repo_root))
@@ -20,7 +25,7 @@ from backend.secuscan.ratelimit import concurrent_limiter, rate_limiter
 @pytest.fixture(autouse=True)
 def setup_test_environment(monkeypatch):
     """Override settings for tests to ensure isolated execution."""
-    temp_dir = tempfile.TemporaryDirectory()
+    temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
     temp_path = temp_dir.name
 
     monkeypatch.setattr(settings, "data_dir", temp_path)


### PR DESCRIPTION
gh pr create --repo utksh1/SecuScan --base main --head ask-z4ch:fix/test-infra --title "fix: resolve pre-existing test-infrastructure bugs (Closes #365)" --body "## Description

Two pre-existing test-infrastructure issues were discovered while validating the sandbox executor (#326). Neither is caused by that feature — both occur on a clean \`main\` checkout.

### Bug 1: Missing \`trio\` dependency

\`test_cli.py\` uses \`@pytest.mark.anyio\`, which parametrizes each test over \`[\"asyncio\", \"trio\"]\` by default. \`trio\` was not listed in \`requirements-dev.txt\`, causing \`ModuleNotFoundError\` for both trio-parametrized tests.

**Fix:** Added \`trio>=0.27.0\` to \`backend/requirements-dev.txt\`.

Additionally, because the codebase uses \`asyncio.create_task\` directly (and is not trio-compatible), the anyio backend is pinned to \`[\"asyncio\"]\` via a \`conftest.py\` fixture. This prevents collection of trio variants that would fail at runtime.

### Bug 2: Windows \`PermissionError\` on temp dir cleanup

\`conftest.py\`'s \`setup_test_environment\` fixture creates a \`TemporaryDirectory\` that holds a SQLite database file. On Windows, the file handle remains held past test teardown, causing \`PermissionError: [WinError 32]\`.

**Fix:** Added \`ignore_cleanup_errors=True\` to the \`TemporaryDirectory()\` call (Python 3.10+).

## Related Issues

Closes #365

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- \`pytest testing/backend/unit/ -q\` — **243 passed, 0 failed**
- \`pytest testing/backend/unit/test_cli.py -v\` — all tests pass (no trio-related failures)
- Verified on Windows: no \`PermissionError\` during temporary directory cleanup

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes."