### PR TITLE
feat(ui): progressive scan phase indicators with real-time SSE updates

### DIFF
--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -210,6 +210,7 @@ class Database:
         
         needed_cols = {
             "exit_code": "INTEGER",
+            "scan_phase": "TEXT",
             "structured_json": "TEXT",
             "raw_output_path": "TEXT",
             "command_used": "TEXT",

--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -18,7 +18,7 @@ from .cache import get_cache
 from .config import settings
 from .database import get_db
 from .plugins import get_plugin_manager
-from .models import TaskStatus
+from .models import TaskStatus, ScanPhase
 from .ratelimit import concurrent_limiter
 from .risk_scoring import compute_risk_score, compute_risk_factors
 
@@ -110,6 +110,15 @@ class TaskExecutor:
             for q in self._listeners[task_id]:
                 await q.put(event)
     
+    async def _broadcast_phase(self, task_id: str, phase: str):
+        """Broadcast a scan phase transition and persist it to the database."""
+        await self._broadcast(task_id, "phase", phase)
+        db = await get_db()
+        await db.execute(
+            "UPDATE tasks SET scan_phase = ? WHERE id = ?",
+            (phase, task_id)
+        )
+    
     async def create_task(
         self,
         plugin_id: str,
@@ -148,8 +157,8 @@ class TaskExecutor:
             """
             INSERT INTO tasks (
                 id, plugin_id, tool_name, target, inputs_json, preset,
-                status, consent_granted, safe_mode
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                status, scan_phase, consent_granted, safe_mode
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -159,6 +168,7 @@ class TaskExecutor:
                 json.dumps(inputs),
                 preset,
                 TaskStatus.QUEUED.value,
+                ScanPhase.QUEUED.value,
                 consent_granted,
                 inputs.get("safe_mode", True)
             )
@@ -249,6 +259,7 @@ class TaskExecutor:
                 
                 logger.info(f"Executing modular scanner {plugin_id} for task {task_id}")
                 await self._broadcast(task_id, "status", TaskStatus.RUNNING.value)
+                await self._broadcast_phase(task_id, ScanPhase.RUNNING_COMMAND.value)
                 
                 start_time = time.time()
                 # Run the scanner
@@ -279,6 +290,7 @@ class TaskExecutor:
                 )
 
                 # Upsert findings and report using the scanner's result
+                await self._broadcast_phase(task_id, ScanPhase.PARSING.value)
                 await self._upsert_findings_and_report_from_scanner(
                     db=db,
                     task_id=task_id,
@@ -288,6 +300,7 @@ class TaskExecutor:
                     status=final_status,
                     result=result
                 )
+                await self._broadcast_phase(task_id, ScanPhase.REPORTING.value)
 
             else:
                 # Standard Plugin Execution
@@ -322,6 +335,7 @@ class TaskExecutor:
 
                 logger.info(f"Executing task {task_id}: {' '.join(command)}")
                 await self._broadcast(task_id, "status", TaskStatus.RUNNING.value)
+                await self._broadcast_phase(task_id, ScanPhase.RUNNING_COMMAND.value)
 
                 # Execute command
                 start_time = time.time()
@@ -371,6 +385,7 @@ class TaskExecutor:
                 )
 
                 # Upsert findings and report
+                await self._broadcast_phase(task_id, ScanPhase.PARSING.value)
                 await self._upsert_findings_and_report(
                     db=db,
                     task_id=task_id,
@@ -380,7 +395,9 @@ class TaskExecutor:
                     status=final_status,
                     output=output
                 )
+                await self._broadcast_phase(task_id, ScanPhase.REPORTING.value)
 
+            await self._broadcast_phase(task_id, ScanPhase.FINISHED.value)
             await self._broadcast(task_id, "status", final_status)
             await self._invalidate_cached_views()
 
@@ -624,7 +641,7 @@ class TaskExecutor:
         db = await get_db()
         task_row = await db.fetchone(
             """
-            SELECT id, plugin_id, tool_name, target, status, created_at, started_at, completed_at, 
+            SELECT id, plugin_id, tool_name, target, status, scan_phase, created_at, started_at, completed_at, 
                    duration_seconds, exit_code, error_message, preset, inputs_json
             FROM tasks WHERE id = ?
             """,
@@ -651,6 +668,7 @@ class TaskExecutor:
             "tool": task_row["tool_name"],
             "target": task_row["target"],
             "status": task_row["status"],
+            "scan_phase": task_row.get("scan_phase"),
             "created_at": task_row["created_at"],
             "started_at": task_row["started_at"],
             "completed_at": task_row["completed_at"],

--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -118,7 +118,7 @@ class TaskExecutor:
             "UPDATE tasks SET scan_phase = ? WHERE id = ?",
             (phase, task_id)
         )
-    
+
     async def create_task(
         self,
         plugin_id: str,
@@ -641,7 +641,7 @@ class TaskExecutor:
         db = await get_db()
         task_row = await db.fetchone(
             """
-            SELECT id, plugin_id, tool_name, target, status, scan_phase, created_at, started_at, completed_at, 
+            SELECT id, plugin_id, tool_name, target, status, scan_phase, created_at, started_at, completed_at,
                    duration_seconds, exit_code, error_message, preset, inputs_json
             FROM tasks WHERE id = ?
             """,

--- a/backend/secuscan/models.py
+++ b/backend/secuscan/models.py
@@ -26,6 +26,15 @@ class TaskStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
+class ScanPhase(str, Enum):
+    """Granular scan phase for progress display"""
+    QUEUED = "queued"
+    RUNNING_COMMAND = "running_command"
+    PARSING = "parsing"
+    REPORTING = "reporting"
+    FINISHED = "finished"
+
+
 class PluginFieldType(str, Enum):
     """Plugin field input types"""
     STRING = "string"

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -324,10 +324,10 @@ async def stream_task_output(task_id: str):
         raise HTTPException(status_code=404, detail="Task not found")
 
     async def event_generator():
-        # First, send the initial status
+        # First, send the initial status and phase
         yield {
             "event": "status",
-            "data": json.dumps({"status": status["status"]})
+            "data": json.dumps({"status": status["status"], "scan_phase": status.get("scan_phase")})
         }
 
         # If it's already completed/failed, we just return the raw output if any and close
@@ -359,6 +359,11 @@ async def stream_task_output(task_id: str):
                     }
                     if event["data"] in ["completed", "failed", "cancelled"]:
                         break
+                elif event["type"] == "phase":
+                    yield {
+                        "event": "phase",
+                        "data": json.dumps({"scan_phase": event["data"]})
+                    }
                 elif event["type"] == "output":
                     yield {
                         "event": "output",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -129,6 +129,8 @@ export function getTasks(params?: URLSearchParams) {
   return request(`/tasks${suffix}`)
 }
 
+export type ScanPhase = 'queued' | 'running_command' | 'parsing' | 'reporting' | 'finished'
+
 export function getTaskStatus(taskId: string): Promise<any> {
   return request<any>(`/task/${taskId}/status`)
 }

--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -16,6 +16,7 @@ interface Task {
   tool: string;
   target: string;
   status: "queued" | "running" | "completed" | "failed" | "cancelled";
+  scan_phase?: string;
   created_at: string;
   started_at?: string;
   completed_at?: string;
@@ -472,6 +473,11 @@ export default function Scans() {
                                       {task.plugin_id}
                                     </span>
                                   </p>
+                                  {task.status === 'running' && task.scan_phase && (
+                                    <p className="text-[10px] font-mono text-rag-blue/80 uppercase tracking-widest">
+                                      PHASE: {task.scan_phase.replace(/_/g, ' ')}
+                                    </p>
+                                  )}
                                   <p className="text-[10px] font-mono text-silver/40">
                                     SESSION:{" "}
                                     <span className="text-silver-bright uppercase">

--- a/frontend/src/pages/TaskDetails.tsx
+++ b/frontend/src/pages/TaskDetails.tsx
@@ -34,6 +34,7 @@ interface Task {
     tool: string
     target: string
     status: string
+    scan_phase?: string
     created_at: string
     started_at?: string
     completed_at?: string
@@ -107,6 +108,57 @@ function defaultValueForField(field: PluginFieldSchema): unknown {
 }
 
 
+const PHASE_LABELS: Record<string, string> = {
+    queued: 'QUEUED',
+    running_command: 'RUNNING_SCAN',
+    parsing: 'PARSING_RESULTS',
+    reporting: 'GENERATING_REPORT',
+    finished: 'FINALIZING',
+}
+
+const PHASE_MESSAGES: Record<string, string> = {
+    queued: 'Awaiting execution slot...',
+    running_command: 'Executing security scan...',
+    parsing: 'Parsing scan results...',
+    reporting: 'Generating reports...',
+    finished: 'Finalizing...',
+}
+
+function PhaseLabel({ phase }: { phase?: string }) {
+    const label = phase ? PHASE_LABELS[phase] : null
+    const message = phase ? PHASE_MESSAGES[phase] : 'Decrypting_Briefing...'
+    return (
+        <p className="text-xs font-black text-silver-bright uppercase tracking-[0.5em] italic">
+            {label || 'DECRYPTING_BRIEFING...'}
+        </p>
+    )
+}
+
+function PhaseProgress({ phase }: { phase?: string }) {
+    if (!phase || phase === 'finished') return null
+    const phases = ['queued', 'running_command', 'parsing', 'reporting']
+    const currentIdx = phases.indexOf(phase)
+    if (currentIdx === -1) return null
+
+    return (
+        <div className="space-y-4">
+            <div className="flex items-center gap-2">
+                {phases.map((p, i) => (
+                    <React.Fragment key={p}>
+                        <div className={`w-3 h-3 border-2 ${i <= currentIdx ? 'bg-rag-blue border-rag-blue shadow-[0_0_8px_rgba(0,112,243,0.5)]' : 'bg-charcoal-dark border-silver/20'} transition-all duration-500`} />
+                        {i < phases.length - 1 && (
+                            <div className={`h-0.5 flex-1 ${i < currentIdx ? 'bg-rag-blue' : 'bg-silver/10'} transition-all duration-500`} />
+                        )}
+                    </React.Fragment>
+                ))}
+            </div>
+            <p className="text-[10px] font-mono text-rag-blue/80 uppercase tracking-[0.3em] italic">
+                {PHASE_MESSAGES[phase] || 'Processing...'}
+            </p>
+        </div>
+    )
+}
+
 function formatToolLabel(tool?: string, pluginId?: string) {
     const normalized = (tool || '').trim()
     if (!normalized || normalized.toLowerCase() === 'history') {
@@ -151,6 +203,7 @@ export default function TaskDetails() {
     const [rawOutput, setRawOutput] = useState<string>('')
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
+    const [scanPhase, setScanPhase] = useState<string | null>(null)
     const [activeTab, setActiveTab] = useState<'summary' | 'results' | 'parameters' | 'raw'>('summary')
     const [expandedFindingRows, setExpandedFindingRows] = useState<Record<number, boolean>>({})
     const [expandedDiscoveryRows, setExpandedDiscoveryRows] = useState<Record<number, boolean>>({})
@@ -315,12 +368,24 @@ export default function TaskDetails() {
             try {
                 const data = JSON.parse(e.data)
                 setTask((prev: Task | null) => prev ? { ...prev, status: data.status } : null)
+                if (data.scan_phase) {
+                    setScanPhase(data.scan_phase)
+                }
                 if (['completed', 'failed', 'cancelled'].includes(data.status)) {
                     es.close()
                     loadTask()
                 }
             } catch (err) {
                 console.error("Status stream error", err)
+            }
+        })
+
+        es.addEventListener('phase', (e) => {
+            try {
+                const data = JSON.parse(e.data)
+                setScanPhase(data.scan_phase)
+            } catch (err) {
+                console.error("Phase stream error", err)
             }
         })
 
@@ -349,6 +414,9 @@ export default function TaskDetails() {
                 getTaskResult(taskId!).catch(() => null) as Promise<TaskResult | null>
             ])
             setTask(statusData)
+            if (statusData.scan_phase) {
+                setScanPhase(statusData.scan_phase)
+            }
             getPluginSchema(statusData.plugin_id).then(setSchema).catch(() => setSchema(null))
 
             if (resultData) {
@@ -424,7 +492,7 @@ export default function TaskDetails() {
             <div className="min-h-screen bg-charcoal-dark flex items-center justify-center p-12">
                 <div className="space-y-4 text-center">
                     <div className="w-20 h-20 border-8 border-silver-bright/10 border-t-rag-blue animate-spin mx-auto shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]"></div>
-                    <p className="text-xs font-black text-silver-bright uppercase tracking-[0.5em] italic">Decrypting_Briefing...</p>
+                    <PhaseLabel phase={scanPhase || undefined} />
                 </div>
             </div>
         )
@@ -712,7 +780,11 @@ export default function TaskDetails() {
                 </div>
             </header>
 
-
+            {!isTerminal && scanPhase && (
+                <section className="border border-rag-blue/20 bg-charcoal p-6">
+                    <PhaseProgress phase={scanPhase} />
+                </section>
+            )}
 
             <section className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
                 <DetailCard

--- a/frontend/testing/unit/pages/ScanPhases.test.tsx
+++ b/frontend/testing/unit/pages/ScanPhases.test.tsx
@@ -1,0 +1,148 @@
+import { render, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import TaskDetails from '../../../src/pages/TaskDetails';
+import * as api from '../../../src/api';
+
+vi.mock('../../../src/api', () => ({
+  API_BASE: 'http://localhost',
+  getTaskStatus: vi.fn(),
+  getTaskResult: vi.fn(),
+  getPluginSchema: vi.fn().mockResolvedValue(null),
+  startTask: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useParams: () => ({ taskId: 'test-task-123' }),
+    useNavigate: () => vi.fn(),
+  };
+});
+
+vi.mock('../../../src/components/ToastContext', () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}));
+
+const RUNNING_TASK = {
+  task_id: 'test-task-123',
+  plugin_id: 'nmap',
+  tool: 'Nmap',
+  target: '127.0.0.1',
+  status: 'running',
+  scan_phase: 'running_command',
+  created_at: '2026-01-01T00:00:00',
+  started_at: '2026-01-01T00:00:01',
+};
+
+const RESULT_EMPTY = {
+  task_id: 'test-task-123',
+  plugin_id: 'nmap',
+  tool: 'Nmap',
+  target: '127.0.0.1',
+  timestamp: '2026-01-01T00:00:00',
+  status: 'running',
+  summary: [],
+  findings: [],
+  structured: {},
+};
+
+function renderTaskDetails() {
+  return render(
+    <MemoryRouter>
+      <TaskDetails />
+    </MemoryRouter>,
+  );
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('TaskDetails — scan phase display', () => {
+  let currentEventSource: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    currentEventSource = undefined;
+    // Mock EventSource before rendering
+    class MockEventSource {
+      url: string;
+      _onerror: any;
+      listeners: Record<string, Function[]> = {};
+      constructor(url: string) { this.url = url; currentEventSource = this; }
+      addEventListener(event: string, handler: Function) {
+        if (!this.listeners[event]) this.listeners[event] = [];
+        this.listeners[event].push(handler);
+      }
+      set onerror(handler: any) { this._onerror = handler; }
+      close() {}
+    }
+    vi.stubGlobal('EventSource', MockEventSource);
+
+    vi.mocked(api.getTaskStatus).mockResolvedValue(RUNNING_TASK);
+    vi.mocked(api.getTaskResult).mockResolvedValue(RESULT_EMPTY);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading screen with phase label while task is loading', async () => {
+    vi.mocked(api.getTaskStatus).mockImplementation(() => new Promise(() => {}));
+
+    renderTaskDetails();
+    await flush();
+
+    expect(document.body.textContent).toContain('DECRYPTING_BRIEFING');
+  });
+
+  it('shows phase progress for running_command phase', async () => {
+    renderTaskDetails();
+    await flush();
+    await flush();
+
+    expect(document.body.textContent).toContain('Executing security scan');
+  });
+
+  it('shows phase progress when phase changes via SSE', async () => {
+    renderTaskDetails();
+    await flush();
+    await flush();
+
+    expect(currentEventSource).toBeTruthy();
+    expect(currentEventSource.listeners['phase']).toBeTruthy();
+    act(() => {
+      currentEventSource.listeners['phase'].forEach((fn: Function) =>
+        fn({ data: JSON.stringify({ scan_phase: 'parsing' }) }),
+      );
+    });
+
+    await flush();
+    expect(document.body.textContent).toContain('Parsing scan results');
+  });
+
+  it('shows reporting phase label', async () => {
+    renderTaskDetails();
+    await flush();
+    await flush();
+
+    expect(currentEventSource).toBeTruthy();
+    expect(currentEventSource.listeners['phase']).toBeTruthy();
+    act(() => {
+      currentEventSource.listeners['phase'].forEach((fn: Function) =>
+        fn({ data: JSON.stringify({ scan_phase: 'reporting' }) }),
+      );
+    });
+
+    await flush();
+    expect(document.body.textContent).toContain('Generating reports');
+  });
+});

--- a/frontend/testing/unit/pages/ScansPhases.test.tsx
+++ b/frontend/testing/unit/pages/ScansPhases.test.tsx
@@ -1,0 +1,142 @@
+import { render, act, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Scans from '../../../src/pages/Scans';
+
+vi.mock('../../../src/api', () => ({
+  API_BASE: 'http://localhost',
+  deleteTask: vi.fn(),
+  clearAllTasks: vi.fn(),
+  bulkDeleteTasks: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+function makeTask(id: string, status: string, scan_phase?: string) {
+  return {
+    task_id: id,
+    plugin_id: 'nmap',
+    tool: 'Nmap',
+    target: '127.0.0.1',
+    status,
+    scan_phase: scan_phase || null,
+    created_at: '2026-01-01T00:00:00',
+    started_at: status === 'running' ? '2026-01-01T00:00:01' : null,
+    completed_at: null,
+    duration_seconds: null,
+    preset: null,
+    inputs: { target: '127.0.0.1' },
+  };
+}
+
+const RUNNING_WITH_PHASE_RESPONSE = {
+  tasks: [makeTask('task-1', 'running', 'running_command')],
+  pagination: { total_items: 1 },
+};
+
+const QUEUED_RESPONSE = {
+  tasks: [makeTask('task-2', 'queued')],
+  pagination: { total_items: 1 },
+};
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function tickTime(ms: number) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function renderScans() {
+  return render(
+    <MemoryRouter>
+      <Scans />
+    </MemoryRouter>,
+  );
+}
+
+describe('Scans — phase display', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    fetchSpy = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(RUNNING_WITH_PHASE_RESPONSE),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function clickExpand() {
+    const card = screen.getByText('Nmap').closest('[class*="cursor-pointer"]') as HTMLElement;
+    act(() => { card.click(); });
+  }
+
+  it('shows phase for a running task in expanded details', async () => {
+    renderScans();
+    await flush();
+
+    clickExpand();
+    await flush();
+
+    expect(screen.getByText(/RUNNING COMMAND/i)).toBeTruthy();
+  });
+
+  it('does not show phase for queued task', async () => {
+    fetchSpy.mockResolvedValue({
+      json: () => Promise.resolve(QUEUED_RESPONSE),
+    });
+
+    renderScans();
+    await flush();
+    await tickTime(5000);
+
+    clickExpand();
+    await flush();
+
+    expect(screen.queryByText(/PHASE/i)).toBeNull();
+  });
+
+  it('updates phase when polling returns a running task with phase', async () => {
+    renderScans();
+    await flush();
+
+    fetchSpy.mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          tasks: [makeTask('task-1', 'running', 'parsing')],
+          pagination: { total_items: 1 },
+        }),
+    });
+
+    await tickTime(5000);
+
+    clickExpand();
+    await flush();
+
+    expect(screen.getByText(/PARSING/i)).toBeTruthy();
+  });
+});

--- a/testing/backend/unit/test_scan_phases.py
+++ b/testing/backend/unit/test_scan_phases.py
@@ -1,0 +1,221 @@
+"""
+Tests for scan_phase field in task status and phase transitions.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from backend.secuscan.executor import TaskExecutor, ScanPhase
+from backend.secuscan.models import TaskStatus
+
+
+def make_task_row(task_id: str, status: str, scan_phase: str = None):
+    return {
+        "id": task_id,
+        "plugin_id": "nmap",
+        "tool_name": "Nmap",
+        "target": "127.0.0.1",
+        "status": status,
+        "scan_phase": scan_phase,
+        "created_at": "2026-01-01T00:00:00",
+        "started_at": None,
+        "completed_at": None,
+        "duration_seconds": None,
+        "exit_code": None,
+        "error_message": None,
+        "preset": None,
+        "inputs_json": "{}",
+    }
+
+
+async def _call_with_mock_db(executor, task_id, mock_db):
+    import backend.secuscan.executor as executor_module
+    original = executor_module.get_db
+
+    async def mock_get_db():
+        return mock_db
+
+    executor_module.get_db = mock_get_db
+    try:
+        return await executor.get_task_status(task_id)
+    finally:
+        executor_module.get_db = original
+
+
+@pytest.mark.asyncio
+async def test_queued_task_has_scan_phase():
+    executor = TaskExecutor()
+    mock_db = AsyncMock()
+    mock_db.fetchone.return_value = make_task_row("aaa", TaskStatus.QUEUED.value, ScanPhase.QUEUED.value)
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        result = await _call_with_mock_db(executor, "aaa", mock_db)
+
+    assert result["scan_phase"] == ScanPhase.QUEUED.value
+
+
+@pytest.mark.asyncio
+async def test_running_task_has_running_command_phase():
+    executor = TaskExecutor()
+    mock_db = AsyncMock()
+    mock_db.fetchone.return_value = make_task_row("aaa", TaskStatus.RUNNING.value, ScanPhase.RUNNING_COMMAND.value)
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        result = await _call_with_mock_db(executor, "aaa", mock_db)
+
+    assert result["scan_phase"] == ScanPhase.RUNNING_COMMAND.value
+
+
+@pytest.mark.asyncio
+async def test_parsing_phase():
+    executor = TaskExecutor()
+    mock_db = AsyncMock()
+    mock_db.fetchone.return_value = make_task_row("aaa", TaskStatus.RUNNING.value, ScanPhase.PARSING.value)
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        result = await _call_with_mock_db(executor, "aaa", mock_db)
+
+    assert result["scan_phase"] == ScanPhase.PARSING.value
+
+
+@pytest.mark.asyncio
+async def test_reporting_phase():
+    executor = TaskExecutor()
+    mock_db = AsyncMock()
+    mock_db.fetchone.return_value = make_task_row("aaa", TaskStatus.RUNNING.value, ScanPhase.REPORTING.value)
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        result = await _call_with_mock_db(executor, "aaa", mock_db)
+
+    assert result["scan_phase"] == ScanPhase.REPORTING.value
+
+
+@pytest.mark.asyncio
+async def test_finished_phase():
+    executor = TaskExecutor()
+    mock_db = AsyncMock()
+    mock_db.fetchone.return_value = make_task_row("aaa", TaskStatus.COMPLETED.value, ScanPhase.FINISHED.value)
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        result = await _call_with_mock_db(executor, "aaa", mock_db)
+
+    assert result["scan_phase"] == ScanPhase.FINISHED.value
+
+
+@pytest.mark.asyncio
+async def test_failed_task_scan_phase():
+    executor = TaskExecutor()
+    mock_db = AsyncMock()
+    mock_db.fetchone.return_value = make_task_row("aaa", TaskStatus.FAILED.value, ScanPhase.FINISHED.value)
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        result = await _call_with_mock_db(executor, "aaa", mock_db)
+
+    assert result["scan_phase"] == ScanPhase.FINISHED.value
+
+
+@pytest.mark.asyncio
+async def test_unknown_scan_phase_is_null():
+    executor = TaskExecutor()
+    mock_db = AsyncMock()
+    row = make_task_row("aaa", TaskStatus.QUEUED.value)
+    row["scan_phase"] = None
+    mock_db.fetchone.return_value = row
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        result = await _call_with_mock_db(executor, "aaa", mock_db)
+
+    assert result["scan_phase"] is None
+
+
+@pytest.mark.asyncio
+async def test_broadcast_phase_persists_to_db():
+    executor = TaskExecutor()
+    mock_db = AsyncMock()
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        await executor._broadcast_phase("task-1", ScanPhase.PARSING.value)
+
+    # Verify the DB was updated
+    mock_db.execute.assert_called_once_with(
+        "UPDATE tasks SET scan_phase = ? WHERE id = ?",
+        (ScanPhase.PARSING.value, "task-1")
+    )
+
+
+@pytest.mark.asyncio
+async def test_broadcast_phase_sends_event():
+    executor = TaskExecutor()
+    mock_db = AsyncMock()
+
+    # Subscribe to the task
+    queue = executor.subscribe("task-1")
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        await executor._broadcast_phase("task-1", ScanPhase.RUNNING_COMMAND.value)
+
+    event = await queue.get()
+    assert event["type"] == "phase"
+    assert event["data"] == ScanPhase.RUNNING_COMMAND.value
+
+
+@pytest.mark.asyncio
+async def test_phase_broadcast_ordering():
+    """
+    Verify that _broadcast_phase broadcasts the expected phase sequence
+    when called in correct order.
+    """
+    executor = TaskExecutor()
+    mock_db = AsyncMock()
+
+    queue = executor.subscribe("task-1")
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        await executor._broadcast_phase("task-1", ScanPhase.RUNNING_COMMAND.value)
+        await executor._broadcast_phase("task-1", ScanPhase.PARSING.value)
+        await executor._broadcast_phase("task-1", ScanPhase.REPORTING.value)
+        await executor._broadcast_phase("task-1", ScanPhase.FINISHED.value)
+
+    phase_events = []
+    while not queue.empty():
+        event = await queue.get()
+        if event["type"] == "phase":
+            phase_events.append(event["data"])
+
+    expected_order = [
+        ScanPhase.RUNNING_COMMAND.value,
+        ScanPhase.PARSING.value,
+        ScanPhase.REPORTING.value,
+        ScanPhase.FINISHED.value,
+    ]
+    assert phase_events == expected_order, f"Phases out of order: {phase_events}"
+
+
+@pytest.mark.asyncio
+async def test_scan_phase_included_in_status_response():
+    """
+    Verify that the get_task_status response includes the scan_phase field
+    via the route integration (mocked DB).
+    """
+    executor = TaskExecutor()
+    mock_db = AsyncMock()
+    mock_db.fetchone.return_value = {
+        "id": "task-sse-1",
+        "plugin_id": "nmap",
+        "tool_name": "Nmap",
+        "target": "127.0.0.1",
+        "status": TaskStatus.RUNNING.value,
+        "scan_phase": ScanPhase.RUNNING_COMMAND.value,
+        "created_at": "2026-01-01T00:00:00",
+        "started_at": None,
+        "completed_at": None,
+        "duration_seconds": None,
+        "exit_code": None,
+        "error_message": None,
+        "preset": None,
+        "inputs_json": "{}",
+    }
+
+    with patch("backend.secuscan.executor.get_db", new=AsyncMock(return_value=mock_db)):
+        result = await _call_with_mock_db(executor, "task-sse-1", mock_db)
+
+    assert result["scan_phase"] == ScanPhase.RUNNING_COMMAND.value


### PR DESCRIPTION
## #240 

This PR replaces the static "Decrypting Briefing" placeholder with progressive loading states that reflect real scan phases. Each scan now broadcasts its phase (`queued`, `running_command`, `parsing`, `reporting`, `finished`) over SSE, and the UI shows a stepped progress bar with a message for the current phase.

## Changes made

### 1. Backend
- **models.py** -- New `ScanPhase` enum with `QUEUED`, `RUNNING_COMMAND`, `PARSING`, `REPORTING`, `FINISHED`
- **database.py** -- Migration that adds a `scan_phase TEXT` column to the tasks table
- **executor.py** -- A `_broadcast_phase()` helper that writes the phase to the database and fires SSE events; phase transitions were added at each stage for both standard plugin and modular scanner paths
- **routes.py** -- Handles SSE `event: phase` and includes `scan_phase` in the initial status event

### 2. Frontend
- **api.ts** -- Exports the `ScanPhase` type
- **TaskDetails.tsx** -- Adds a `PhaseLabel` component for the loading state and a `PhaseProgress` component with a stepped bar and connector lines; listens for "phase" events over SSE and falls back to `scan_phase` from status responses
- **Scans.tsx** -- Shows the phase label in expanded task details for running tasks

## Tests
- **11 backend tests** -- Phase values, null handling, `_broadcast_phase` persistence and event delivery, broadcast ordering, status response inclusion
- **7 frontend tests** -- Loading state label, phase progress display, SSE phase updates, polling behavior, absence of phase for queued tasks

All 18 tests pass.