### PR TITLE
fix(stream): bound task listener queues

### DIFF
--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -69,6 +69,7 @@ MODULAR_SCANNERS = {
 }
 
 logger = logging.getLogger(__name__)
+STREAM_LISTENER_QUEUE_MAXSIZE = 100
 
 
 def extract_target(inputs: Dict[str, Any]) -> str:
@@ -92,7 +93,7 @@ class TaskExecutor:
         """Subscribe to a task's real-time events."""
         if task_id not in self._listeners:
             self._listeners[task_id] = []
-        q = asyncio.Queue()
+        q = asyncio.Queue(maxsize=STREAM_LISTENER_QUEUE_MAXSIZE)
         self._listeners[task_id].append(q)
         return q
 
@@ -107,8 +108,24 @@ class TaskExecutor:
         """Broadcast an event to all active listeners of a task."""
         if task_id in self._listeners:
             event = {"type": event_type, "data": data}
-            for q in self._listeners[task_id]:
-                await q.put(event)
+            for q in list(self._listeners[task_id]):
+                self._enqueue_listener_event(task_id, q, event)
+
+    def _enqueue_listener_event(self, task_id: str, q: asyncio.Queue, event: Dict[str, Any]):
+        """Add an event to a bounded listener queue without unbounded memory growth."""
+        try:
+            q.put_nowait(event)
+            return
+        except asyncio.QueueFull:
+            try:
+                q.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+
+        try:
+            q.put_nowait(event)
+        except asyncio.QueueFull:
+            logger.warning("Dropping stream event for slow listener on task %s", task_id)
     
     async def create_task(
         self,

--- a/testing/backend/unit/test_executor.py
+++ b/testing/backend/unit/test_executor.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from backend.secuscan.config import settings
 from backend.secuscan.database import get_db, init_db
-from backend.secuscan.executor import TaskExecutor
+from backend.secuscan.executor import STREAM_LISTENER_QUEUE_MAXSIZE, TaskExecutor
 from backend.secuscan.models import TaskStatus
 from backend.secuscan.plugins import get_plugin_manager, init_plugins
 
@@ -18,6 +18,45 @@ def _ensure_plugins_loaded():
     except RuntimeError:
         asyncio.run(init_plugins(settings.plugins_dir))
         return get_plugin_manager()
+
+
+@pytest.mark.asyncio
+async def test_stream_listener_queue_is_bounded_for_slow_consumers():
+    executor = TaskExecutor()
+    queue = executor.subscribe("task-1")
+
+    for index in range(STREAM_LISTENER_QUEUE_MAXSIZE + 5):
+        await executor._broadcast("task-1", "output", f"line-{index}")
+
+    assert queue.maxsize == STREAM_LISTENER_QUEUE_MAXSIZE
+    assert queue.qsize() == STREAM_LISTENER_QUEUE_MAXSIZE
+
+    events = []
+    while not queue.empty():
+        events.append(queue.get_nowait())
+
+    assert events[0]["data"] == "line-5"
+    assert events[-1]["data"] == f"line-{STREAM_LISTENER_QUEUE_MAXSIZE + 4}"
+
+
+@pytest.mark.asyncio
+async def test_stream_listener_keeps_latest_status_when_queue_is_full():
+    executor = TaskExecutor()
+    queue = executor.subscribe("task-1")
+
+    for index in range(STREAM_LISTENER_QUEUE_MAXSIZE):
+        await executor._broadcast("task-1", "output", f"line-{index}")
+    await executor._broadcast("task-1", "status", TaskStatus.COMPLETED.value)
+
+    events = []
+    while not queue.empty():
+        events.append(queue.get_nowait())
+
+    assert len(events) == STREAM_LISTENER_QUEUE_MAXSIZE
+    assert events[-1] == {
+        "type": "status",
+        "data": TaskStatus.COMPLETED.value,
+    }
 
 
 def test_parse_results_prefers_report_path_when_available(setup_test_environment, tmp_path):


### PR DESCRIPTION
## Description

Bounds per-client task stream listener queues so a slow or stalled SSE client cannot accumulate unbounded output/status events in memory.

The executor now creates listener queues with a fixed max size and uses non-blocking enqueue behavior. When a listener is full, the oldest buffered event is dropped so the latest output/status event can still be delivered. The SSE event format is unchanged. I am contributing this under GSSoC.

## Related Issues

Closes #412

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] `.venv/bin/python -m py_compile backend/secuscan/executor.py testing/backend/unit/test_executor.py`
- [x] `git diff --check`
- [x] Direct async runtime check for bounded queue behavior and latest status retention
- [ ] `.venv/bin/python -m pytest testing/backend/unit/test_executor.py -k stream_listener`

Local pytest note: this environment cannot run targeted pytest because the local `.venv` dependency install stopped before installing `pytest`; the install is blocked by native Cairo development packages required by `xhtml2pdf`. The upstream CI environment installs those native packages, so CI should run the backend tests normally.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
