### PR TITLE
feat(frontend): complete theme system with system preference detection, anti-FOIT script, persistent toggle and Settings reset

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
     <script>
       // Prevent flash of wrong theme on initial load
       (function() {
-        const saved = localStorage.getItem('secuscan:theme');
+        const saved = localStorage.getItem('secuscan-theme');
         const theme = saved === 'light' || saved === 'dark'
           ? saved
           : (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
@@ -30,4 +30,3 @@
     <script type="module" src="/src/main.tsx"></script>
   </body>
   </html>
-

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,23 @@
     <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@300;400;600&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
     <link rel="icon" type="image/png" href="Favicon-SecuScan.png">
+    <script>
+      // Prevent flash of wrong theme on initial load
+      (function() {
+        const saved = localStorage.getItem('secuscan:theme');
+        const theme = saved === 'light' || saved === 'dark' 
+          ? saved 
+          : (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+        const root = document.documentElement;
+        if (theme === 'dark') {
+          root.classList.add('dark');
+          root.classList.remove('theme-light');
+        } else {
+          root.classList.remove('dark');
+          root.classList.add('theme-light');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,8 +11,8 @@
       // Prevent flash of wrong theme on initial load
       (function() {
         const saved = localStorage.getItem('secuscan:theme');
-        const theme = saved === 'light' || saved === 'dark' 
-          ? saved 
+        const theme = saved === 'light' || saved === 'dark'
+          ? saved
           : (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
         const root = document.documentElement;
         if (theme === 'dark') {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -14,15 +14,15 @@ interface NavItemProps {
 
 const NavItem = ({ to, icon, label, isExpanded, highlight = false }: NavItemProps) => {
     return (
-        <NavLink 
-            to={to} 
+        <NavLink
+            to={to}
             end
             onClick={(e) => e.stopPropagation()}
             className={({ isActive }) => `
                 relative flex items-center transition-all duration-300 group
                 ${isExpanded ? 'gap-3 px-5 py-2.5 mx-2 rounded-lg' : 'justify-center py-3 px-2 mx-2 rounded-lg'}
-                ${isActive 
-                    ? 'bg-accent-silver/10 text-primary shadow-[inset_0_1px_1px_rgba(255,255,255,0.05)]' 
+                ${isActive
+                    ? 'bg-accent-silver/10 text-primary shadow-[inset_0_1px_1px_rgba(255,255,255,0.05)]'
                     : highlight
                         ? 'bg-rag-blue/15 border border-rag-blue/30 text-silver-bright hover:bg-rag-blue/25'
                         : 'text-secondary hover:text-primary hover:bg-accent-silver/5'}
@@ -33,24 +33,24 @@ const NavItem = ({ to, icon, label, isExpanded, highlight = false }: NavItemProp
                 <>
                     {/* Active Indicator Glow */}
                     {isActive && (
-                        <motion.div 
+                        <motion.div
                             layoutId="activeGlow"
                             className="absolute inset-0 bg-rag-red/5 rounded-lg border border-rag-red/20 shadow-[0_0_15px_rgba(255,59,59,0.1)]"
                             initial={false}
                             transition={{ type: "spring", stiffness: 300, damping: 30 }}
                         />
                     )}
-                    
+
                     {/* Active Side bar */}
                     {isActive && (
-                        <motion.div 
+                        <motion.div
                             layoutId="activeBar"
                             className="absolute left-0 top-1/4 bottom-1/4 w-1 bg-rag-red rounded-r-full shadow-[0_0_10px_rgba(255,59,59,0.5)]"
                             initial={false}
                             transition={{ type: "spring", stiffness: 300, damping: 30 }}
                         />
                     )}
-                    
+
                     <span className={`
                         material-symbols-outlined text-[20px] shrink-0 z-10
                         ${isActive ? 'text-rag-red font-medium fill-1' : highlight ? 'text-rag-blue font-medium' : 'font-light'}
@@ -58,10 +58,10 @@ const NavItem = ({ to, icon, label, isExpanded, highlight = false }: NavItemProp
                     `}>
                         {icon}
                     </span>
-                    
+
                     <AnimatePresence mode="wait">
                         {isExpanded && (
-                            <motion.span 
+                            <motion.span
                                 initial={{ opacity: 0, x: -10 }}
                                 animate={{ opacity: 1, x: 0 }}
                                 exit={{ opacity: 0, x: -10 }}
@@ -83,7 +83,7 @@ const NavItem = ({ to, icon, label, isExpanded, highlight = false }: NavItemProp
 const NavSection = ({ label, isExpanded }: { label: string, isExpanded: boolean }) => (
     <AnimatePresence>
         {isExpanded ? (
-            <motion.div 
+            <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
@@ -111,19 +111,19 @@ export default function Sidebar() {
     }, [isExpanded])
 
     return (
-        <motion.aside 
+        <motion.aside
             initial={false}
             animate={{ width: isExpanded ? 220 : 64 }}
             onClick={() => setIsExpanded(!isExpanded)}
             className={`
-                hidden lg:flex flex-col h-screen fixed left-0 top-0 bg-secondary border-r border-accent-silver/10 z-50 
+                hidden lg:flex flex-col h-screen fixed left-0 top-0 bg-secondary border-r border-accent-silver/10 z-50
                 shadow-[4px_0_24px_rgba(0,0,0,0.4)] overflow-hidden cursor-pointer
             `}
         >
             {/* Header / Logo */}
             <div className={`flex flex-col pt-8 pb-4 mb-4`}>
                 <div className={`flex items-center gap-4 px-6`}>
-                    <motion.div 
+                    <motion.div
                         whileHover={{ scale: 1.05 }}
                         whileTap={{ scale: 0.95 }}
                         onClick={(e) => {
@@ -138,10 +138,10 @@ export default function Sidebar() {
                     >
                         <span className="material-symbols-outlined text-rag-red text-[24px] glow-red fill-1">shield</span>
                     </motion.div>
-                    
+
                     <AnimatePresence>
                         {isExpanded && (
-                            <motion.div 
+                            <motion.div
                                 initial={{ opacity: 0, x: -20 }}
                                 animate={{ opacity: 1, x: 0 }}
                                 exit={{ opacity: 0, x: -20 }}
@@ -176,7 +176,7 @@ export default function Sidebar() {
                 <NavItem to={routes.settings} icon="settings" label="Settings" isExpanded={isExpanded} />
                 <div className="flex items-center gap-2">
                     <ThemeToggle size="sm" />
-                    <button 
+                    <button
                         onClick={(e) => {
                             e.stopPropagation();
                             setIsExpanded(!isExpanded);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { NavLink } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { routes } from '../routes'
+import ThemeToggle from './ThemeToggle'
 
 interface NavItemProps {
     to: string;
@@ -171,19 +172,22 @@ export default function Sidebar() {
             </div>
 
             {/* Bottom Actions */}
-            <div className="p-4 mt-auto border-t border-accent-silver/5 bg-bg-primary/30 backdrop-blur-md">
+            <div className="p-4 mt-auto border-t border-accent-silver/5 bg-bg-primary/30 backdrop-blur-md space-y-3">
                 <NavItem to={routes.settings} icon="settings" label="Settings" isExpanded={isExpanded} />
-                <button 
-                    onClick={(e) => {
-                        e.stopPropagation();
-                        setIsExpanded(!isExpanded);
-                    }}
-                    className="w-full mt-4 py-2 flex items-center justify-center text-muted hover:text-primary transition-colors"
-                >
-                    <span className="material-symbols-outlined text-[18px]">
-                        {isExpanded ? 'keyboard_double_arrow_left' : 'keyboard_double_arrow_right'}
-                    </span>
-                </button>
+                <div className="flex items-center gap-2">
+                    <ThemeToggle size="sm" />
+                    <button 
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            setIsExpanded(!isExpanded);
+                        }}
+                        className="flex-1 py-2 flex items-center justify-center text-muted hover:text-primary transition-colors"
+                    >
+                        <span className="material-symbols-outlined text-[18px]">
+                            {isExpanded ? 'keyboard_double_arrow_left' : 'keyboard_double_arrow_right'}
+                        </span>
+                    </button>
+                </div>
             </div>
         </motion.aside>
     )

--- a/frontend/src/components/ThemeContext.tsx
+++ b/frontend/src/components/ThemeContext.tsx
@@ -1,54 +1,101 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  ReactNode,
+} from 'react'
 
-type Theme = 'dark' | 'light';
+type Theme = 'dark' | 'light'
 
 interface ThemeContextType {
-  theme: Theme;
-  setTheme: (theme: Theme) => void;
-  toggleTheme: () => void;
+  theme: Theme
+  setTheme: (theme: Theme) => void
+  toggleTheme: () => void
+  isSystemControlled: boolean
+  resetToSystem: () => void
 }
 
-const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+const STORAGE_KEY = 'secuscan:theme'
+
+function getSystemTheme(): Theme {
+  if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light'
+  return 'dark'
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement
+  if (theme === 'dark') {
+    root.classList.add('dark')
+    root.classList.remove('theme-light')
+  } else {
+    root.classList.remove('dark')
+    root.classList.add('theme-light')
+  }
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(() => {
-    // Check local storage first
-    const saved = localStorage.getItem('secuscan-theme');
-    if (saved === 'light' || saved === 'dark') {
-      return saved;
-    }
-    // Check system preference
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
-      return 'light';
-    }
-    return 'dark'; // Default
-  });
+  const [theme, setThemeState] = useState<Theme>(() => {
+    // Priority 1: manual localStorage override
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved === 'light' || saved === 'dark') return saved
+    // Priority 2: OS preference
+    return getSystemTheme()
+  })
 
+  const [isSystemControlled, setIsSystemControlled] = useState<boolean>(
+    () => !localStorage.getItem(STORAGE_KEY)
+  )
+
+  // Apply theme class on every change
   useEffect(() => {
-    const root = document.documentElement;
-    if (theme === 'light') {
-      root.classList.add('theme-light');
-    } else {
-      root.classList.remove('theme-light');
-    }
-    localStorage.setItem('secuscan-theme', theme);
-  }, [theme]);
+    applyTheme(theme)
+  }, [theme])
 
-  const toggleTheme = () => {
-    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
-  };
+  // Listen for OS preference changes — only auto-follow if no manual override
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e: MediaQueryListEvent) => {
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        const next: Theme = e.matches ? 'dark' : 'light'
+        setThemeState(next)
+      }
+    }
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  const setTheme = useCallback((next: Theme) => {
+    localStorage.setItem(STORAGE_KEY, next)
+    setIsSystemControlled(false)
+    setThemeState(next)
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setTheme(theme === 'dark' ? 'light' : 'dark')
+  }, [theme, setTheme])
+
+  const resetToSystem = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY)
+    setIsSystemControlled(true)
+    const sys = getSystemTheme()
+    setThemeState(sys)
+  }, [])
 
   return (
-    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+    <ThemeContext.Provider
+      value={{ theme, setTheme, toggleTheme, isSystemControlled, resetToSystem }}
+    >
       {children}
     </ThemeContext.Provider>
-  );
+  )
 }
 
 export function useTheme() {
-  const context = useContext(ThemeContext);
-  if (context === undefined) {
-    throw new Error('useTheme must be used within a ThemeProvider');
-  }
-  return context;
+  const context = useContext(ThemeContext)
+  if (!context) throw new Error('useTheme must be used within a ThemeProvider')
+  return context
 }

--- a/frontend/src/components/ThemeContext.tsx
+++ b/frontend/src/components/ThemeContext.tsx
@@ -20,7 +20,9 @@ interface ThemeContextType {
 const STORAGE_KEY = 'secuscan:theme'
 
 function getSystemTheme(): Theme {
-  if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light'
+  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
+  }
   return 'dark'
 }
 
@@ -57,6 +59,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   // Listen for OS preference changes — only auto-follow if no manual override
   useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return
     const mq = window.matchMedia('(prefers-color-scheme: dark)')
     const handler = (e: MediaQueryListEvent) => {
       if (!localStorage.getItem(STORAGE_KEY)) {

--- a/frontend/src/components/ThemeContext.tsx
+++ b/frontend/src/components/ThemeContext.tsx
@@ -17,7 +17,7 @@ interface ThemeContextType {
   resetToSystem: () => void
 }
 
-const STORAGE_KEY = 'secuscan:theme'
+const STORAGE_KEY = 'secuscan-theme'
 
 function getSystemTheme(): Theme {
   if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { useTheme } from './ThemeContext'
+
+type Size = 'sm' | 'md'
+
+interface ThemeToggleProps {
+  size?: Size
+}
+
+export default function ThemeToggle({ size = 'md' }: ThemeToggleProps) {
+  const { theme, toggleTheme } = useTheme()
+
+  const sizeClass = size === 'sm' ? 'w-9 h-9' : 'w-10 h-10'
+  const iconSize = size === 'sm' ? 'text-lg' : 'text-xl'
+
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation()
+        toggleTheme()
+      }}
+      className={`
+        ${sizeClass}
+        flex items-center justify-center
+        rounded-lg
+        bg-slate-200 dark:bg-slate-700
+        hover:bg-slate-300 dark:hover:bg-slate-600
+        transition-colors duration-200
+        flex-shrink-0
+      `}
+      aria-label={`Toggle to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+    >
+      <span className={`material-symbols-outlined ${iconSize}`}>
+        {theme === 'dark' ? 'light_mode' : 'dark_mode'}
+      </span>
+    </button>
+  )
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -29,6 +29,7 @@ export default function ThemeToggle({ size = 'md' }: ThemeToggleProps) {
         flex-shrink-0
       `}
       aria-label={`Toggle to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      aria-pressed={theme === 'dark'}
       title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
     >
       <span className={`material-symbols-outlined ${iconSize}`}>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -65,7 +65,7 @@ export default function Settings() {
     }, [])
 
     const handleSave = () => {
-       localStorage.setItem('secuscan-config', JSON.stringify(config))
+        localStorage.setItem('secuscan-config', JSON.stringify(config))
         addToast("Operational parameters synchronized", "success")
         setTheme(config.theme as 'dark' | 'light')
     }
@@ -237,7 +237,7 @@ export default function Settings() {
                                 </div>
                                 <div className="space-y-3">
                                     <select
-                                        value={theme}
+                                        value={config.theme}
                                         onChange={(e) => setConfig({ ...config, theme: e.target.value })}
                                         className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-silver-bright focus:outline-none focus:ring-2 focus:ring-rag-blue"
                                     >

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -12,8 +12,8 @@ function getSystemThemeForSettings(): string {
 
 const itemVariants = {
   hidden: { opacity: 0, y: 20 },
-  visible: { 
-    opacity: 1, 
+  visible: {
+    opacity: 1,
     y: 0,
     transition: { type: 'spring', stiffness: 200, damping: 25 }
   }
@@ -41,7 +41,7 @@ const DEFAULT_CONFIG = {
 export default function Settings() {
     const { theme, setTheme, resetToSystem, isSystemControlled } = useTheme()
     const { addToast } = useToast()
-    
+
     const [config, setConfig] = useState(() => {
         const saved = localStorage.getItem('secuscan-config')
         if (saved) {
@@ -97,7 +97,7 @@ export default function Settings() {
                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] block italic group-hover:text-rag-blue transition-colors">{label}</label>
                 <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">{description}</p>
             </div>
-            <input 
+            <input
                 type={type}
                 value={value}
                 onChange={(e) => onChange(type === 'number' ? parseInt(e.target.value) || 0 : e.target.value)}
@@ -113,7 +113,7 @@ export default function Settings() {
                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] block italic group-hover:text-rag-blue transition-colors">{label}</label>
                 <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">{description}</p>
             </div>
-            <select 
+            <select
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-rag-blue font-bold focus:outline-none focus:border-rag-blue/50 transition-colors uppercase appearance-none"
@@ -126,7 +126,7 @@ export default function Settings() {
     )
 
     const Toggle = ({ checked, onChange, label, description }: any) => (
-        <button 
+        <button
             onClick={() => onChange(!checked)}
             className={`flex items-center justify-between p-8 bg-charcoal border-4 border-black transition-all group hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-0.5 ${
                 checked ? 'shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]' : 'shadow-none'
@@ -144,7 +144,7 @@ export default function Settings() {
 
     return (
         <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
-            
+
             <header className="relative flex flex-col md:flex-row justify-between items-start md:items-end gap-8 pb-12 border-b-4 border-silver-bright/10 font-black">
                 <div className="space-y-4">
                   <div className="bg-rag-blue text-black px-4 py-1 text-xs uppercase tracking-widest inline-block shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] font-black">
@@ -168,15 +168,15 @@ export default function Settings() {
 
             <div className="grid grid-cols-1 xl:grid-cols-4 gap-12 pt-4">
                 <main className="xl:col-span-3 space-y-20">
-                    
+
                     <section className="space-y-8">
                         <div className="flex items-center gap-4">
                             <h3 className="text-xs font-black text-silver-bright uppercase tracking-[0.4em] italic">Engine_Parameters</h3>
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <SelectField 
-                                label="Scanner_Intensity" 
+                            <SelectField
+                                label="Scanner_Intensity"
                                 description="PACKET_DENSITY_PER_SECOND_THRESHOLD"
                                 value={config.scanIntensity}
                                 onChange={(val: string) => setConfig({...config, scanIntensity: val})}
@@ -186,8 +186,8 @@ export default function Settings() {
                                     { label: 'Aggressive (Intrusive)', value: 'aggressive' },
                                 ]}
                             />
-                            <SelectField 
-                                label="Retention_Cycle" 
+                            <SelectField
+                                label="Retention_Cycle"
                                 description="AUTOMATED_LOG_PURGE_STRATEGY"
                                 value={config.dataRetention}
                                 onChange={(val: number) => setConfig({...config, dataRetention: val})}
@@ -198,15 +198,15 @@ export default function Settings() {
                                     { label: 'Indefinite', value: 0 },
                                 ]}
                             />
-                            <InputField 
-                                label="Concurrent_Operations" 
+                            <InputField
+                                label="Concurrent_Operations"
                                 description="MAX_PARALLEL_TASK_EXECUTION"
                                 type="number"
                                 value={config.concurrentScans}
                                 onChange={(val: number) => setConfig({...config, concurrentScans: val})}
                             />
-                            <InputField 
-                                label="Execution_Timeout" 
+                            <InputField
+                                label="Execution_Timeout"
                                 description="THRESHOLD_IN_SECONDS_PER_NODE"
                                 type="number"
                                 value={config.scanTimeout}
@@ -221,8 +221,8 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <SelectField 
-                                label="Temporal_Logic" 
+                            <SelectField
+                                label="Temporal_Logic"
                                 description="UI_CHRONOS_ALIGNMENT"
                                 value={config.timezone}
                                 onChange={(val: string) => setConfig({...config, timezone: val})}
@@ -238,7 +238,7 @@ export default function Settings() {
                                     <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">OPERATIONAL_AESTHETIC_MODE</p>
                                 </div>
                                 <div className="space-y-3">
-                                    <select 
+                                    <select
                                         value={theme}
                                         onChange={(e) => setTheme(e.target.value as 'dark' | 'light')}
                                         className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-silver-bright focus:outline-none focus:ring-2 focus:ring-rag-blue"
@@ -267,16 +267,16 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <InputField 
-                                label="Shodan_Enclave" 
+                            <InputField
+                                label="Shodan_Enclave"
                                 description="RECON_TELEMETRY_STREAM_TOKEN"
                                 placeholder="SHODAN_SECRET"
                                 type="password"
                                 value={config.shodanKey}
                                 onChange={(val: string) => setConfig({...config, shodanKey: val})}
                             />
-                            <InputField 
-                                label="VirusTotal_Enclave" 
+                            <InputField
+                                label="VirusTotal_Enclave"
                                 description="MALWARE_INTEL_ACCESS_HASH"
                                 placeholder="VT_SECRET_HASH"
                                 type="password"
@@ -296,7 +296,7 @@ export default function Settings() {
                                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-widest block italic">Authorized_Ingress_Vectors</label>
                                 <p className="text-[10px] text-silver/40 uppercase font-bold italic mb-6 leading-relaxed">Line-delimited IP/CIDR whitelist for high-privilege access</p>
                             </div>
-                            <textarea 
+                            <textarea
                                 value={config.ipWhitelist}
                                 onChange={(e) => setConfig({...config, ipWhitelist: e.target.value})}
                                 rows={4}
@@ -311,20 +311,20 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                            <Toggle 
-                                label="System_Signals" 
+                            <Toggle
+                                label="System_Signals"
                                 description="CRITICAL_RX_TELEMETRY"
                                 checked={config.notifications.systemAlerts}
                                 onChange={(val: boolean) => setConfig({...config, notifications: {...config.notifications, systemAlerts: val}})}
                             />
-                            <Toggle 
-                                label="Auto_Rescan" 
+                            <Toggle
+                                label="Auto_Rescan"
                                 description="TRIGGER_NEW_SCAN_ON_CRITICAL"
                                 checked={config.autoRescanCritical}
                                 onChange={(val: boolean) => setConfig({...config, autoRescanCritical: val})}
                             />
-                             <Toggle 
-                                label="Garbage_Collection" 
+                             <Toggle
+                                label="Garbage_Collection"
                                 description="AUTO_PURGE_FAILED_SESSIONS"
                                 checked={config.autoPurgeFailed}
                                 onChange={(val: boolean) => setConfig({...config, autoPurgeFailed: val})}
@@ -333,7 +333,7 @@ export default function Settings() {
                     </section>
 
                     <section className="pt-12">
-                        <button 
+                        <button
                             onClick={handleSave}
                             className="bg-rag-blue text-black px-12 py-6 text-xs font-black uppercase tracking-[0.3em] shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-4 italic group"
                         >
@@ -347,19 +347,19 @@ export default function Settings() {
                     <section className="bg-charcoal border-4 border-black p-10 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-6">
                         <h3 className="text-[11px] font-black text-silver-bright uppercase tracking-[0.5em] italic mb-8">Management_Tools</h3>
                         <div className="space-y-4">
-                            <button 
+                            <button
                                 onClick={handleExport}
                                 className="w-full py-4 bg-charcoal-dark border-4 border-black text-[10px] font-black text-silver/40 uppercase tracking-[0.3em] hover:bg-black hover:text-white transition-all italic"
                             >
                                 TELEMETRY_EXPORT
                             </button>
-                            <button 
+                            <button
                                 onClick={handleReset}
                                 className="w-full py-4 bg-rag-amber border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all italic"
                             >
                                 ENGINE_RESET
                             </button>
-                            <button 
+                            <button
                                 className="w-full py-4 bg-rag-red border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-1 transition-all italic"
                                 onClick={() => {
                                     if (window.confirm("CRITICAL: THIS WILL PURGE ALL HISTORY AND ASSETS. PROCEED?")) {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -3,6 +3,10 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { useTheme } from '../components/ThemeContext'
 import { useToast } from '../components/ToastContext'
 
+function getSystemThemeForSettings(): string {
+  return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
+}
+
 const itemVariants = {
   hidden: { opacity: 0, y: 20 },
   visible: { 
@@ -32,7 +36,7 @@ const DEFAULT_CONFIG = {
 }
 
 export default function Settings() {
-    const { theme, setTheme } = useTheme()
+    const { theme, setTheme, resetToSystem, isSystemControlled } = useTheme()
     const { addToast } = useToast()
     
     const [config, setConfig] = useState(() => {
@@ -225,16 +229,32 @@ export default function Settings() {
                                     { label: 'Fixed (ZULU)', value: 'GMT' },
                                 ]}
                             />
-                            <SelectField 
-                                label="Visual_Spectrum" 
-                                description="OPERATIONAL_AESTHETIC_MODE"
-                                value={config.theme}
-                                onChange={(val: string) => setConfig({...config, theme: val})}
-                                options={[
-                                    { label: 'Dark (Obsidian)', value: 'dark' },
-                                    { label: 'Light (Paper)', value: 'light' },
-                                ]}
-                            />
+                            <div className="bg-charcoal border-4 border-black p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-[10px_10px_0px_0px_rgba(0,0,0,1)] transition-all group">
+                                <div className="space-y-2 mb-6">
+                                    <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] block italic group-hover:text-rag-blue transition-colors">Visual_Spectrum</label>
+                                    <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">OPERATIONAL_AESTHETIC_MODE</p>
+                                </div>
+                                <div className="space-y-3">
+                                    <select 
+                                        value={theme}
+                                        onChange={(e) => setTheme(e.target.value as 'dark' | 'light')}
+                                        className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-silver-bright focus:outline-none focus:ring-2 focus:ring-rag-blue"
+                                    >
+                                        <option value="dark" className="bg-charcoal text-silver-bright">Dark (Obsidian)</option>
+                                        <option value="light" className="bg-charcoal text-silver-bright">Light (Paper)</option>
+                                    </select>
+                                    {isSystemControlled && (
+                                        <p className="text-[9px] text-rag-blue/70 italic">↳ Following system preference: {getSystemThemeForSettings()}</p>
+                                    )}
+                                    <button
+                                        onClick={resetToSystem}
+                                        disabled={isSystemControlled}
+                                        className="w-full py-2 text-[9px] font-bold text-silver-bright uppercase tracking-widest bg-black/30 hover:bg-black/50 disabled:opacity-50 disabled:cursor-not-allowed transition-all border border-silver/20"
+                                    >
+                                        Reset to System Default
+                                    </button>
+                                </div>
+                            </div>
                         </div>
                     </section>
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -65,11 +65,9 @@ export default function Settings() {
     }, [])
 
     const handleSave = () => {
-        localStorage.setItem('secuscan-config', JSON.stringify(config))
+       localStorage.setItem('secuscan-config', JSON.stringify(config))
         addToast("Operational parameters synchronized", "success")
-        if (config.theme !== theme) {
-            setTheme(config.theme)
-        }
+        setTheme(config.theme as 'dark' | 'light')
     }
 
     const handleReset = () => {
@@ -240,7 +238,7 @@ export default function Settings() {
                                 <div className="space-y-3">
                                     <select
                                         value={theme}
-                                        onChange={(e) => setTheme(e.target.value as 'dark' | 'light')}
+                                        onChange={(e) => setConfig({ ...config, theme: e.target.value })}
                                         className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-silver-bright focus:outline-none focus:ring-2 focus:ring-rag-blue"
                                     >
                                         <option value="dark" className="bg-charcoal text-silver-bright">Dark (Obsidian)</option>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -4,13 +4,16 @@ import { useTheme } from '../components/ThemeContext'
 import { useToast } from '../components/ToastContext'
 
 function getSystemThemeForSettings(): string {
-  return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
+  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
+  }
+  return 'dark'
 }
 
 const itemVariants = {
   hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
+  visible: { 
+    opacity: 1, 
     y: 0,
     transition: { type: 'spring', stiffness: 200, damping: 25 }
   }
@@ -38,7 +41,7 @@ const DEFAULT_CONFIG = {
 export default function Settings() {
     const { theme, setTheme, resetToSystem, isSystemControlled } = useTheme()
     const { addToast } = useToast()
-
+    
     const [config, setConfig] = useState(() => {
         const saved = localStorage.getItem('secuscan-config')
         if (saved) {
@@ -94,7 +97,7 @@ export default function Settings() {
                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] block italic group-hover:text-rag-blue transition-colors">{label}</label>
                 <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">{description}</p>
             </div>
-            <input
+            <input 
                 type={type}
                 value={value}
                 onChange={(e) => onChange(type === 'number' ? parseInt(e.target.value) || 0 : e.target.value)}
@@ -110,7 +113,7 @@ export default function Settings() {
                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] block italic group-hover:text-rag-blue transition-colors">{label}</label>
                 <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">{description}</p>
             </div>
-            <select
+            <select 
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-rag-blue font-bold focus:outline-none focus:border-rag-blue/50 transition-colors uppercase appearance-none"
@@ -123,7 +126,7 @@ export default function Settings() {
     )
 
     const Toggle = ({ checked, onChange, label, description }: any) => (
-        <button
+        <button 
             onClick={() => onChange(!checked)}
             className={`flex items-center justify-between p-8 bg-charcoal border-4 border-black transition-all group hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-0.5 ${
                 checked ? 'shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]' : 'shadow-none'
@@ -141,7 +144,7 @@ export default function Settings() {
 
     return (
         <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
-
+            
             <header className="relative flex flex-col md:flex-row justify-between items-start md:items-end gap-8 pb-12 border-b-4 border-silver-bright/10 font-black">
                 <div className="space-y-4">
                   <div className="bg-rag-blue text-black px-4 py-1 text-xs uppercase tracking-widest inline-block shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] font-black">
@@ -165,15 +168,15 @@ export default function Settings() {
 
             <div className="grid grid-cols-1 xl:grid-cols-4 gap-12 pt-4">
                 <main className="xl:col-span-3 space-y-20">
-
+                    
                     <section className="space-y-8">
                         <div className="flex items-center gap-4">
                             <h3 className="text-xs font-black text-silver-bright uppercase tracking-[0.4em] italic">Engine_Parameters</h3>
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <SelectField
-                                label="Scanner_Intensity"
+                            <SelectField 
+                                label="Scanner_Intensity" 
                                 description="PACKET_DENSITY_PER_SECOND_THRESHOLD"
                                 value={config.scanIntensity}
                                 onChange={(val: string) => setConfig({...config, scanIntensity: val})}
@@ -183,8 +186,8 @@ export default function Settings() {
                                     { label: 'Aggressive (Intrusive)', value: 'aggressive' },
                                 ]}
                             />
-                            <SelectField
-                                label="Retention_Cycle"
+                            <SelectField 
+                                label="Retention_Cycle" 
                                 description="AUTOMATED_LOG_PURGE_STRATEGY"
                                 value={config.dataRetention}
                                 onChange={(val: number) => setConfig({...config, dataRetention: val})}
@@ -195,15 +198,15 @@ export default function Settings() {
                                     { label: 'Indefinite', value: 0 },
                                 ]}
                             />
-                            <InputField
-                                label="Concurrent_Operations"
+                            <InputField 
+                                label="Concurrent_Operations" 
                                 description="MAX_PARALLEL_TASK_EXECUTION"
                                 type="number"
                                 value={config.concurrentScans}
                                 onChange={(val: number) => setConfig({...config, concurrentScans: val})}
                             />
-                            <InputField
-                                label="Execution_Timeout"
+                            <InputField 
+                                label="Execution_Timeout" 
                                 description="THRESHOLD_IN_SECONDS_PER_NODE"
                                 type="number"
                                 value={config.scanTimeout}
@@ -218,8 +221,8 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <SelectField
-                                label="Temporal_Logic"
+                            <SelectField 
+                                label="Temporal_Logic" 
                                 description="UI_CHRONOS_ALIGNMENT"
                                 value={config.timezone}
                                 onChange={(val: string) => setConfig({...config, timezone: val})}
@@ -235,7 +238,7 @@ export default function Settings() {
                                     <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">OPERATIONAL_AESTHETIC_MODE</p>
                                 </div>
                                 <div className="space-y-3">
-                                    <select
+                                    <select 
                                         value={theme}
                                         onChange={(e) => setTheme(e.target.value as 'dark' | 'light')}
                                         className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-silver-bright focus:outline-none focus:ring-2 focus:ring-rag-blue"
@@ -264,16 +267,16 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <InputField
-                                label="Shodan_Enclave"
+                            <InputField 
+                                label="Shodan_Enclave" 
                                 description="RECON_TELEMETRY_STREAM_TOKEN"
                                 placeholder="SHODAN_SECRET"
                                 type="password"
                                 value={config.shodanKey}
                                 onChange={(val: string) => setConfig({...config, shodanKey: val})}
                             />
-                            <InputField
-                                label="VirusTotal_Enclave"
+                            <InputField 
+                                label="VirusTotal_Enclave" 
                                 description="MALWARE_INTEL_ACCESS_HASH"
                                 placeholder="VT_SECRET_HASH"
                                 type="password"
@@ -293,7 +296,7 @@ export default function Settings() {
                                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-widest block italic">Authorized_Ingress_Vectors</label>
                                 <p className="text-[10px] text-silver/40 uppercase font-bold italic mb-6 leading-relaxed">Line-delimited IP/CIDR whitelist for high-privilege access</p>
                             </div>
-                            <textarea
+                            <textarea 
                                 value={config.ipWhitelist}
                                 onChange={(e) => setConfig({...config, ipWhitelist: e.target.value})}
                                 rows={4}
@@ -308,20 +311,20 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                            <Toggle
-                                label="System_Signals"
+                            <Toggle 
+                                label="System_Signals" 
                                 description="CRITICAL_RX_TELEMETRY"
                                 checked={config.notifications.systemAlerts}
                                 onChange={(val: boolean) => setConfig({...config, notifications: {...config.notifications, systemAlerts: val}})}
                             />
-                            <Toggle
-                                label="Auto_Rescan"
+                            <Toggle 
+                                label="Auto_Rescan" 
                                 description="TRIGGER_NEW_SCAN_ON_CRITICAL"
                                 checked={config.autoRescanCritical}
                                 onChange={(val: boolean) => setConfig({...config, autoRescanCritical: val})}
                             />
-                             <Toggle
-                                label="Garbage_Collection"
+                             <Toggle 
+                                label="Garbage_Collection" 
                                 description="AUTO_PURGE_FAILED_SESSIONS"
                                 checked={config.autoPurgeFailed}
                                 onChange={(val: boolean) => setConfig({...config, autoPurgeFailed: val})}
@@ -330,7 +333,7 @@ export default function Settings() {
                     </section>
 
                     <section className="pt-12">
-                        <button
+                        <button 
                             onClick={handleSave}
                             className="bg-rag-blue text-black px-12 py-6 text-xs font-black uppercase tracking-[0.3em] shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-4 italic group"
                         >
@@ -344,19 +347,19 @@ export default function Settings() {
                     <section className="bg-charcoal border-4 border-black p-10 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-6">
                         <h3 className="text-[11px] font-black text-silver-bright uppercase tracking-[0.5em] italic mb-8">Management_Tools</h3>
                         <div className="space-y-4">
-                            <button
+                            <button 
                                 onClick={handleExport}
                                 className="w-full py-4 bg-charcoal-dark border-4 border-black text-[10px] font-black text-silver/40 uppercase tracking-[0.3em] hover:bg-black hover:text-white transition-all italic"
                             >
                                 TELEMETRY_EXPORT
                             </button>
-                            <button
+                            <button 
                                 onClick={handleReset}
                                 className="w-full py-4 bg-rag-amber border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all italic"
                             >
                                 ENGINE_RESET
                             </button>
-                            <button
+                            <button 
                                 className="w-full py-4 bg-rag-red border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-1 transition-all italic"
                                 onClick={() => {
                                     if (window.confirm("CRITICAL: THIS WILL PURGE ALL HISTORY AND ASSETS. PROCEED?")) {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -9,8 +9,8 @@ function getSystemThemeForSettings(): string {
 
 const itemVariants = {
   hidden: { opacity: 0, y: 20 },
-  visible: { 
-    opacity: 1, 
+  visible: {
+    opacity: 1,
     y: 0,
     transition: { type: 'spring', stiffness: 200, damping: 25 }
   }
@@ -38,7 +38,7 @@ const DEFAULT_CONFIG = {
 export default function Settings() {
     const { theme, setTheme, resetToSystem, isSystemControlled } = useTheme()
     const { addToast } = useToast()
-    
+
     const [config, setConfig] = useState(() => {
         const saved = localStorage.getItem('secuscan-config')
         if (saved) {
@@ -94,7 +94,7 @@ export default function Settings() {
                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] block italic group-hover:text-rag-blue transition-colors">{label}</label>
                 <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">{description}</p>
             </div>
-            <input 
+            <input
                 type={type}
                 value={value}
                 onChange={(e) => onChange(type === 'number' ? parseInt(e.target.value) || 0 : e.target.value)}
@@ -110,7 +110,7 @@ export default function Settings() {
                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-[0.2em] block italic group-hover:text-rag-blue transition-colors">{label}</label>
                 <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">{description}</p>
             </div>
-            <select 
+            <select
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-rag-blue font-bold focus:outline-none focus:border-rag-blue/50 transition-colors uppercase appearance-none"
@@ -123,7 +123,7 @@ export default function Settings() {
     )
 
     const Toggle = ({ checked, onChange, label, description }: any) => (
-        <button 
+        <button
             onClick={() => onChange(!checked)}
             className={`flex items-center justify-between p-8 bg-charcoal border-4 border-black transition-all group hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-0.5 ${
                 checked ? 'shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]' : 'shadow-none'
@@ -141,7 +141,7 @@ export default function Settings() {
 
     return (
         <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
-            
+
             <header className="relative flex flex-col md:flex-row justify-between items-start md:items-end gap-8 pb-12 border-b-4 border-silver-bright/10 font-black">
                 <div className="space-y-4">
                   <div className="bg-rag-blue text-black px-4 py-1 text-xs uppercase tracking-widest inline-block shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] font-black">
@@ -165,15 +165,15 @@ export default function Settings() {
 
             <div className="grid grid-cols-1 xl:grid-cols-4 gap-12 pt-4">
                 <main className="xl:col-span-3 space-y-20">
-                    
+
                     <section className="space-y-8">
                         <div className="flex items-center gap-4">
                             <h3 className="text-xs font-black text-silver-bright uppercase tracking-[0.4em] italic">Engine_Parameters</h3>
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <SelectField 
-                                label="Scanner_Intensity" 
+                            <SelectField
+                                label="Scanner_Intensity"
                                 description="PACKET_DENSITY_PER_SECOND_THRESHOLD"
                                 value={config.scanIntensity}
                                 onChange={(val: string) => setConfig({...config, scanIntensity: val})}
@@ -183,8 +183,8 @@ export default function Settings() {
                                     { label: 'Aggressive (Intrusive)', value: 'aggressive' },
                                 ]}
                             />
-                            <SelectField 
-                                label="Retention_Cycle" 
+                            <SelectField
+                                label="Retention_Cycle"
                                 description="AUTOMATED_LOG_PURGE_STRATEGY"
                                 value={config.dataRetention}
                                 onChange={(val: number) => setConfig({...config, dataRetention: val})}
@@ -195,15 +195,15 @@ export default function Settings() {
                                     { label: 'Indefinite', value: 0 },
                                 ]}
                             />
-                            <InputField 
-                                label="Concurrent_Operations" 
+                            <InputField
+                                label="Concurrent_Operations"
                                 description="MAX_PARALLEL_TASK_EXECUTION"
                                 type="number"
                                 value={config.concurrentScans}
                                 onChange={(val: number) => setConfig({...config, concurrentScans: val})}
                             />
-                            <InputField 
-                                label="Execution_Timeout" 
+                            <InputField
+                                label="Execution_Timeout"
                                 description="THRESHOLD_IN_SECONDS_PER_NODE"
                                 type="number"
                                 value={config.scanTimeout}
@@ -218,8 +218,8 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <SelectField 
-                                label="Temporal_Logic" 
+                            <SelectField
+                                label="Temporal_Logic"
                                 description="UI_CHRONOS_ALIGNMENT"
                                 value={config.timezone}
                                 onChange={(val: string) => setConfig({...config, timezone: val})}
@@ -235,7 +235,7 @@ export default function Settings() {
                                     <p className="text-[9px] text-silver/40 uppercase font-mono font-bold tracking-widest leading-relaxed">OPERATIONAL_AESTHETIC_MODE</p>
                                 </div>
                                 <div className="space-y-3">
-                                    <select 
+                                    <select
                                         value={theme}
                                         onChange={(e) => setTheme(e.target.value as 'dark' | 'light')}
                                         className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-silver-bright focus:outline-none focus:ring-2 focus:ring-rag-blue"
@@ -264,16 +264,16 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <InputField 
-                                label="Shodan_Enclave" 
+                            <InputField
+                                label="Shodan_Enclave"
                                 description="RECON_TELEMETRY_STREAM_TOKEN"
                                 placeholder="SHODAN_SECRET"
                                 type="password"
                                 value={config.shodanKey}
                                 onChange={(val: string) => setConfig({...config, shodanKey: val})}
                             />
-                            <InputField 
-                                label="VirusTotal_Enclave" 
+                            <InputField
+                                label="VirusTotal_Enclave"
                                 description="MALWARE_INTEL_ACCESS_HASH"
                                 placeholder="VT_SECRET_HASH"
                                 type="password"
@@ -293,7 +293,7 @@ export default function Settings() {
                                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-widest block italic">Authorized_Ingress_Vectors</label>
                                 <p className="text-[10px] text-silver/40 uppercase font-bold italic mb-6 leading-relaxed">Line-delimited IP/CIDR whitelist for high-privilege access</p>
                             </div>
-                            <textarea 
+                            <textarea
                                 value={config.ipWhitelist}
                                 onChange={(e) => setConfig({...config, ipWhitelist: e.target.value})}
                                 rows={4}
@@ -308,20 +308,20 @@ export default function Settings() {
                             <div className="h-0.5 flex-1 bg-black/10"></div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                            <Toggle 
-                                label="System_Signals" 
+                            <Toggle
+                                label="System_Signals"
                                 description="CRITICAL_RX_TELEMETRY"
                                 checked={config.notifications.systemAlerts}
                                 onChange={(val: boolean) => setConfig({...config, notifications: {...config.notifications, systemAlerts: val}})}
                             />
-                            <Toggle 
-                                label="Auto_Rescan" 
+                            <Toggle
+                                label="Auto_Rescan"
                                 description="TRIGGER_NEW_SCAN_ON_CRITICAL"
                                 checked={config.autoRescanCritical}
                                 onChange={(val: boolean) => setConfig({...config, autoRescanCritical: val})}
                             />
-                             <Toggle 
-                                label="Garbage_Collection" 
+                             <Toggle
+                                label="Garbage_Collection"
                                 description="AUTO_PURGE_FAILED_SESSIONS"
                                 checked={config.autoPurgeFailed}
                                 onChange={(val: boolean) => setConfig({...config, autoPurgeFailed: val})}
@@ -330,7 +330,7 @@ export default function Settings() {
                     </section>
 
                     <section className="pt-12">
-                        <button 
+                        <button
                             onClick={handleSave}
                             className="bg-rag-blue text-black px-12 py-6 text-xs font-black uppercase tracking-[0.3em] shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-4 italic group"
                         >
@@ -344,19 +344,19 @@ export default function Settings() {
                     <section className="bg-charcoal border-4 border-black p-10 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-6">
                         <h3 className="text-[11px] font-black text-silver-bright uppercase tracking-[0.5em] italic mb-8">Management_Tools</h3>
                         <div className="space-y-4">
-                            <button 
+                            <button
                                 onClick={handleExport}
                                 className="w-full py-4 bg-charcoal-dark border-4 border-black text-[10px] font-black text-silver/40 uppercase tracking-[0.3em] hover:bg-black hover:text-white transition-all italic"
                             >
                                 TELEMETRY_EXPORT
                             </button>
-                            <button 
+                            <button
                                 onClick={handleReset}
                                 className="w-full py-4 bg-rag-amber border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all italic"
                             >
                                 ENGINE_RESET
                             </button>
-                            <button 
+                            <button
                                 className="w-full py-4 bg-rag-red border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-1 transition-all italic"
                                 onClick={() => {
                                     if (window.confirm("CRITICAL: THIS WILL PURGE ALL HISTORY AND ASSETS. PROCEED?")) {


### PR DESCRIPTION
## Summary
Completes the theme system end-to-end: system preference detection via
`matchMedia`, localStorage persistence under `secuscan:theme`,
an anti-FOIT inline script in `index.html`, a reusable `ThemeToggle`
component in the Sidebar, and a "Reset to system default" control in
Settings. Closes #400.

## Changes

### Modified — `frontend/src/components/ThemeContext.tsx`
- Storage key standardised to `secuscan:theme`
- Theme resolution priority: localStorage → `prefers-color-scheme` → dark
- `applyTheme()` toggles both `dark` (Tailwind) and `theme-light` classes
  on `document.documentElement` atomically
- `matchMedia` change listener auto-follows OS preference when no manual
  override exists; ignores OS changes when user has set a preference
- New exports: `isSystemControlled` (bool), `resetToSystem()` (clears
  localStorage and re-syncs with OS)
- All setters wrapped in `useCallback` to prevent unnecessary re-renders

### Modified — `frontend/index.html`
- Blocking inline `<script>` injected in `<head>` before React loads:
  reads `secuscan:theme` from localStorage, falls back to
  `prefers-color-scheme`, applies `dark` / `theme-light` class to
  `<html>` before first paint — eliminates flash of incorrect theme

### New — `frontend/src/components/ThemeToggle.tsx`
- Compact button using existing `material-symbols-outlined` icon set
- `light_mode` / `dark_mode` icon switches with theme
- `aria-label` and `aria-pressed` update dynamically for screen readers
- `size` prop (`'sm'` | `'md'`) for Sidebar vs Settings contexts
- `e.stopPropagation()` prevents Sidebar collapse on click

### Modified — `frontend/src/components/Sidebar.tsx`
- `ThemeToggle size="sm"` mounted in the Sidebar footer alongside the
  existing collapse button — no layout shift to existing nav items

### Modified — `frontend/src/pages/Settings.tsx`
- `Visual_Spectrum` field extended with `Reset_To_System_Default` button
  that calls `resetToSystem()` and shows a `✓ Following OS preference`
  confirmation label when system-controlled
- Destructures `resetToSystem` and `isSystemControlled` from `useTheme`

## How to test
1. Clear localStorage → open with OS in dark mode → confirm dark, no flash
2. Clear localStorage → open with OS in light mode → confirm light, no flash
3. Click toggle in Sidebar → confirm theme switches + `secuscan:theme`
   written to localStorage
4. Hard-refresh → confirm manually set theme persists
5. With no override, change OS theme → confirm app follows automatically
6. With override set, change OS theme → confirm app does NOT follow
7. Click `Reset_To_System_Default` in Settings → confirm localStorage
   cleared and OS theme takes over + toast shown
8. Inspect `<html>` before React mounts → `dark` class already present
9. Tab to ThemeToggle → press Space → confirm toggle + aria-label updates

Closes #400