### PR TITLE
fix(backend): resolve safe-mode guardrail bypass via targets containing  '/' #267

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -29,7 +29,6 @@ def parse_json_fields(rows: List[Dict], fields: List[str]) -> List[Dict]:
         parsed.append(item)
     return parsed
 
-
 def _parse_workflow_steps(raw_steps: Any) -> List[Dict[str, Any]]:
     if isinstance(raw_steps, list):
         return raw_steps
@@ -40,7 +39,6 @@ def _parse_workflow_steps(raw_steps: Any) -> List[Dict[str, Any]]:
     except (TypeError, json.JSONDecodeError):
         return []
     return parsed if isinstance(parsed, list) else []
-
 
 def _serialize_workflow(row: Dict[str, Any], queued_task_ids: Optional[List[str]] = None) -> Dict[str, Any]:
     """Return the workflow shape consumed by the frontend."""
@@ -55,22 +53,34 @@ def _serialize_workflow(row: Dict[str, Any], queued_task_ids: Optional[List[str]
         "queued_task_ids": queued_task_ids or [],
     }
 
-
 def is_filesystem_target(target: str) -> bool:
-    """Best-effort detection for path-based targets that should bypass host validation."""
-    if target.startswith(("/", "./", "../", "~")):
+    """
+    Return True only for genuine local filesystem paths.
+
+    Explicit roots accepted:
+      - Unix absolute paths:   /home/user/repo
+      - Unix relative paths:   ./src, ../lib
+      - Home-relative paths:   ~/projects
+      - Windows paths:         C:\\Users\\repo, D:/work
+
+    Anything else — including CIDR notation (8.8.8.8/32, 192.168.1.0/24),
+    bare hostnames, URLs, and domain paths — returns False and will be
+    subject to the full validate_target() check including safe-mode enforcement.
+
+    CIDR notation is handled correctly by ipaddress.ip_network() inside
+    validate_target() and does NOT need special-casing here.
+    """
+    # Unix absolute, relative, and home-relative paths
+    if target.startswith(("/", "./", "../", "~/")):
         return True
+    # Windows paths: C:\ or C:/
     if re.match(r"^[A-Za-z]:[\\/]", target):
         return True
-    if "/" in target and not target.startswith(("http://", "https://")):
-        return True
     return False
-
 
 def _slugify_filename_part(value: str, fallback: str) -> str:
     cleaned = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
     return cleaned or fallback
-
 
 def build_report_filename(task: Dict[str, Any], extension: str) -> str:
     tool = _slugify_filename_part(str(task.get("tool_name") or task.get("plugin_id") or "scan"), "scan")
@@ -125,7 +135,6 @@ async def get_or_set_cached(key: str, builder):
     value = await builder()
     await cache.set_json(key, value)
     return value
-
 
 async def invalidate_view_cache():
     """Clear aggregate caches after writes."""

--- a/testing/backend/integration/test_routes.py
+++ b/testing/backend/integration/test_routes.py
@@ -119,3 +119,126 @@ def test_start_task_missing_plugin(test_client):
     assert response.status_code == 404
     detail = response.json().get("detail", "")
     assert missing_id in detail or "plugin" in detail.lower()
+
+class TestSafeModeCIDRBypass:
+    """
+    Regression tests for issue #267: is_filesystem_target() was treating
+    CIDR notation as a filesystem path, silently bypassing safe-mode enforcement.
+
+    With the fix applied, any CIDR target (public or private) must go through
+    validate_target(), which enforces safe-mode restrictions correctly.
+    """
+
+    def test_public_cidr_rejected_in_safe_mode(self, test_client, monkeypatch):
+        """
+        The canonical attack payload from issue #267.
+        8.8.8.8/32 must be rejected with 400 when safe_mode=True.
+        Before the fix, this returned 200 and queued an nmap scan against Google DNS.
+        """
+        from backend.secuscan.config import settings
+        monkeypatch.setattr(settings, "safe_mode_default", True)
+
+        response = test_client.post(
+            "/api/v1/task/start",
+            json={
+                "plugin_id": "nmap",
+                "inputs": {"target": "8.8.8.8/32"},
+                "consent_granted": True,
+            },
+        )
+        assert response.status_code == 400
+        detail = response.json().get("detail", "")
+        assert "Public IPs" in detail or "safe mode" in detail.lower(), (
+            f"Expected safe-mode rejection message, got: {detail!r}"
+        )
+
+    def test_public_class_b_cidr_rejected_in_safe_mode(self, test_client, monkeypatch):
+        """1.1.1.1/16 is another CIDR that must be rejected."""
+        from backend.secuscan.config import settings
+        monkeypatch.setattr(settings, "safe_mode_default", True)
+
+        response = test_client.post(
+            "/api/v1/task/start",
+            json={
+                "plugin_id": "nmap",
+                "inputs": {"target": "1.1.1.1/16"},
+                "consent_granted": True,
+            },
+        )
+        assert response.status_code == 400
+
+    def test_private_cidr_accepted_in_safe_mode(self, test_client, monkeypatch):
+        """
+        192.168.1.0/24 is a private CIDR and should be accepted in safe mode.
+        This verifies the fix does not break legitimate private-network scanning.
+        """
+        from backend.secuscan.config import settings
+        monkeypatch.setattr(settings, "safe_mode_default", True)
+
+        # Mock executor to avoid actual network scan
+        with patch("backend.secuscan.executor.TaskExecutor._execute_command") as mock_exec:
+            mock_exec.return_value = ("Mocked successful output", 0)
+
+            response = test_client.post(
+                "/api/v1/task/start",
+                json={
+                    "plugin_id": "nmap",
+                    "inputs": {"target": "192.168.1.0/24"},
+                    "consent_granted": True,
+                },
+            )
+            # Should be accepted (200) or at worst a concurrency/rate-limit issue (429/503)
+            # — NOT a 400 validation rejection
+            assert response.status_code != 400, (
+                f"Private CIDR should not be rejected by safe mode. Got: {response.json()}"
+            )
+
+    def test_cidr_accepted_when_safe_mode_disabled(self, test_client, monkeypatch):
+        """
+        With safe mode off, a public CIDR should be accepted.
+        This verifies we haven't accidentally hardcoded CIDR rejection.
+        """
+        from backend.secuscan.config import settings
+        monkeypatch.setattr(settings, "safe_mode_default", False)
+
+        with patch("backend.secuscan.executor.TaskExecutor._execute_command") as mock_exec:
+            mock_exec.return_value = ("Mocked successful output", 0)
+
+            response = test_client.post(
+                "/api/v1/task/start",
+                json={
+                    "plugin_id": "nmap",
+                    "inputs": {"target": "8.8.8.8/32"},
+                    "consent_granted": True,
+                },
+            )
+            assert response.status_code != 400, (
+                f"Public CIDR should be accepted when safe mode is disabled. Got: {response.json()}"
+            )
+
+    def test_filesystem_path_still_accepted_for_code_plugins(self, test_client, monkeypatch):
+        """
+        Regression: filesystem paths must still bypass network validation for code plugins.
+        This verifies the fix does not break the intended filesystem-path behaviour.
+        """
+        from backend.secuscan.config import settings
+        monkeypatch.setattr(settings, "safe_mode_default", True)
+
+        with patch("backend.secuscan.executor.TaskExecutor._execute_command") as mock_exec:
+            mock_exec.return_value = ("Mocked successful output", 0)
+
+            response = test_client.post(
+                "/api/v1/task/start",
+                json={
+                    "plugin_id": "code_analyzer",  # code-category plugin
+                    "inputs": {"target": "/home/user/repo"},
+                    "consent_granted": True,
+                },
+            )
+            # Must NOT be rejected with a network-validation 400
+            if response.status_code == 400:
+                detail = response.json().get("detail", "")
+                assert "safe mode" not in detail.lower() and "Public IP" not in detail, (
+                    f"Filesystem path was incorrectly rejected by network validation: {detail!r}"
+                )
+

--- a/testing/backend/integration/test_routes.py
+++ b/testing/backend/integration/test_routes.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 from backend.secuscan.models import TaskStatus
 
-
 def test_health_check(test_client):
     """Test health check endpoint."""
     response = test_client.get("/api/v1/health")
@@ -11,7 +10,6 @@ def test_health_check(test_client):
     data = response.json()
     assert data["status"] == "operational"
     assert "version" in data
-
 
 def test_list_plugins(test_client):
     """Test plugins list endpoint."""
@@ -51,7 +49,6 @@ def test_plugin_summary(test_client):
     data["unavailable_count"]
     ) == data["total_plugins"]
 
-
 def test_start_task(test_client):
     """Test starting a task with a mocked executor."""
     with patch("backend.secuscan.executor.TaskExecutor._execute_command") as mock_exec:
@@ -83,7 +80,6 @@ def test_start_task(test_client):
         result_data = result_response.json()
         assert "Mocked successful output" in result_data["raw_output_excerpt"]
 
-
 def test_missing_consent(test_client):
     """Test starting a task without consent."""
     payload = {
@@ -95,7 +91,6 @@ def test_missing_consent(test_client):
     response = test_client.post("/api/v1/task/start", json=payload)
     assert response.status_code == 400
     assert "Consent required" in response.json()["detail"]
-
 
 def test_get_settings(test_client):
     """Test settings endpoint."""
@@ -241,4 +236,3 @@ class TestSafeModeCIDRBypass:
                 assert "safe mode" not in detail.lower() and "Public IP" not in detail, (
                     f"Filesystem path was incorrectly rejected by network validation: {detail!r}"
                 )
-

--- a/testing/backend/unit/test_validation.py
+++ b/testing/backend/unit/test_validation.py
@@ -4,7 +4,7 @@ from backend.secuscan.validation import (
     validate_target, validate_port, validate_port_range, validate_url,
     sanitize_input, is_safe_path, match_pattern
 )
-
+from backend.secuscan.routes import is_filesystem_target
 
 def test_validate_target():
     # Valid IP target
@@ -21,14 +21,12 @@ def test_validate_target():
     assert validate_target("10.0.0.0/24")[0] is True  # Private CIDR ranges are allowed in safe mode
     assert validate_target("not!a!valid!hostname")[0] is False
 
-
 def test_validate_target_safe_mode_blocks_public_hostname(monkeypatch):
     def fake_getaddrinfo(_host, *_args, **_kwargs):
         return [(socket.AF_INET, None, None, None, ("8.8.8.8", 0))]
 
     monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
     assert validate_target("example.com", safe_mode=True)[0] is False
-
 
 def test_validate_target_safe_mode_blocks_multi_record_when_any_public(monkeypatch):
     """If any A/AAAA record is public, safe-mode must fail closed."""
@@ -40,7 +38,6 @@ def test_validate_target_safe_mode_blocks_multi_record_when_any_public(monkeypat
 
     monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
     assert validate_target("multirecord.example", safe_mode=True)[0] is False
-
 
 def test_validate_target_safe_mode_blocks_dns_rebinding_union(monkeypatch):
     """Rebinding/round-robin: validate_target resolves twice and validates the union."""
@@ -57,10 +54,8 @@ def test_validate_target_safe_mode_blocks_dns_rebinding_union(monkeypatch):
     assert ok is False
     assert calls["n"] >= 2
 
-
 def test_validate_target_safe_mode_blocks_url_ip_literal():
     assert validate_target("http://8.8.8.8", safe_mode=True)[0] is False
-
 
 def test_validate_port():
     assert validate_port(80) == (True, "")
@@ -77,7 +72,6 @@ def test_validate_port():
     assert validate_port(True)[0] is False       # bool (subclass of int)
     assert validate_port(None)[0] is False       # None
 
-
 def test_validate_url():
     assert validate_url("http://localhost:8080")[0] is True
     assert validate_url("https://localhost/path?param=value")[0] is True
@@ -91,7 +85,6 @@ def test_validate_url():
     assert validate_url("http://example.com:port")[0] is False
     assert validate_url("not_a_url")[0] is False
     assert validate_url("http://")[0] is False
-
 
 def test_sanitize_input():
     # Regular input should be unchanged
@@ -111,7 +104,6 @@ def test_sanitize_input():
     # Output should be a plain string with no leading/trailing whitespace
     assert sanitize_input("  192.168.1.1  ") == "192.168.1.1"
 
-
 def test_is_safe_path():
     base = "/opt/secuscan/data"
 
@@ -125,13 +117,11 @@ def test_is_safe_path():
     assert is_safe_path("../../../etc/passwd", base) is False
     assert is_safe_path("subdir/../../etc/passwd", base) is False
 
-
 def test_match_pattern():
     assert match_pattern("http_inspector", "http_*") is True
     assert match_pattern("nmap", "nmap") is True
     assert match_pattern("tls_inspector", "*inspector") is True
     assert match_pattern("dirb", "http_*") is False
-
 
 def test_validate_port_range():
     # Single port
@@ -162,3 +152,106 @@ def test_validate_port_range():
     # Invalid: non-numeric
     assert validate_port_range("abc")[0] is False
     assert validate_port_range("80,bad")[0] is False
+
+class TestIsFilesystemTarget:
+    """
+    Unit tests for is_filesystem_target().
+
+    This function is the gatekeeper that decides whether a target
+    should bypass validate_target(). Getting it wrong in the permissive
+    direction causes safe-mode bypass (CVE-equivalent: issue #267).
+
+    Rule: the function must return False for ANYTHING that is not
+    unambiguously a local filesystem path. When in doubt, return False
+    and let validate_target() do its job.
+    """
+
+    # ── Network addresses — must all return False ──────────────────────
+
+    def test_cidr_public_ipv4_is_not_filesystem(self):
+        """8.8.8.8/32 is the canonical attack payload from issue #267."""
+        assert is_filesystem_target("8.8.8.8/32") is False
+
+    def test_cidr_public_class_b_is_not_filesystem(self):
+        assert is_filesystem_target("1.1.1.1/16") is False
+
+    def test_cidr_private_is_not_filesystem(self):
+        """Even private CIDRs must go through validate_target — not our call here."""
+        assert is_filesystem_target("192.168.1.0/24") is False
+
+    def test_cidr_rfc1918_10_is_not_filesystem(self):
+        assert is_filesystem_target("10.0.0.0/8") is False
+
+    def test_cidr_loopback_is_not_filesystem(self):
+        assert is_filesystem_target("127.0.0.1/32") is False
+
+    def test_bare_ipv4_is_not_filesystem(self):
+        assert is_filesystem_target("192.168.1.1") is False
+
+    def test_bare_public_ip_is_not_filesystem(self):
+        assert is_filesystem_target("8.8.8.8") is False
+
+    def test_hostname_is_not_filesystem(self):
+        assert is_filesystem_target("example.com") is False
+
+    def test_hostname_with_path_is_not_filesystem(self):
+        """A hostname with a URL path should NOT be treated as a local path."""
+        assert is_filesystem_target("example.com/robots.txt") is False
+
+    def test_http_url_is_not_filesystem(self):
+        assert is_filesystem_target("http://192.168.1.1/path") is False
+
+    def test_https_url_is_not_filesystem(self):
+        assert is_filesystem_target("https://example.com/path") is False
+
+    def test_bare_tilde_is_not_filesystem(self):
+        """Bare ~ alone is NOT a valid home-relative path — must not match."""
+        assert is_filesystem_target("~") is False
+
+    def test_tilde_without_slash_is_not_filesystem(self):
+        """~evil.com would have matched the old '~' prefix — must not match now."""
+        assert is_filesystem_target("~evil.com") is False
+
+    def test_empty_string_is_not_filesystem(self):
+        assert is_filesystem_target("") is False
+
+    # ── Filesystem paths — must all return True ────────────────────────
+
+    def test_unix_absolute_path(self):
+        assert is_filesystem_target("/home/user/repo") is True
+
+    def test_unix_root(self):
+        assert is_filesystem_target("/") is True
+
+    def test_unix_absolute_path_with_spaces(self):
+        assert is_filesystem_target("/home/my user/project") is True
+
+    def test_relative_path_dot_slash(self):
+        assert is_filesystem_target("./src") is True
+
+    def test_relative_path_dot(self):
+        assert is_filesystem_target("./") is True
+
+    def test_relative_path_parent(self):
+        assert is_filesystem_target("../lib") is True
+
+    def test_relative_path_deep(self):
+        assert is_filesystem_target("../../etc/config") is True
+
+    def test_home_relative_path(self):
+        assert is_filesystem_target("~/projects") is True
+
+    def test_home_relative_path_deep(self):
+        assert is_filesystem_target("~/code/secuscan/backend") is True
+
+    def test_windows_path_backslash(self):
+        assert is_filesystem_target(r"C:\Users\repo") is True
+
+    def test_windows_path_forward_slash(self):
+        assert is_filesystem_target("C:/Users/repo") is True
+
+    def test_windows_path_other_drive(self):
+        assert is_filesystem_target(r"D:\work\project") is True
+
+    def test_windows_lowercase_drive(self):
+        assert is_filesystem_target(r"c:\users\repo") is True


### PR DESCRIPTION
Closes #267 


## Description
Removes the overly broad `"/" in target` check from `is_filesystem_target()` in `backend/secuscan/routes.py`. 

### The Problem:
Previously, the helper function classified any target containing a `/` (and not starting with `http://` or `https://`) as a filesystem target. This allowed valid network CIDR inputs (like `8.8.8.8/32` or `1.1.1.1/24`) to bypass `validate_target()` entirely, completely subverting the safe-mode public-IP guardrail.

### The Solution:
- Removed the generic `"/" in target` condition. Since CIDR notation is already parsed and private/public properties validated securely via `ipaddress.ip_network()` within the core `validate_target()` block, no special-casing is required in the filesystem check.
- Tightened tilde home-directory checking from starting with `"~"` to `"~/"` to prevent bare tildes or crafted domain paths (e.g. `~evil.com`) from being misclassified as filesystem targets.
- Retained legitimate Unix absolute, relative, and Windows roots as valid filesystem paths so code-scanning plugins (like `code_analyzer`) still bypass network validation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
We added complete automated coverage across multiple test layers to guarantee the fix is correct and introduces zero regressions:

1. **Unit Tests** (`testing/backend/unit/test_validation.py`):
   - Added `TestIsFilesystemTarget` containing 26 distinct test cases to verify genuine filesystem paths (positive matches) and block network CIDRs, domains, URLs, and bare tildes (negative matches).
2. **Integration Tests** (`testing/backend/integration/test_routes.py`):
   - Added `TestSafeModeCIDRBypass` verifying the exact `8.8.8.8/32` attack vector is rejected with `400 Bad Request` under safe mode, while legitimate private CIDRs and local filesystem targets still proceed normally.
3. **Safe Mode Filesystem Targets Suite** (`testing/backend/test_safe_mode_filesystem_targets.py`):
   - Verified target behavior for both `code` and `network` plugins to ensure standard workflows remain unaffected.

### Test Commands Executed:
```bash
python -m pytest testing/backend/unit/test_validation.py -v
python -m pytest testing/backend/integration/test_routes.py -v
python -m pytest testing/backend/test_safe_mode_filesystem_targets.py -v
