### PR TITLE
fix(docker): remove out-of-context plugins COPY, fix app entrypoint and host binding

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,12 @@
 FROM python:3.11-slim
 
 WORKDIR /app
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY secuscan ./secuscan
-COPY plugins ./plugins
 
 EXPOSE 8081
 
-CMD ["uvicorn", "secuscan.api:app", "--host", "127.0.0.1", "--port", "8081"]
-
+CMD ["uvicorn", "secuscan.main:app", "--host", "0.0.0.0", "--port", "8081"]


### PR DESCRIPTION
## Summary
Fixes three inconsistencies in the backend Dockerfile that prevented
`docker compose up --build` from working on a clean checkout.
Closes #381.

## Changes

### `backend/Dockerfile`
- Removed `COPY plugins ./plugins` — the `plugins/` directory is
  outside the `./backend` build context so this line caused a build
  failure. Plugins are already mounted correctly via the compose
  volume `./plugins:/app/plugins`, making the COPY redundant.
- Fixed app entrypoint from `secuscan.api:app` to `secuscan.main:app`
  to match the actual FastAPI application module.
- Fixed `--host 127.0.0.1` to `--host 0.0.0.0` so uvicorn binds to
  all interfaces inside the container and is reachable from the host
  via the mapped port.

## How to test
1. From the repository root run `docker compose up --build`
2. Confirm the backend image builds without error
3. Confirm the API is reachable at `http://127.0.0.1:8081/api/v1/health`

## Notes
- `docker-compose.yml` is unchanged — the compose file was already
  correct with `context: ./backend` and the plugins volume mount
- No backend Python code changes

Closes #381