### PR TITLE
fix: use dict.get() instead of getattr() for plugin category

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -193,7 +193,7 @@ async def get_plugins_summary():
     category_counts: Dict[str, int] = {}
 
     for plugin in plugins:
-        category = getattr(plugin, "category", "unknown")
+        category = plugin.get("category", "unknown")
 
         category_counts[category] = (
             category_counts.get(category, 0) + 1


### PR DESCRIPTION
## Description
Replace `getattr(plugin, 'category', 'Unknown')` with `plugin.get('category', 'Unknown')` in `/api/v1/plugins/summary` since plugins are dicts, not objects.

## Related Issues
Split from #433 as requested by maintainer.

## Type of Change
- [x] Bug fix