### PR TITLE
docs(api): fix malformed pagination code fences

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -31,13 +31,12 @@
     "previous": null
   }
 }
+```
 
-
-
-"""
+```bash
 # Basic pagination
 curl "http://localhost:8000/api/v1/tasks?page=2&per_page=10"
 
 # With filters
 curl "http://localhost:8000/api/v1/tasks?status=completed&plugin_id=nmap&page=1&per_page=20"
-"""
+```


### PR DESCRIPTION
## Description
Fixes malformed Markdown fencing in `docs/API.md` for the Tasks pagination examples. The JSON response block is now properly closed and the curl examples are rendered as a `bash` code fence.

## Related Issues
Closes #468

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- Ran `git diff --check`
- Verified `docs/API.md` no longer contains triple-quote markers and now has balanced fenced code blocks around the Tasks API pagination examples

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
