### PR TITLE
test (findings): add coverage for corrupted review state storage #470

### DIFF
--- a/frontend/testing/unit/pages/Findings.test.tsx
+++ b/frontend/testing/unit/pages/Findings.test.tsx
@@ -511,6 +511,27 @@ describe('Findings — risk score display', () => {
   beforeEach(() => {
     vi.mocked(getFindings).mockResolvedValue({ findings: [criticalFindingWithRisk, highFinding, mediumFinding] })
   })
+  describe('Findings — corrupted review state storage', () => {
+  beforeEach(() => {
+    vi.mocked(getFindings).mockResolvedValue({ findings: allFindings })
+  })
+
+  it('ignores malformed review state stored in localStorage', async () => {
+    localStorage.setItem(
+      'secuscan-finding-review-state',
+      '{invalid-json'
+    )
+
+    renderFindings()
+
+    await waitForLoad()
+
+    expect(
+      screen.getAllByText('SQL Injection in Login').length
+    ).toBeGreaterThanOrEqual(1)
+  })
+})
+
 
   it('shows risk score in sidebar when available', async () => {
     renderFindings()


### PR DESCRIPTION
**### Description**

Added test coverage for malformed review state data stored in localStorage. The new test verifies that the Findings page continues to render successfully when invalid JSON is present in the persisted review state.

**### Related Issues**

Fixes #470

**### Type of Change**

- [x] Bug fix (non-breaking change which fixes an issue)

**### How Has This Been Tested?**

- Added a unit test covering malformed review state storage.
- Ran the full frontend test suite.

### **Test Results:**

- 31 test files passed
- 283 tests passed

**### Checklist**

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
