### PR TITLE
fix(frontend): clear request timeout on failed requests

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -115,28 +115,38 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const apiKey = getApiKey()
   const authHeaders: Record<string, string> = apiKey ? { 'X-Api-Key': apiKey } : {}
 
-  const response = await fetch(`${API_BASE}${path}`, {
-    ...init,
-    headers: {
-      ...authHeaders,
-      ...(init?.headers as Record<string, string> | undefined),
-    },
-    signal: controller.signal,
-  })
-  window.clearTimeout(timeoutId)
+  try {
+    const response = await fetch(`${API_BASE}${path}`, {
+      ...init,
+      headers: {
+        ...authHeaders,
+        ...(init?.headers as Record<string, string> | undefined),
+      },
+      signal: controller.signal,
+    })
 
-  if (response.status === 401) {
-    // Notify the app so it can show the API-key setup UI without every
-    // caller needing to handle auth independently.
-    window.dispatchEvent(new CustomEvent(AUTH_REQUIRED_EVENT))
-    throw new Error('AUTH_REQUIRED')
-  }
+    if (response.status === 401) {
+      // Notify the app so it can show the API-key setup UI without every
+      // caller needing to handle auth independently.
+      window.dispatchEvent(new CustomEvent(AUTH_REQUIRED_EVENT))
+      throw new Error('AUTH_REQUIRED')
+    }
 
-  if (!response.ok) {
-    throw new Error(`Request failed: ${response.status}`)
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status}`)
+    }
+    return response.json()
+  } finally {
+    window.clearTimeout(timeoutId)
   }
-  return response.json()
 }
+  
+  //   if (!response.ok) {
+    //     throw new Error(`Request failed: ${response.status}`)
+    //   }
+    //   return response.json()
+    // }
+
 
 export function getHealth() {
   return request('/health')

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -140,13 +140,6 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     window.clearTimeout(timeoutId)
   }
 }
-  
-  //   if (!response.ok) {
-    //     throw new Error(`Request failed: ${response.status}`)
-    //   }
-    //   return response.json()
-    // }
-
 
 export function getHealth() {
   return request('/health')

--- a/frontend/testing/unit/api.auth.test.ts
+++ b/frontend/testing/unit/api.auth.test.ts
@@ -30,7 +30,7 @@ function mockResponse(status: number, body: unknown = {}) {
     ok: status >= 200 && status < 300,
     status,
     json: () => Promise.resolve(body),
-  } as Response)
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -152,6 +152,47 @@ describe('request() 401 handling', () => {
 
     window.removeEventListener(AUTH_REQUIRED_EVENT, handler)
     expect(fired).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// request() — timeout cleanup
+// ---------------------------------------------------------------------------
+
+describe('request() timeout cleanup', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('clears the timeout when fetch rejects', async () => {
+    const timeoutId = 1 as unknown as ReturnType<typeof setTimeout>
+vi.spyOn(window, 'setTimeout').mockImplementation(() => timeoutId)
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('fetch failed')))
+
+    await expect(listPlugins()).rejects.toThrow('fetch failed')
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(timeoutId)
+  })
+
+  it('clears the timeout when request is aborted', async () => {
+    vi.useFakeTimers()
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
+
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((_, init) => {
+      const signal = (init as any)?.signal
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'))
+        })
+      })
+    }))
+
+    const promise = listPlugins()
+    vi.runAllTimers()
+    await expect(promise).rejects.toThrow('Aborted')
+    expect(clearTimeoutSpy).toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
## Description
Moved request timeout cleanup in frontend/src/api.ts into a finally block so timers are cleared for all request paths, including rejected and aborted requests.

Also added focused unit tests covering:

rejected fetch requests
aborted requests

This preserves the existing abort behavior while ensuring timeout cleanup always occurs.



## Related Issues
Closes #465

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
npm run test -- api.auth

Result:

15 tests passed

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
