### PR TITLE
feat(reports): add report comparison view (closes #36)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import Toolkit from './pages/Toolkit'
 import ToolConfig from './pages/ToolConfig'
 import Findings from './pages/Findings'
 import Reports from './pages/Reports'
+import ReportCompare from './pages/ReportCompare'
 import Settings from './pages/Settings'
 import Scans from './pages/Scans'
 import TaskDetails from './pages/TaskDetails'
@@ -27,6 +28,7 @@ export function AppRoutes() {
       <Route path={routes.findings} element={<Findings />} />
       <Route path={routes.scans} element={<Scans />} />
       <Route path={routes.reports} element={<Reports />} />
+      <Route path={routes.reportsCompare} element={<ReportCompare />} />
       <Route path={routes.workflows} element={<Workflows />} />
       <Route path={routes.settings} element={<Settings />} />
       <Route path={routes.task} element={<TaskDetails />} />

--- a/frontend/src/pages/ReportCompare.tsx
+++ b/frontend/src/pages/ReportCompare.tsx
@@ -26,6 +26,30 @@ type ReportOption = {
   status: string
 }
 
+function reportHasFindings(
+  report: ReportOption,
+  findingsByTask: Record<string, ComparableFinding[]>,
+): boolean {
+  const fromApi = Number(report.findings)
+  if (fromApi > 0) return true
+  return (findingsByTask[report.task_id]?.length ?? 0) > 0
+}
+
+/** Compare uses finding diffs; include ready reports and failed scans that still produced findings. */
+function comparableReports(
+  rows: ReportOption[],
+  findingsByTask: Record<string, ComparableFinding[]>,
+): ReportOption[] {
+  return rows.filter(
+    (r) => r.status === 'ready' || (r.status === 'failed' && reportHasFindings(r, findingsByTask)),
+  )
+}
+
+function reportOptionLabel(report: ReportOption): string {
+  const statusNote = report.status === 'failed' ? ' (scan failed)' : ''
+  return `${report.name}${statusNote} — ${formatDateLong(report.generated_at)}`
+}
+
 const severityChip: Record<string, string> = {
   critical: 'bg-rag-red text-black',
   high: 'bg-rag-amber text-black',
@@ -131,8 +155,6 @@ export default function ReportCompare() {
       .then((results) => {
         const reportData = results[0] as { reports?: ReportOption[] }
         const findingsData = results[1] as { findings?: Record<string, unknown>[] }
-        const ready = (reportData.reports || []).filter((r) => r.status === 'ready')
-        setReports(ready)
 
         const byTask: Record<string, ComparableFinding[]> = {}
         for (const raw of findingsData.findings || []) {
@@ -146,6 +168,12 @@ export default function ReportCompare() {
           }
         }
         setFindingsByTask(byTask)
+
+        const rawReports = (reportData.reports || []).map((r) => ({
+          ...r,
+          findings: Number(r.findings ?? 0),
+        }))
+        setReports(comparableReports(rawReports, byTask))
       })
       .catch(() => setError('Failed to load reports or findings'))
       .finally(() => setLoading(false))
@@ -227,7 +255,7 @@ export default function ReportCompare() {
                 <option value="">Select baseline...</option>
                 {reports.map((r) => (
                   <option key={r.id} value={r.id}>
-                    {r.name} — {formatDateLong(r.generated_at)}
+                    {reportOptionLabel(r)}
                   </option>
                 ))}
               </select>
@@ -244,7 +272,7 @@ export default function ReportCompare() {
                 <option value="">Select comparison...</option>
                 {reports.map((r) => (
                   <option key={r.id} value={r.id}>
-                    {r.name} — {formatDateLong(r.generated_at)}
+                    {reportOptionLabel(r)}
                   </option>
                 ))}
               </select>
@@ -253,7 +281,8 @@ export default function ReportCompare() {
 
           {reports.length < 2 && (
             <p className="text-[10px] font-black uppercase tracking-widest text-silver/40">
-              At least two ready reports are required to compare.
+              At least two reports with findings are required to compare. Run scans that finish
+              with results, then refresh.
             </p>
           )}
 

--- a/frontend/src/pages/ReportCompare.tsx
+++ b/frontend/src/pages/ReportCompare.tsx
@@ -1,0 +1,321 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  ArrowLeft02Icon,
+  Analytics02Icon,
+  Refresh01Icon,
+} from '@hugeicons/core-free-icons'
+import { getFindings, getReports } from '../api'
+import { routes } from '../routes'
+import { formatDateLong } from '../utils/date'
+import {
+  compareFindings,
+  type ComparableFinding,
+  type ComparedFinding,
+  type ReportComparisonResult,
+} from '../utils/compareFindings'
+
+type ReportOption = {
+  id: string
+  task_id: string
+  name: string
+  generated_at: string
+  findings: number
+  status: string
+}
+
+const severityChip: Record<string, string> = {
+  critical: 'bg-rag-red text-black',
+  high: 'bg-rag-amber text-black',
+  medium: 'bg-rag-blue text-black',
+  low: 'bg-charcoal-dark text-silver-bright border border-silver-bright/15',
+  info: 'bg-charcoal-dark text-silver border border-silver/15',
+}
+
+function toComparableFinding(raw: Record<string, unknown>): ComparableFinding | null {
+  const title = typeof raw.title === 'string' ? raw.title : ''
+  const target = typeof raw.target === 'string' ? raw.target : ''
+  const category = typeof raw.category === 'string' ? raw.category : ''
+  const severity = typeof raw.severity === 'string' ? raw.severity : 'info'
+  if (!title && !target) return null
+  return {
+    id: typeof raw.id === 'string' ? raw.id : undefined,
+    title: title || 'Untitled finding',
+    target: target || 'Unknown target',
+    category: category || 'General',
+    severity,
+    description: typeof raw.description === 'string' ? raw.description : undefined,
+  }
+}
+
+function FindingRow({ item, showBaseline, showComparison }: {
+  item: ComparedFinding
+  showBaseline?: boolean
+  showComparison?: boolean
+}) {
+  const finding = (showComparison ? item.comparison : item.baseline) ?? item.comparison ?? item.baseline
+  if (!finding) return null
+  const severity = (finding.severity || 'info').toLowerCase()
+  const chip = severityChip[severity] ?? severityChip.info
+
+  return (
+    <div className="border-2 border-black bg-charcoal-dark/50 p-4 space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className={`px-2 py-0.5 text-[9px] font-black uppercase border-2 border-black ${chip}`}>
+          {severity}
+        </span>
+        <span className="text-[9px] font-mono text-silver/40 uppercase">{finding.category}</span>
+      </div>
+      <p className="text-sm font-black text-silver-bright uppercase tracking-tight">{finding.title}</p>
+      <p className="text-[10px] font-mono text-silver/50">{finding.target}</p>
+      {showBaseline && showComparison && item.baseline && item.comparison && (
+        <p className="text-[9px] font-black uppercase tracking-widest text-rag-amber">
+          {item.baseline.severity} → {item.comparison.severity}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function CompareSection({
+  title,
+  items,
+  tone,
+  showBaseline,
+  showComparison,
+}: {
+  title: string
+  items: ComparedFinding[]
+  tone: string
+  showBaseline?: boolean
+  showComparison?: boolean
+}) {
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between border-b-2 border-black pb-2">
+        <h3 className={`text-lg font-black uppercase tracking-tighter italic ${tone}`}>{title}</h3>
+        <span className="text-[10px] font-mono text-silver/40">{items.length}</span>
+      </div>
+      {items.length === 0 ? (
+        <p className="text-[10px] font-black uppercase tracking-widest text-silver/30 italic">None</p>
+      ) : (
+        <div className="space-y-3 max-h-80 overflow-y-auto pr-1">
+          {items.map((item) => (
+            <FindingRow
+              key={item.fingerprint}
+              item={item}
+              showBaseline={showBaseline}
+              showComparison={showComparison}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default function ReportCompare() {
+  const [reports, setReports] = useState<ReportOption[]>([])
+  const [findingsByTask, setFindingsByTask] = useState<Record<string, ComparableFinding[]>>({})
+  const [baselineReportId, setBaselineReportId] = useState('')
+  const [comparisonReportId, setComparisonReportId] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadData = () => {
+    setLoading(true)
+    setError(null)
+    Promise.all([getReports(), getFindings()])
+      .then((results) => {
+        const reportData = results[0] as { reports?: ReportOption[] }
+        const findingsData = results[1] as { findings?: Record<string, unknown>[] }
+        const ready = (reportData.reports || []).filter((r) => r.status === 'ready')
+        setReports(ready)
+
+        const byTask: Record<string, ComparableFinding[]> = {}
+        for (const raw of findingsData.findings || []) {
+          const row = raw as Record<string, unknown>
+          const finding = toComparableFinding(row)
+          if (!finding) continue
+          const taskId = typeof row.task_id === 'string' ? row.task_id : ''
+          if (taskId) {
+            if (!byTask[taskId]) byTask[taskId] = []
+            byTask[taskId].push(finding)
+          }
+        }
+        setFindingsByTask(byTask)
+      })
+      .catch(() => setError('Failed to load reports or findings'))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  const baselineReport = reports.find((r) => r.id === baselineReportId)
+  const comparisonReport = reports.find((r) => r.id === comparisonReportId)
+
+  const comparison: ReportComparisonResult | null = useMemo(() => {
+    if (!baselineReport || !comparisonReport) return null
+    if (baselineReport.id === comparisonReport.id) return null
+    const baselineFindings = findingsByTask[baselineReport.task_id] || []
+    const comparisonFindings = findingsByTask[comparisonReport.task_id] || []
+    return compareFindings(baselineFindings, comparisonFindings)
+  }, [baselineReport, comparisonReport, findingsByTask])
+
+  const sameReportSelected = Boolean(
+    baselineReportId && comparisonReportId && baselineReportId === comparisonReportId,
+  )
+
+  return (
+    <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-10">
+      <header className="flex flex-col md:flex-row justify-between items-start md:items-end gap-6 pb-10 border-b-4 border-silver-bright/10">
+        <div className="space-y-4">
+          <Link
+            to={routes.reports}
+            className="inline-flex items-center gap-2 text-[10px] font-black uppercase tracking-widest text-silver/50 hover:text-silver-bright"
+          >
+            <HugeiconsIcon icon={ArrowLeft02Icon} size={16} />
+            Back to reports
+          </Link>
+          <div className="bg-rag-blue text-black px-4 py-1 text-xs uppercase tracking-widest inline-block shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] font-black">
+            Report_Diff v1.0
+          </div>
+          <h1 className="text-5xl md:text-7xl text-silver-bright uppercase tracking-tighter leading-none italic font-black">
+            Compare <span className="text-rag-amber">Reports</span>
+          </h1>
+          <p className="text-sm font-mono text-silver/40 uppercase tracking-widest italic">
+            BASELINE_VS_COMPARISON // NEW_FIXED_UNCHANGED_SEVERITY
+          </p>
+        </div>
+        <button
+          onClick={loadData}
+          className="bg-charcoal border-4 border-black p-4 text-silver-bright shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all"
+          title="Refresh"
+        >
+          <HugeiconsIcon icon={Refresh01Icon} size={20} />
+        </button>
+      </header>
+
+      {loading && (
+        <p className="text-[10px] font-black uppercase tracking-[0.4em] text-silver/30 animate-pulse">
+          Loading comparison data...
+        </p>
+      )}
+
+      {!loading && error && (
+        <div className="border-4 border-rag-red bg-rag-red/10 p-6 text-rag-red text-[10px] font-black uppercase tracking-widest">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && (
+        <>
+          <section className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <label className="space-y-3 block">
+              <span className="text-[10px] font-black uppercase tracking-widest text-silver-bright">
+                Baseline report (older)
+              </span>
+              <select
+                value={baselineReportId}
+                onChange={(e) => setBaselineReportId(e.target.value)}
+                className="w-full bg-charcoal border-4 border-black p-4 text-sm font-mono text-silver-bright"
+              >
+                <option value="">Select baseline...</option>
+                {reports.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.name} — {formatDateLong(r.generated_at)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-3 block">
+              <span className="text-[10px] font-black uppercase tracking-widest text-silver-bright">
+                Comparison report (newer)
+              </span>
+              <select
+                value={comparisonReportId}
+                onChange={(e) => setComparisonReportId(e.target.value)}
+                className="w-full bg-charcoal border-4 border-black p-4 text-sm font-mono text-silver-bright"
+              >
+                <option value="">Select comparison...</option>
+                {reports.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.name} — {formatDateLong(r.generated_at)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </section>
+
+          {reports.length < 2 && (
+            <p className="text-[10px] font-black uppercase tracking-widest text-silver/40">
+              At least two ready reports are required to compare.
+            </p>
+          )}
+
+          {sameReportSelected && (
+            <p className="text-[10px] font-black uppercase tracking-widest text-rag-amber">
+              Select two different reports to compare.
+            </p>
+          )}
+
+          {comparison && (
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="border-4 border-black bg-charcoal p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-10"
+            >
+              <div className="flex items-center gap-3 text-silver-bright">
+                <HugeiconsIcon icon={Analytics02Icon} size={28} />
+                <div>
+                  <p className="text-[10px] font-black uppercase tracking-widest text-silver/40">Diff ready</p>
+                  <p className="text-sm font-mono">
+                    {baselineReport?.name} → {comparisonReport?.name}
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-10">
+                <CompareSection
+                  title="New findings"
+                  items={comparison.newFindings}
+                  tone="text-rag-red"
+                  showComparison
+                />
+                <CompareSection
+                  title="Fixed findings"
+                  items={comparison.fixedFindings}
+                  tone="text-rag-green"
+                  showBaseline
+                />
+                <CompareSection
+                  title="Unchanged"
+                  items={comparison.unchangedFindings}
+                  tone="text-silver-bright"
+                  showComparison
+                />
+                <CompareSection
+                  title="Severity changed"
+                  items={comparison.severityChanged}
+                  tone="text-rag-amber"
+                  showBaseline
+                  showComparison
+                />
+              </div>
+            </motion.div>
+          )}
+
+          {!comparison && baselineReportId && comparisonReportId && !sameReportSelected && (
+            <p className="text-[10px] font-black uppercase tracking-widest text-silver/40">
+              No findings to compare for the selected reports.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -64,6 +64,29 @@ function ReportIcon({
   return <HugeiconsIcon icon={icon} size={size} strokeWidth={1.9} className={className} />
 }
 
+function normalizeReport(raw: Partial<Report> & Record<string, unknown>): Report {
+  const findings = Number(raw.findings ?? 0)
+  const pages = Number(raw.pages ?? 0)
+  const assets = Number(raw.assets ?? 0)
+  const type = raw.type === 'executive' || raw.type === 'compliance' ? raw.type : 'technical'
+  const status =
+    raw.status === 'ready' || raw.status === 'generating' || raw.status === 'failed'
+      ? raw.status
+      : 'ready'
+
+  return {
+    id: String(raw.id ?? ''),
+    task_id: String(raw.task_id ?? ''),
+    name: String(raw.name ?? 'Untitled report'),
+    type,
+    generated_at: String(raw.generated_at ?? ''),
+    status,
+    findings: Number.isFinite(findings) ? findings : 0,
+    assets: Number.isFinite(assets) ? assets : 0,
+    pages: Number.isFinite(pages) ? pages : 0,
+  }
+}
+
 export default function Reports() {
   const navigate = useNavigate()
   const [reports, setReports] = useState<Report[]>([])
@@ -83,7 +106,8 @@ export default function Reports() {
     setError(null)
     Promise.all([getReports(), getDashboardSummary()])
       .then(([reportData, summaryData]: any) => {
-        setReports(reportData.reports || [])
+        const rows = Array.isArray(reportData?.reports) ? reportData.reports : []
+        setReports(rows.map((row: Record<string, unknown>) => normalizeReport(row)))
         setSummary(summaryData || {})
       })
       .catch(() => {

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
+import { routes } from '../routes'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
   Analytics02Icon,
@@ -122,6 +123,12 @@ export default function Reports() {
         </div>
 
         <div className="flex items-center gap-6">
+          <Link
+            to={routes.reportsCompare}
+            className="bg-rag-blue border-4 border-black px-6 py-4 text-[9px] font-black uppercase tracking-widest text-black shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all"
+          >
+            Compare Reports
+          </Link>
           <button
             onClick={() => {
               if (!latestReadyReport) return

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -5,6 +5,7 @@ export const routes = {
   findings: '/findings',
   scans: '/scans',
   reports: '/reports',
+  reportsCompare: '/reports/compare',
   workflows: '/workflows',
   settings: '/settings',
   task: '/task/:taskId',

--- a/frontend/src/utils/compareFindings.ts
+++ b/frontend/src/utils/compareFindings.ts
@@ -1,0 +1,84 @@
+export type ComparableFinding = {
+  id?: string
+  title: string
+  target: string
+  category: string
+  severity: string
+  description?: string
+}
+
+export type ComparedFinding = {
+  fingerprint: string
+  baseline?: ComparableFinding
+  comparison?: ComparableFinding
+}
+
+export type ReportComparisonResult = {
+  newFindings: ComparedFinding[]
+  fixedFindings: ComparedFinding[]
+  unchangedFindings: ComparedFinding[]
+  severityChanged: ComparedFinding[]
+}
+
+export function findingFingerprint(finding: ComparableFinding): string {
+  const title = (finding.title || '').trim().toLowerCase()
+  const target = (finding.target || '').trim().toLowerCase()
+  const category = (finding.category || '').trim().toLowerCase()
+  return `${title}|${target}|${category}`
+}
+
+function indexFindings(findings: ComparableFinding[]): Map<string, ComparableFinding> {
+  const map = new Map<string, ComparableFinding>()
+  for (const finding of findings) {
+    map.set(findingFingerprint(finding), finding)
+  }
+  return map
+}
+
+export function compareFindings(
+  baselineFindings: ComparableFinding[],
+  comparisonFindings: ComparableFinding[],
+): ReportComparisonResult {
+  const baseline = indexFindings(baselineFindings)
+  const comparison = indexFindings(comparisonFindings)
+
+  const newFindings: ComparedFinding[] = []
+  const fixedFindings: ComparedFinding[] = []
+  const unchangedFindings: ComparedFinding[] = []
+  const severityChanged: ComparedFinding[] = []
+
+  for (const [fingerprint, comparisonFinding] of comparison.entries()) {
+    const baselineFinding = baseline.get(fingerprint)
+    if (!baselineFinding) {
+      newFindings.push({ fingerprint, comparison: comparisonFinding })
+      continue
+    }
+
+    const baselineSeverity = (baselineFinding.severity || 'info').toLowerCase()
+    const comparisonSeverity = (comparisonFinding.severity || 'info').toLowerCase()
+    const entry: ComparedFinding = {
+      fingerprint,
+      baseline: baselineFinding,
+      comparison: comparisonFinding,
+    }
+
+    if (baselineSeverity === comparisonSeverity) {
+      unchangedFindings.push(entry)
+    } else {
+      severityChanged.push(entry)
+    }
+  }
+
+  for (const [fingerprint, baselineFinding] of baseline.entries()) {
+    if (!comparison.has(fingerprint)) {
+      fixedFindings.push({ fingerprint, baseline: baselineFinding })
+    }
+  }
+
+  return {
+    newFindings,
+    fixedFindings,
+    unchangedFindings,
+    severityChanged,
+  }
+}

--- a/frontend/testing/unit/pages/ReportCompare.test.tsx
+++ b/frontend/testing/unit/pages/ReportCompare.test.tsx
@@ -74,6 +74,22 @@ describe('ReportCompare page', () => {
     })
   })
 
+  it('lists failed reports when they still have findings', async () => {
+    vi.mocked(getReports).mockResolvedValue({
+      reports: [
+        { ...readyA, status: 'failed' },
+        { ...readyB, status: 'failed' },
+      ],
+    })
+    renderCompare()
+
+    await waitFor(() => {
+      const options = screen.getAllByRole('option')
+      expect(options.some((o) => o.textContent?.includes('Scan A'))).toBe(true)
+      expect(options.some((o) => o.textContent?.includes('Scan B'))).toBe(true)
+    })
+  })
+
   it('renders compare selectors and diff sections', async () => {
     const user = userEvent.setup()
     renderCompare()

--- a/frontend/testing/unit/pages/ReportCompare.test.tsx
+++ b/frontend/testing/unit/pages/ReportCompare.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import ReportCompare from '../../../src/pages/ReportCompare'
+import { getFindings, getReports } from '../../../src/api'
+
+vi.mock('../../../src/api', () => ({
+  getReports: vi.fn(),
+  getFindings: vi.fn(),
+}))
+
+const readyA = {
+  id: 'report-a',
+  task_id: 'task-a',
+  name: 'Scan A',
+  type: 'technical',
+  generated_at: '2026-05-01T10:00:00Z',
+  status: 'ready',
+  findings: 1,
+  assets: 1,
+  pages: 1,
+}
+
+const readyB = {
+  id: 'report-b',
+  task_id: 'task-b',
+  name: 'Scan B',
+  type: 'technical',
+  generated_at: '2026-05-02T10:00:00Z',
+  status: 'ready',
+  findings: 2,
+  assets: 1,
+  pages: 1,
+}
+
+function renderCompare() {
+  return render(
+    <MemoryRouter>
+      <ReportCompare />
+    </MemoryRouter>,
+  )
+}
+
+describe('ReportCompare page', () => {
+  beforeEach(() => {
+    vi.mocked(getReports).mockResolvedValue({ reports: [readyA, readyB] })
+    vi.mocked(getFindings).mockResolvedValue({
+      findings: [
+        {
+          id: 'f1',
+          task_id: 'task-a',
+          title: 'Only in A',
+          target: '127.0.0.1',
+          category: 'network',
+          severity: 'high',
+        },
+        {
+          id: 'f2',
+          task_id: 'task-b',
+          title: 'Only in A',
+          target: '127.0.0.1',
+          category: 'network',
+          severity: 'high',
+        },
+        {
+          id: 'f3',
+          task_id: 'task-b',
+          title: 'Only in B',
+          target: '127.0.0.1',
+          category: 'network',
+          severity: 'critical',
+        },
+      ],
+    })
+  })
+
+  it('renders compare selectors and diff sections', async () => {
+    const user = userEvent.setup()
+    renderCompare()
+
+    expect(await screen.findByRole('heading', { name: /compare reports/i })).toBeInTheDocument()
+
+    const selects = screen.getAllByRole('combobox')
+    await user.selectOptions(selects[0], 'report-a')
+    await user.selectOptions(selects[1], 'report-b')
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /new findings/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /fixed findings/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /^unchanged$/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /severity changed/i })).toBeInTheDocument()
+      expect(screen.getByText(/Only in B/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/testing/unit/utils/compareFindings.test.ts
+++ b/frontend/testing/unit/utils/compareFindings.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compareFindings,
+  findingFingerprint,
+  type ComparableFinding,
+} from '../../../src/utils/compareFindings'
+
+const base = (overrides: Partial<ComparableFinding> = {}): ComparableFinding => ({
+  title: 'Open port',
+  target: '127.0.0.1',
+  category: 'network',
+  severity: 'high',
+  ...overrides,
+})
+
+describe('findingFingerprint', () => {
+  it('is stable for same title target category', () => {
+    const a = base({ title: 'Open Port', target: '127.0.0.1' })
+    const b = base({ title: 'open port', target: '127.0.0.1' })
+    expect(findingFingerprint(a)).toBe(findingFingerprint(b))
+  })
+})
+
+describe('compareFindings', () => {
+  it('detects new findings in comparison scan', () => {
+    const baseline = [base({ title: 'Old issue' })]
+    const comparison = [base({ title: 'Old issue' }), base({ title: 'New issue' })]
+    const result = compareFindings(baseline, comparison)
+    expect(result.newFindings).toHaveLength(1)
+    expect(result.newFindings[0].comparison?.title).toBe('New issue')
+  })
+
+  it('detects fixed findings removed in comparison scan', () => {
+    const baseline = [base({ title: 'Fixed issue' }), base({ title: 'Still here' })]
+    const comparison = [base({ title: 'Still here' })]
+    const result = compareFindings(baseline, comparison)
+    expect(result.fixedFindings).toHaveLength(1)
+    expect(result.fixedFindings[0].baseline?.title).toBe('Fixed issue')
+  })
+
+  it('detects unchanged findings with same severity', () => {
+    const baseline = [base({ title: 'Stable', severity: 'medium' })]
+    const comparison = [base({ title: 'Stable', severity: 'medium' })]
+    const result = compareFindings(baseline, comparison)
+    expect(result.unchangedFindings).toHaveLength(1)
+    expect(result.severityChanged).toHaveLength(0)
+  })
+
+  it('detects severity changes for matching findings', () => {
+    const baseline = [base({ title: 'Escalated', severity: 'medium' })]
+    const comparison = [base({ title: 'Escalated', severity: 'critical' })]
+    const result = compareFindings(baseline, comparison)
+    expect(result.severityChanged).toHaveLength(1)
+    expect(result.unchangedFindings).toHaveLength(0)
+  })
+
+  it('handles empty findings on both sides', () => {
+    const result = compareFindings([], [])
+    expect(result.newFindings).toHaveLength(0)
+    expect(result.fixedFindings).toHaveLength(0)
+    expect(result.unchangedFindings).toHaveLength(0)
+    expect(result.severityChanged).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Adds a<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">frontend-only report comparison</span><span> </span>view at<span> </span><code class="md-inline-path-filename-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;"><span class="md-inline-path-prefix">/reports/</span><span class="md-inline-path-filename">compare</span></code><span> </span>so you can diff findings between two scans without exporting PDFs.</p><ul class="list-inside list-disc whitespace-normal [li_&amp;]:pl-6" data-streamdown="unordered-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; list-style-type: disc; white-space: normal; padding-left: 2em; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(0, 0, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Baseline vs comparison</span><span> </span>dropdowns load from<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">GET /reports</code><span> </span>and<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">GET /findings</code></li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Diff sections:</span><span> </span>new findings, fixed findings, unchanged, severity changed (matched by title + target + category)</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Failed scans with findings</span><span> </span>appear in the dropdowns (labeled<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">(scan failed)</code>), not only<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">status: ready</code></li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Reports page:</span><span> </span>“Compare Reports” link;<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">normalizeReport()</code><span> </span>avoids blank list when API omits<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">assets</code></li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Tests:</span><span> </span><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: rgb(36, 114, 200); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-filename">compareFindings.test.ts</span></code><span> </span>(6),<span> </span><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: rgb(36, 114, 200); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-filename">ReportCompare.test.tsx</span></code><span> </span>(2)</li></ul><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Closes #36.</p><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 4px; --tw-font-weight: 600; font-weight: 590; line-height: 1.42; font-size: 1.428em; margin-top: 16px; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Scope</h2><div class="ui-scroll-area" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scrollbar-size: 6px; --scrollbar-inset: 0px; --scrollbar-thumb-top-offset: 6px; --scroll-area-scroll-padding: 4px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr; margin: 1em 0px; border-color: color(srgb 0.8 0.8 0.8 / 0.08); border-style: solid; border-width: 0.8px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain auto; scrollbar-width: none !important;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: auto; min-width: 100%; max-width: 100%; min-height: 100%; display: flex; flex-direction: row; height: fit-content;">
Area | Change
-- | --
frontend/src/utils/compareFindings.ts | Diff logic
frontend/src/pages/ReportCompare.tsx | Compare UI
frontend/src/pages/Reports.tsx | Link + report normalization
frontend/src/routes.ts, App.tsx | Route /reports/compare

</div></div></div><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">No backend API changes.</p><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 4px; --tw-font-weight: 600; font-weight: 590; line-height: 1.42; font-size: 1.428em; margin-top: 16px; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">How to test</h2><ol class="list-inside list-decimal whitespace-normal [li_&amp;]:pl-6" data-streamdown="ordered-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; list-style-type: decimal; white-space: normal; padding-left: 2em; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(0, 0, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Start backend + frontend; set API key in Settings.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Run<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">at least two scans</span><span> </span>that produce findings (ready or failed).</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Open<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Reports → Compare Reports</span><span> </span>(or<span> </span><code class="md-inline-path-filename-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;"><span class="md-inline-path-prefix">/reports/</span><span class="md-inline-path-filename">compare</span></code>).</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Confirm both dropdowns list scans; failed ones show<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">(scan failed)</code>.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Pick baseline (older) and comparison (newer); verify four diff sections update.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Pick the same report in both dropdowns → “Select two different reports”.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">cd frontend</code><span> </span>→<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">npm test -- --run testing/unit/utils/compareFindings.test.ts testing/unit/pages/ReportCompare.test.tsx</code></li></ol><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 4px; --tw-font-weight: 600; font-weight: 590; line-height: 1.42; font-size: 1.428em; margin-top: 16px; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Notes</h2><ul class="list-inside list-disc whitespace-normal [li_&amp;]:pl-6" data-streamdown="unordered-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; list-style-type: disc; white-space: normal; padding-left: 2em; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(0, 0, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">Comparison uses stored findings per<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">task_id</code>, not report PDF export.</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;">If dropdowns are empty, you need two reports that each have findings (or API/auth failure).</li></ul><!--EndFragment-->
</body>
</html>