### PR TITLE
Validate task status query parameter

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -109,7 +109,7 @@ from .models import (
     TaskCreateRequest, TaskResponse, TaskResult,
     PluginListResponse, ErrorResponse, BulkDeleteRequest,
     NotificationRuleCreate, NotificationRuleUpdate,
-    NotificationChannelType,
+    NotificationChannelType, TaskStatus,
 )
 from .config import settings
 from .database import get_db
@@ -867,6 +867,15 @@ async def list_tasks(
         where_clauses.append("plugin_id = ?")
         params.append(plugin_id)
     if status:
+        try:
+            status = TaskStatus(status).value
+        except ValueError:
+            allowed_values = ", ".join([s.value for s in TaskStatus])
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid task status '{status}'. Allowed values: {allowed_values}"
+            )
+
         where_clauses.append("status = ?")
         params.append(status)
 

--- a/testing/backend/test_task_pagination.py
+++ b/testing/backend/test_task_pagination.py
@@ -57,6 +57,23 @@ class TestTasksPagination:
         response = test_client.get(f"/api/v1/tasks?{qs}")
         assert response.status_code == 422
 
+    def test_status_filter_valid(self, test_client):
+        response = test_client.get("/api/v1/tasks?status=completed")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "tasks" in data
+        assert all(task["status"] == "completed" for task in data["tasks"])
+
+    def test_status_filter_invalid(self, test_client):
+        response = test_client.get("/api/v1/tasks?status=invalid-status")
+        assert response.status_code == 400
+
+        data = response.json()
+        assert data["detail"] == (
+            "Invalid task status 'invalid-status'. Allowed values: queued, running, completed, failed, cancelled"
+        )
+
     def test_first_page_previous_is_null(self, test_client):
         """Test that previous is None on first page"""
         response = test_client.get("/api/v1/tasks?page=1&per_page=10")

--- a/testing/backend/test_task_pagination.py
+++ b/testing/backend/test_task_pagination.py
@@ -124,7 +124,7 @@ class TestTasksPagination:
     def test_next_url_encodes_filtered_pagination_params(self, test_client):
         """Test that filtered pagination links URL-encode query values."""
         plugin_id = "web scanner/alpha"
-        status = "queued & reviewed"
+        status = "queued"
         asyncio.run(
             _insert_task("encoded-filter-1", plugin_id, status, "2026-06-02T10:00:00")
         )
@@ -146,5 +146,5 @@ class TestTasksPagination:
         next_url = response.json()["pagination"]["next"]
         assert next_url == (
             "/api/v1/tasks?page=2&per_page=1&"
-            "plugin_id=web+scanner%2Falpha&status=queued+%26+reviewed"
+            "plugin_id=web+scanner%2Falpha&status=queued"
         )


### PR DESCRIPTION
## Description
Added validation for the optional status query parameter in GET /api/v1/tasks.

Previously, invalid status values returned an empty result set. The endpoint now validates the value against the supported TaskStatus enum values and returns a structured 400 Bad Request response for invalid inputs.

Also added tests covering both valid and invalid status filters.

## Related Issues
Closes #467

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
 pytest testing/backend/test_task_pagination.py 
 Result:
 12 test passed

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
