### PR TITLE
docs: sync README repository map with actual directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ The project is designed to be:
 - `frontend/testing/`: frontend unit and end-to-end test files
 - `docs/`: supporting project documentation
 - `scripts/`: helper scripts for signing, benchmarking, and maintenance
+- `wordlists/`: reusable wordlists and scan input dictionaries
+- `output/`: generated scan exports, reports, and other runtime artifacts
+- `scratch/`: temporary workspace used during scan execution and experimentation
 
 ## Prerequisites
 


### PR DESCRIPTION
## Changes

* Updated the README repository map to reflect the current project structure.
* Added missing directories:

  * `wordlists/`
  * `output/`
  * `scratch/`
* Clarified the purpose of generated and temporary directories.

Fixes #587
