### PR TITLE
feat(notifications): dispatch alerts after scan completes (PR 4 of #254)

### DIFF
--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -19,12 +19,13 @@ from .cache import get_cache
 from .config import settings
 from .database import get_db
 from .plugins import get_plugin_manager
-from .models import TaskStatus, ScanPhase
+from .models import NotificationDeliveryStatus, TaskStatus, ScanPhase
 from .ratelimit import concurrent_limiter
 from .risk_scoring import compute_risk_score, compute_risk_factors
 from .capabilities import CapabilityEnforcer, CapabilityDeniedError, build_enforcer_from_settings
 from .parser_sandbox import run_parser_in_sandbox, ParserSandboxError
 from .network_policy import get_policy_engine
+from .notification_service import process_task_notifications
 
 def _parse_discovered_at(finding: dict) -> Optional[datetime]:
     """Extract and parse discovered_at from a finding dict, or return current UTC time."""
@@ -537,6 +538,8 @@ class TaskExecutor:
                     output=output
                 )
                 await self._broadcast_phase(task_id, ScanPhase.REPORTING.value)
+
+            await self._dispatch_task_notifications(db, task_id)
 
             await self._broadcast_phase(task_id, ScanPhase.FINISHED.value)
             await self._broadcast(task_id, "status", final_status)
@@ -1302,6 +1305,25 @@ class TaskExecutor:
             "technologies": sorted(list(set(techs))),
             "findings": findings
         }
+
+    async def _dispatch_task_notifications(self, db, task_id: str) -> None:
+        """Evaluate notification rules for all findings on a completed task."""
+        try:
+            results = await process_task_notifications(db, task_id)
+            sent = sum(
+                1
+                for r in results
+                if not r.skipped and r.status == NotificationDeliveryStatus.SUCCESS
+            )
+            if sent:
+                logger.info("Task %s: delivered %d notification(s)", task_id, sent)
+        except Exception as exc:
+            logger.warning(
+                "Task %s: notification dispatch failed: %s",
+                task_id,
+                exc,
+                exc_info=True,
+            )
 
     async def _invalidate_cached_views(self):
         """Clear cached aggregate views after write operations."""

--- a/testing/backend/unit/test_executor_notifications.py
+++ b/testing/backend/unit/test_executor_notifications.py
@@ -1,0 +1,151 @@
+"""Executor integration with notification dispatch (PR 4 of #254)."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.secuscan.config import settings
+from backend.secuscan.database import get_db, init_db
+from backend.secuscan.executor import TaskExecutor
+from backend.secuscan.models import TaskStatus
+
+
+@pytest.mark.asyncio
+async def test_execute_task_dispatches_notifications_after_findings(setup_test_environment):
+    """Successful task completion should trigger process_task_notifications."""
+    await init_db(settings.database_path)
+    db = await get_db()
+
+    task_id = str(uuid.uuid4())
+    await db.execute(
+        """
+        INSERT INTO tasks (id, plugin_id, tool_name, target, inputs_json,
+                           status, consent_granted, safe_mode)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            task_id,
+            "nmap",
+            "nmap",
+            "127.0.0.1",
+            '{"target":"127.0.0.1"}',
+            TaskStatus.QUEUED.value,
+            1,
+            1,
+        ),
+    )
+
+    executor = TaskExecutor()
+
+    async def fake_command(*args, **kwargs):
+        return "80/tcp open http", 0
+
+    mock_dispatch = AsyncMock(return_value=[])
+
+    with (
+        patch.object(executor, "_execute_command", side_effect=fake_command),
+        patch("backend.secuscan.executor.concurrent_limiter") as mock_limiter,
+        patch("backend.secuscan.executor.get_plugin_manager") as mock_pm,
+        patch(
+            "backend.secuscan.executor.process_task_notifications",
+            mock_dispatch,
+        ),
+    ):
+        mock_limiter.release = AsyncMock()
+
+        mock_plugin = MagicMock()
+        mock_plugin.name = "nmap"
+        mock_plugin.presets = {}
+        mock_plugin.docker_image = None
+        mock_plugin.output = {"parser": "builtin_nmap", "format": "text"}
+        mock_plugin.category = "Network"
+        mock_plugin.id = "nmap"
+        mock_plugin.capabilities = []
+        mock_plugin.safety = {"level": "safe"}
+        mock_pm.return_value.get_plugin.return_value = mock_plugin
+        mock_pm.return_value.build_command.return_value = ["nmap", "127.0.0.1"]
+        mock_pm.return_value.plugins_dir = MagicMock()
+        mock_pm.return_value.plugins_dir.__truediv__ = MagicMock(
+            return_value=MagicMock(
+                __truediv__=MagicMock(return_value=MagicMock(exists=lambda: False))
+            )
+        )
+
+        await executor.execute_task(task_id)
+
+    mock_dispatch.assert_awaited_once()
+    assert mock_dispatch.await_args.args[1] == task_id
+
+    row = await db.fetchone("SELECT status FROM tasks WHERE id = ?", (task_id,))
+    assert row["status"] in (TaskStatus.COMPLETED.value, TaskStatus.FAILED.value)
+    await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_execute_task_survives_notification_dispatch_failure(setup_test_environment):
+    """Notification errors must not prevent task completion."""
+    await init_db(settings.database_path)
+    db = await get_db()
+
+    task_id = str(uuid.uuid4())
+    await db.execute(
+        """
+        INSERT INTO tasks (id, plugin_id, tool_name, target, inputs_json,
+                           status, consent_granted, safe_mode)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            task_id,
+            "nmap",
+            "nmap",
+            "127.0.0.1",
+            '{"target":"127.0.0.1"}',
+            TaskStatus.QUEUED.value,
+            1,
+            1,
+        ),
+    )
+
+    executor = TaskExecutor()
+
+    async def fake_command(*args, **kwargs):
+        return "80/tcp open http", 0
+
+    with (
+        patch.object(executor, "_execute_command", side_effect=fake_command),
+        patch("backend.secuscan.executor.concurrent_limiter") as mock_limiter,
+        patch("backend.secuscan.executor.get_plugin_manager") as mock_pm,
+        patch(
+            "backend.secuscan.executor.process_task_notifications",
+            AsyncMock(side_effect=RuntimeError("webhook down")),
+        ),
+    ):
+        mock_limiter.release = AsyncMock()
+
+        mock_plugin = MagicMock()
+        mock_plugin.name = "nmap"
+        mock_plugin.presets = {}
+        mock_plugin.docker_image = None
+        mock_plugin.output = {"parser": "builtin_nmap", "format": "text"}
+        mock_plugin.category = "Network"
+        mock_plugin.id = "nmap"
+        mock_plugin.capabilities = []
+        mock_plugin.safety = {"level": "safe"}
+        mock_pm.return_value.get_plugin.return_value = mock_plugin
+        mock_pm.return_value.build_command.return_value = ["nmap", "127.0.0.1"]
+        mock_pm.return_value.plugins_dir = MagicMock()
+        mock_pm.return_value.plugins_dir.__truediv__ = MagicMock(
+            return_value=MagicMock(
+                __truediv__=MagicMock(return_value=MagicMock(exists=lambda: False))
+            )
+        )
+
+        await executor.execute_task(task_id)
+
+    row = await db.fetchone(
+        "SELECT status, completed_at FROM tasks WHERE id = ?", (task_id,)
+    )
+    assert row["completed_at"] is not None
+    assert row["status"] in (TaskStatus.COMPLETED.value, TaskStatus.FAILED.value)
+    await db.disconnect()


### PR DESCRIPTION
## Description
 PR 4 of 5 for #254 — calls process_task_notifications() after findings are persisted. Errors are logged and do not fail tasks.
 No Settings UI (PR 5).



## Type of Change
- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Test 1 — Hook runs after a scan
test_execute_task_dispatches_notifications_after_findings

Test 2 — Scan survives notification errors
test_execute_task_survives_notification_dispatch_failure

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
