### PR TITLE
fix: wrap bulk delete in transaction for atomicity (issue #402)

### DIFF
--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -369,6 +369,22 @@ class Database:
         await self.connection.execute(query, params)
         await self.connection.commit()
 
+    async def execute_no_commit(self, query: str, params: tuple = ()):
+        """Execute a write query without committing (for use inside transactions)."""
+        await self.connection.execute(query, params)
+
+    async def begin(self):
+        """Begin a transaction."""
+        await self.connection.execute("BEGIN")
+
+    async def commit(self):
+        """Commit the current transaction."""
+        await self.connection.commit()
+
+    async def rollback(self):
+        """Roll back the current transaction."""
+        await self.connection.rollback()
+
     async def fetchone(self, query: str, params: tuple = ()) -> Optional[Dict]:
         """Fetch one row."""
         async with await self.connection.execute(query, params) as cursor:

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -1001,6 +1001,9 @@ async def delete_task_records(task_ids: List[str]):
 
     Processes IDs in chunks of SQLITE_CHUNK_SIZE to stay under
     SQLite's SQLITE_LIMIT_VARIABLE_NUMBER = 999 limit.
+
+    The deletion is wrapped in a transaction so that a failure mid-way
+    (e.g. crash, constraint violation) does not leave orphaned records.
     """
     if not task_ids:
         return
@@ -1018,16 +1021,50 @@ async def delete_task_records(task_ids: List[str]):
         )
         all_task_rows.extend(rows)
 
-    # Delete associated records in chunks
-    for i in range(0, len(task_ids), SQLITE_CHUNK_SIZE):
-        chunk = task_ids[i : i + SQLITE_CHUNK_SIZE]
-        placeholders = ",".join(["?"] * len(chunk))
-        await db.execute(f"DELETE FROM findings   WHERE task_id IN ({placeholders})", tuple(chunk))
-        await db.execute(f"DELETE FROM reports    WHERE task_id IN ({placeholders})", tuple(chunk))
-        await db.execute(f"DELETE FROM audit_log  WHERE task_id IN ({placeholders})", tuple(chunk))
-        await db.execute(f"DELETE FROM tasks      WHERE id       IN ({placeholders})", tuple(chunk))
+    # Delete associated records in chunks, atomic within a transaction
+    await db.begin()
+    try:
+        # Re-check running status inside the transaction to prevent the
+        # race where a task starts running between the check and the delete.
+        for i in range(0, len(task_ids), SQLITE_CHUNK_SIZE):
+            chunk = task_ids[i : i + SQLITE_CHUNK_SIZE]
+            placeholders = ",".join(["?"] * len(chunk))
+            running = await db.fetchone(
+                f"SELECT 1 FROM tasks WHERE id IN ({placeholders}) AND status = 'running' LIMIT 1",
+                tuple(chunk)
+            )
+            if running:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot delete running tasks. Abort them first."
+                )
 
-    # Cleanup files on disk
+        for i in range(0, len(task_ids), SQLITE_CHUNK_SIZE):
+            chunk = task_ids[i : i + SQLITE_CHUNK_SIZE]
+            placeholders = ",".join(["?"] * len(chunk))
+            await db.execute_no_commit(
+                f"DELETE FROM findings   WHERE task_id IN ({placeholders})", tuple(chunk)
+            )
+            await db.execute_no_commit(
+                f"DELETE FROM reports    WHERE task_id IN ({placeholders})", tuple(chunk)
+            )
+            await db.execute_no_commit(
+                f"DELETE FROM audit_log  WHERE task_id IN ({placeholders})", tuple(chunk)
+            )
+            await db.execute_no_commit(
+                f"DELETE FROM tasks      WHERE id       IN ({placeholders})", tuple(chunk)
+            )
+        await db.commit()
+    except HTTPException:
+        await db.rollback()
+        raise
+    except Exception:
+        await db.rollback()
+        raise
+
+    # Cleanup files on disk (outside the transaction — file deletion is not
+    # transactional; a failure here does not leave the DB in an inconsistent
+    # state).
     for row in all_task_rows:
         if row and row["raw_output_path"]:
             try:

--- a/testing/backend/integration/test_task_cleanup.py
+++ b/testing/backend/integration/test_task_cleanup.py
@@ -342,6 +342,67 @@ async def test_bulk_delete_with_running_task_returns_400(app_client):
         assert len(rows) == 1, f"Task {tid} should NOT have been deleted after 400"
 
 
+@pytest.mark.asyncio
+async def test_bulk_delete_atomicity_no_partial_delete_with_running_task(app_client):
+    """Atomicity: running-task rejection rolls back ALL deletes — no orphaned records."""
+    db = app_client._db
+    db_path = app_client._db_path
+
+    task_ok = await insert_task(db, status="completed")
+    finding_id = await insert_finding(db, task_ok)
+    report_id = await insert_report(db, task_ok)
+    await insert_audit_log(db, task_ok)
+
+    task_running = await insert_task(db, status="running")
+
+    resp = await app_client.request(
+        "DELETE", "/api/v1/tasks/bulk", json=[task_ok, task_running],
+    )
+    assert resp.status_code == 400, resp.text
+
+    # Task rows must survive
+    for tid in (task_ok, task_running):
+        rows = await db_fetchall(db_path, "SELECT id FROM tasks WHERE id = ?", (tid,))
+        assert len(rows) == 1, f"Task {tid} should NOT have been deleted"
+
+    # Associated records must survive
+    rows = await db_fetchall(db_path, "SELECT id FROM findings WHERE id = ?", (finding_id,))
+    assert len(rows) == 1, "Finding should NOT have been deleted"
+
+    rows = await db_fetchall(db_path, "SELECT id FROM reports WHERE id = ?", (report_id,))
+    assert len(rows) == 1, "Report should NOT have been deleted"
+
+    rows = await db_fetchall(db_path, "SELECT id FROM audit_log WHERE task_id = ?", (task_ok,))
+    assert len(rows) >= 1, "Audit log should NOT have been deleted"
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_cascades_to_associated_records(app_client):
+    """Bulk delete removes findings, reports, and audit_log for each deleted task."""
+    db = app_client._db
+    db_path = app_client._db_path
+
+    task_id = await insert_task(db, status="completed")
+    finding_id = await insert_finding(db, task_id)
+    report_id = await insert_report(db, task_id)
+    await insert_audit_log(db, task_id)
+
+    resp = await app_client.request(
+        "DELETE", "/api/v1/tasks/bulk", json=[task_id],
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["deleted_count"] == 1
+
+    rows = await db_fetchall(db_path, "SELECT id FROM findings WHERE id = ?", (finding_id,))
+    assert len(rows) == 0, "Finding should have been deleted"
+
+    rows = await db_fetchall(db_path, "SELECT id FROM reports WHERE id = ?", (report_id,))
+    assert len(rows) == 0, "Report should have been deleted"
+
+    rows = await db_fetchall(db_path, "SELECT id FROM audit_log WHERE task_id = ?", (task_id,))
+    assert len(rows) == 0, "Audit log should have been deleted"
+
+
 # ---------------------------------------------------------------------------
 # Tests: DELETE /api/v1/tasks/clear
 # ---------------------------------------------------------------------------

--- a/testing/backend/unit/test_bulk_delete_sqlite_limit.py
+++ b/testing/backend/unit/test_bulk_delete_sqlite_limit.py
@@ -186,9 +186,13 @@ class TestDeleteTaskRecordsChunking:
 
         mock_db = AsyncMock()
         mock_db.fetchall = AsyncMock(return_value=[])
+        mock_db.fetchone = AsyncMock(return_value=None)
+        mock_db.begin = AsyncMock()
+        mock_db.commit = AsyncMock()
+        mock_db.rollback = AsyncMock()
         async def capture_execute(sql, params=()):
             captured_sql.append(sql)
-        mock_db.execute = capture_execute
+        mock_db.execute_no_commit = capture_execute
 
         with patch("backend.secuscan.routes.get_db", return_value=mock_db):
             await delete_task_records(ids)
@@ -218,10 +222,14 @@ class TestDeleteTaskRecordsChunking:
 
         mock_db = AsyncMock()
         mock_db.fetchall = AsyncMock(return_value=[])
+        mock_db.fetchone = AsyncMock(return_value=None)
+        mock_db.begin = AsyncMock()
+        mock_db.commit = AsyncMock()
+        mock_db.rollback = AsyncMock()
         async def capture_execute(sql, params=()):
             captured_sql.append(sql)
             captured_params.append(params)
-        mock_db.execute = capture_execute
+        mock_db.execute_no_commit = capture_execute
 
         with patch("backend.secuscan.routes.get_db", return_value=mock_db):
             await delete_task_records(ids)
@@ -256,4 +264,9 @@ class TestDeleteTaskRecordsChunking:
             await delete_task_records([])
 
         mock_db.execute.assert_not_called()
+        mock_db.execute_no_commit.assert_not_called()
         mock_db.fetchall.assert_not_called()
+        mock_db.fetchone.assert_not_called()
+        mock_db.begin.assert_not_called()
+        mock_db.commit.assert_not_called()
+        mock_db.rollback.assert_not_called()


### PR DESCRIPTION
## Problem

\delete_task_records()\ deletes from \indings\, \eports\, \udit_log\, and \	asks\ without a transaction. Each \DELETE\ auto-commits independently, so a crash mid-way can orphan records. There's also a race window between the running-task check and the actual deletion.

## Changes

### \ackend/secuscan/database.py\
- Added \execute_no_commit()\, \egin()\, \commit()\, \ollback()\ methods to the \Database\ class

### \ackend/secuscan/routes.py\
- \delete_task_records()\ now wraps all DELETE statements in a \BEGIN/COMMIT/ROLLBACK\ transaction — any failure mid-way rolls back completely
- Re-checks \status = 'running'\ *inside* the transaction to prevent the race where a task starts running between the check and the delete
- File cleanup (raw output files) happens *outside* the transaction, since file I/O is not transactional and a failure there doesn't leave the DB inconsistent

### \	esting/backend/integration/test_task_cleanup.py\
- \	est_bulk_delete_atomicity_no_partial_delete_with_running_task\ — verifies that when a running task is present, NOTHING is deleted (not even associated findings/reports/audit_log)
- \	est_bulk_delete_cascades_to_associated_records\ — verifies that successful bulk delete removes all associated records atomically

### \	esting/backend/unit/test_bulk_delete_sqlite_limit.py\
- Updated mock setup in chunking unit tests to account for new transaction methods (\etchone\, \execute_no_commit\, \egin\, \commit\, \ollback\)

## Test Plan
- \pytest testing/backend/integration/test_task_cleanup.py\ — 14 passed
- \pytest testing/backend/integration/test_bulk_delete_contract.py\ — 12 passed
- \pytest testing/backend/unit/test_bulk_delete_sqlite_limit.py\ — 12 passed

Closes #402