### PR TITLE
fix(routes): rate limit the scheduler tick endpoint

### DIFF
--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -98,6 +98,12 @@ class Settings(BaseSettings):
     rate_limit_read_heavy_limit: int = 100
     rate_limit_read_heavy_window: int = 60
 
+    # Scheduler tick: one trigger per 10 seconds allows legitimate external
+    # callers while preventing a tight loop from forcing continuous workflow
+    # execution and exhausting scan quotas.
+    rate_limit_scheduler_tick_limit: int = 1
+    rate_limit_scheduler_tick_window: int = 10
+
     trusted_proxies: List[str] = ["127.0.0.1", "::1"]
 
     # Sandbox

--- a/backend/secuscan/ratelimit.py
+++ b/backend/secuscan/ratelimit.py
@@ -272,6 +272,12 @@ admin_limiter = EndpointRateLimiter(
     window_seconds=60
 )
 
+scheduler_tick_limiter = EndpointRateLimiter(
+    bucket_name="scheduler_tick",
+    limit=settings.rate_limit_scheduler_tick_limit,
+    window_seconds=settings.rate_limit_scheduler_tick_window
+)
+
 async def reset_all_endpoint_limiters():
     """Reset rate limiting history for all route-specific buckets."""
     await task_start_limiter.reset()
@@ -279,3 +285,4 @@ async def reset_all_endpoint_limiters():
     await report_download_limiter.reset()
     await read_heavy_limiter.reset()
     await admin_limiter.reset()
+    await scheduler_tick_limiter.reset()

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -120,6 +120,7 @@ from .ratelimit import (
     task_start_limiter, vault_limiter,
     report_download_limiter, read_heavy_limiter,
     resolve_client_identity, admin_limiter,
+    scheduler_tick_limiter,
 )
 from .validation import validate_target, validate_task_start_payload, validate_url
 from .reporting import reporting
@@ -1325,7 +1326,7 @@ async def delete_workflow(workflow_id: str):
     return {"workflow_id": workflow_id, "deleted": True}
 
 
-@router.post("/workflows/scheduler/tick")
+@router.post("/workflows/scheduler/tick", dependencies=[Depends(scheduler_tick_limiter)])
 async def trigger_workflow_tick():
     await scheduler.tick()
     return {"tick": "ok"}

--- a/testing/backend/unit/test_endpoint_rate_limiter.py
+++ b/testing/backend/unit/test_endpoint_rate_limiter.py
@@ -275,6 +275,39 @@ def test_route_level_integration_and_independent_buckets(test_client, monkeypatc
     assert resp_vault1.headers["X-RateLimit-Remaining"] == "1"
 
 
+def test_scheduler_tick_is_rate_limited(test_client, monkeypatch):
+    """The scheduler tick endpoint must throttle rapid repeated calls.
+
+    Without a limiter, any API key holder could call the tick endpoint in a
+    tight loop and force continuous workflow execution. This test confirms the
+    limiter is wired: with a limit of 1, the second call within the window is
+    rejected with 429.
+    """
+    from backend.secuscan import workflows
+    from backend.secuscan.ratelimit import scheduler_tick_limiter
+
+    # Avoid any real scheduling side effects; only the limiter is under test.
+    async def _noop_tick():
+        return None
+
+    monkeypatch.setattr(workflows.scheduler, "tick", _noop_tick)
+
+    # Tighten the limiter to one call per window for a deterministic assertion.
+    scheduler_tick_limiter.limit = 1
+    scheduler_tick_limiter.window_seconds = 10
+    asyncio.run(scheduler_tick_limiter.reset())
+
+    first = test_client.post("/api/v1/workflows/scheduler/tick")
+    assert first.status_code == 200
+    assert first.json() == {"tick": "ok"}
+    assert first.headers["X-RateLimit-Limit"] == "1"
+    assert first.headers["X-RateLimit-Remaining"] == "0"
+
+    second = test_client.post("/api/v1/workflows/scheduler/tick")
+    assert second.status_code == 429
+    assert "Retry-After" in second.headers
+
+
 # ── RateLimiter per-client keying tests ───────────────────────────────────────
 
 


### PR DESCRIPTION
## Description

`POST /api/v1/workflows/scheduler/tick` was the only execution endpoint in `routes.py` without a rate limiter. Every other resource-intensive endpoint uses the `Depends(...)` limiter pattern (`task_start_limiter`, `vault_limiter`, `read_heavy_limiter`, `report_download_limiter`). Any API key holder could call the tick endpoint in a tight loop, triggering every enabled workflow on each tick with no throttling, which bypasses the scheduling interval and can exhaust scan quotas or flood the task queue.

## Related Issue

Closes #474

## Changes Made

| File | Change |
|---|---|
| `backend/secuscan/config.py` | Added `rate_limit_scheduler_tick_limit` (default 1) and `rate_limit_scheduler_tick_window` (default 10) settings |
| `backend/secuscan/ratelimit.py` | Added `scheduler_tick_limiter` instance and registered it in `reset_all_endpoint_limiters` |
| `backend/secuscan/routes.py` | Imported `scheduler_tick_limiter` and attached it to the tick endpoint via `dependencies=[Depends(scheduler_tick_limiter)]` |
| `testing/backend/unit/test_endpoint_rate_limiter.py` | Added a route-level test asserting the second tick within the window returns 429 |

The default of one tick per 10 seconds permits legitimate external triggers while blocking runaway loops. Both values are configurable through settings, consistent with the other endpoint limiters.

## Testing Done

Verified directly against the real limiter and config:

```
tick limit: 1 window: 10
limiter bucket: scheduler_tick limit: 1 window: 10
after 1st call remaining: 0
second call blocked with status: 429
reset_all_endpoint_limiters includes scheduler_tick: OK
```

The added integration test (`test_scheduler_tick_is_rate_limited`) mocks `scheduler.tick` so only the limiter is exercised, then asserts the first POST returns 200 and the second returns 429.

## Checklist

- [x] Follows the existing `EndpointRateLimiter` pattern used by other endpoints
- [x] New settings are configurable and have sensible defaults
- [x] Limiter is reset alongside the others for test isolation
- [x] No merge conflicts with the base branch
- [x] Changes are focused on the reported surface