### PR TITLE
test: add Scans.test.tsx for paginated Scans page with ConfirmModal

### DIFF
--- a/frontend/testing/unit/pages/Scans.test.tsx
+++ b/frontend/testing/unit/pages/Scans.test.tsx
@@ -1,0 +1,216 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import Scans from '../../../src/pages/Scans'
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../../../src/api', () => ({
+  API_BASE: 'http://localhost:5000',
+  deleteTask: vi.fn().mockResolvedValue({}),
+  clearAllTasks: vi.fn().mockResolvedValue({}),
+  bulkDeleteTasks: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('../../../src/routes', () => ({
+  routePath: { task: (id: string) => `/task/${id}` },
+}))
+
+vi.mock('../../../src/utils/date', () => ({
+  parseDateSafe: (d: any) => new Date(d || Date.now()),
+  formatLocaleDate: () => '2024-01-01',
+  formatLocaleTime: () => '12:00',
+}))
+
+vi.mock('../../../src/components/ConfirmModal', () => ({
+  ConfirmModal: ({ isOpen, onConfirm, title }: any) =>
+    isOpen ? (
+      <div>
+        <span>{title}</span>
+        <button onClick={onConfirm}>Confirm</button>
+      </div>
+    ) : null,
+}))
+
+vi.mock('../../../src/components/Pagination', () => ({
+  default: ({ page, onNext, onPrev }: any) => (
+    <div>
+      <button onClick={onPrev}>Prev</button>
+      <span>Page {page}</span>
+      <button onClick={onNext}>Next</button>
+    </div>
+  ),
+}))
+
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}))
+
+Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, value: 800 })
+Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 600 })
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeTask(overrides: any = {}) {
+  const id = overrides.task_id ?? `task-${Math.random().toString(36).slice(2)}`
+  return {
+    task_id: id,
+    plugin_id: 'nmap',
+    tool: 'nmap',
+    target: 'example.com',
+    status: 'completed' as const,
+    created_at: '2024-01-01T00:00:00Z',
+    duration_seconds: 30,
+    ...overrides,
+  }
+}
+
+function mockFetch(tasks: ReturnType<typeof makeTask>[], total?: number) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({
+      tasks,
+      pagination: { total_items: total ?? tasks.length },
+    }),
+  } as any)
+}
+
+function renderScans() {
+  return render(
+    <MemoryRouter>
+      <Scans />
+    </MemoryRouter>
+  )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Scans — task list', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders the page header', () => {
+    mockFetch([])
+    renderScans()
+    expect(screen.getByRole('heading', { name: /Operational/i })).toBeInTheDocument()
+  })
+
+  it('shows empty state when there are no tasks', async () => {
+    mockFetch([])
+    renderScans()
+    await waitFor(() => expect(screen.getByText(/Archive Isolated/i)).toBeInTheDocument())
+  })
+
+  it('renders task cards for loaded tasks', async () => {
+    const tasks = [makeTask({ tool: 'nmap', target: 'target.com' })]
+    mockFetch(tasks)
+    renderScans()
+    await waitFor(() => expect(screen.getByText('nmap')).toBeInTheDocument())
+    expect(screen.getByText('target.com')).toBeInTheDocument()
+  })
+
+  it('status filter buttons are rendered and clickable', async () => {
+    mockFetch([])
+    renderScans()
+    const allBtn = screen.getByRole('button', { name: /ALL_OPERATIONS/i })
+    expect(allBtn).toBeInTheDocument()
+    await userEvent.click(allBtn)
+  })
+
+  it('select-all selects all tasks', async () => {
+    const tasks = [makeTask({ task_id: 'task-1' }), makeTask({ task_id: 'task-2' })]
+    mockFetch(tasks)
+    renderScans()
+
+    await waitFor(() => expect(screen.getAllByText(/nmap/i).length).toBeGreaterThan(0))
+
+    await userEvent.click(screen.getByRole('button', { name: /Select_All/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('2')).toBeInTheDocument()
+    })
+  })
+
+  it('cancel clears selection', async () => {
+    const tasks = [makeTask({ task_id: 'task-1' })]
+    mockFetch(tasks)
+    renderScans()
+
+    await waitFor(() => expect(screen.getByText('nmap')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByRole('button', { name: /Select_All/i }))
+    await waitFor(() => expect(screen.getByText(/Records_Selected_For_Pruning/i)).toBeInTheDocument())
+
+    await userEvent.click(screen.getByRole('button', { name: /Cancel/i }))
+
+    await waitFor(() => {
+      const selectAllBtn = screen.getByRole('button', { name: /Select_All/i })
+      expect(selectAllBtn.className).not.toContain('bg-rag-blue')
+    })
+  })
+
+  it('polls every 5 seconds', async () => {
+    mockFetch([])
+    renderScans()
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(5000)
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2))
+  })
+
+  it('shows pagination when total exceeds page limit', async () => {
+    const tasks = Array.from({ length: 10 }, (_, i) => makeTask({ task_id: `task-${i}` }))
+    mockFetch(tasks, 25)
+    renderScans()
+
+    await waitFor(() => expect(screen.getAllByText(/nmap/i).length).toBeGreaterThan(0))
+    expect(screen.getByText(/Page 1/i)).toBeInTheDocument()
+  })
+
+  it('negative: Delete_Record button NOT shown for running tasks', async () => {
+    const tasks = [makeTask({ status: 'running' })]
+    mockFetch(tasks)
+    renderScans()
+
+    await waitFor(() => expect(screen.getByText('nmap')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('nmap').closest('[class*="cursor-pointer"]')!)
+
+    expect(screen.queryByText('Delete_Record')).not.toBeInTheDocument()
+  })
+
+  it('negative: bulk delete not triggered with empty selection', async () => {
+    mockFetch([makeTask()])
+    renderScans()
+
+    await waitFor(() => expect(screen.getByText('nmap')).toBeInTheDocument())
+
+    const { bulkDeleteTasks } = await import('../../../src/api')
+    expect(bulkDeleteTasks).not.toHaveBeenCalled()
+  })
+
+  it('shows confirm modal when deleting a task', async () => {
+    const tasks = [makeTask({ task_id: 'task-1', status: 'completed' })]
+    mockFetch(tasks)
+    renderScans()
+
+    await waitFor(() => expect(screen.getByText('nmap')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('nmap').closest('[class*="cursor-pointer"]')!)
+    await waitFor(() => expect(screen.getByText('Delete_Record')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('Delete_Record'))
+
+    await waitFor(() => expect(screen.getByText('Delete Scan Record')).toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
**Description of changes made:**
Added `frontend/testing/unit/pages/Scans.test.tsx` — unit tests for the paginated `Scans.tsx` page.

**Reasons for the changes:**
The Scans page was refactored to use pagination, ConfirmModal, and Pagination components. There was no test coverage for the new implementation. This adds it.

**How to test:**

```
cd frontend && npm install
npx vitest run testing/unit/pages/Scans.test.tsx --reporter=verbose
```
All 11 tests should pass