### PR TITLE
docs: update repository map in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,13 @@ The project is designed to be:
 ## Repository Map
 
 - `backend/`: FastAPI app, execution logic, database/config, plugin loading, workflows
+- `backend/data/`: backend-specific datasets and resources used by scanners
+- `backend/wordlists/`: backend scanning wordlists and supporting resources
 - `frontend/`: React + Vite app, routes, pages, shared components, and test config
 - `plugins/`: scanner metadata, parser code, and plugin-specific helpers
-- `testing/backend/`: Python unit and integration tests plus backend test scripts
-- `frontend/testing/`: frontend unit and end-to-end test files
+- `testing/`: shared test utilities, backend test scripts, and validation helpers
+- `frontend/testing/`: frontend unit and integration test files
+- `frontend/e2e/`: Playwright end-to-end test suites
 - `docs/`: supporting project documentation
 - `scripts/`: helper scripts for signing, benchmarking, and maintenance
 - `.github/`: GitHub Actions workflows, issue templates, and contributor automation


### PR DESCRIPTION
## Description

Updated the Repository Map section in the README to better reflect the current repository structure and improve contributor discoverability.

### Changes Made

* Added `backend/data/`
* Added `backend/wordlists/`
* Added `frontend/e2e/`
* Replaced the outdated `testing/backend/` entry with the top-level `testing/` directory
* Clarified testing-related directory descriptions

## Related Issues

#587 

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] Documentation update

## How Has This Been Tested?

* Compared the README Repository Map against the current repository directory structure using `tree -L 2`
* Verified that contributor-relevant directories present in the repository are represented in the README
* Confirmed that generated/runtime directories remain appropriately described

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
