### PR TITLE
docs: add field help text for volatility plugin metadata

### DIFF
--- a/plugins/volatility/metadata.json
+++ b/plugins/volatility/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83e\udde0",
+  "icon": "🧠",
   "engine": {
     "type": "cli",
     "binary": "volatility3"
@@ -27,7 +27,8 @@
       "label": "Memory Dump Path",
       "type": "string",
       "required": true,
-      "placeholder": "/tmp/memdump.raw"
+      "placeholder": "/tmp/memdump.raw",
+      "help": "Absolute path to the raw memory image file to analyse (e.g. /tmp/memdump.raw). Supported formats include .raw, .mem, .vmem, and .lime."
     },
     {
       "id": "plugin_name",
@@ -66,5 +67,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "b4c467aea9e0da68860eb34289de63f16d8fb03851cb5e85c1895345e3d892fc"
+  "checksum": "886d2aa358ca55bb4bd49ec90ac5dcf0cc7d8962c21daeec78bd77128fc1f888"
 }

--- a/plugins/volatility/metadata.json
+++ b/plugins/volatility/metadata.json
@@ -67,5 +67,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "886d2aa358ca55bb4bd49ec90ac5dcf0cc7d8962c21daeec78bd77128fc1f888"
+  "checksum": "733f04bb43785f9b3350876fe9bd9c88e3294b58f540175877d34636091f1df9"
 }


### PR DESCRIPTION
Fixes #535

## Changes
- Added `help` text to the `target` field in `plugins/volatility/metadata.json`
- Refreshed plugin checksum after metadata edit

## What the help text says
Explains that the field expects an absolute path to a raw memory image file, with supported formats (.raw, .mem, .vmem, .lime).