### PR TITLE
fix: sanitize plugin command placeholders

### DIFF
--- a/backend/secuscan/plugins.py
+++ b/backend/secuscan/plugins.py
@@ -15,6 +15,7 @@ import hmac
 from .models import PluginMetadata, PluginFieldType
 from .config import settings
 from .capabilities import validate_capability_list, ALL_CAPABILITIES
+from .validation import sanitize_input
 
 # Port specifications: one or more comma-separated port numbers or port ranges.
 # Valid: "22", "80,443", "1-1000", "22,80,1000-2000"
@@ -378,7 +379,7 @@ class PluginManager:
                 return None
 
             placeholder = "{" + var_name + (f":{default_value}" if default_value else "") + "}"
-            rendered = rendered.replace(placeholder, str(value))
+            rendered = rendered.replace(placeholder, sanitize_input(str(value)))
 
         return rendered
 

--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -382,11 +382,15 @@ def sanitize_input(value: str) -> str:
     Returns:
         Sanitized value
     """
-    # Remove shell metacharacters and non-printable control characters
+    # Remove shell metacharacters and non-printable control characters.
     dangerous_chars = [';', '|', '&', '$', '`', '(', ')', '<', '>', '\n', '\r', "'", '"', '\\', '!', '{', '}', '\t', '\x00']
     for char in dangerous_chars:
         value = value.replace(char, '')
-    
+
+    # User-controlled placeholders are passed as argv values, not through a
+    # shell, but leading dashes can still be interpreted as tool options.
+    value = value.lstrip("-")
+
     return value.strip()
 
 

--- a/testing/backend/unit/test_plugins.py
+++ b/testing/backend/unit/test_plugins.py
@@ -55,6 +55,25 @@ def test_plugin_interpolation_sanitizes_user_controlled_values():
     )
 
 
+def test_plugin_interpolation_preserves_legitimate_argv_values():
+    manager = PluginManager("plugins")
+
+    assert (
+        manager._interpolate(
+            "--url={target}",
+            {"target": "https://api-v1.example.com:8443/health-check"},
+        )
+        == "--url=https://api-v1.example.com:8443/health-check"
+    )
+    assert (
+        manager._interpolate(
+            "--user-agent={user_agent}",
+            {"user_agent": "SecuScan-CLI/1.0 api-health-check"},
+        )
+        == "--user-agent=SecuScan-CLI/1.0 api-health-check"
+    )
+
+
 def test_plugin_list_exposes_runtime_capabilities(setup_test_environment, monkeypatch):
     """Plugin list payload includes consent and availability details."""
     manager = PluginManager(settings.plugins_dir)

--- a/testing/backend/unit/test_plugins.py
+++ b/testing/backend/unit/test_plugins.py
@@ -45,6 +45,16 @@ def test_plugin_manager_build_command(setup_test_environment):
     assert "http://127.0.0.1" in command
 
 
+def test_plugin_interpolation_sanitizes_user_controlled_values():
+    manager = PluginManager("plugins")
+
+    assert manager._interpolate("{templates}", {"templates": "--debug;$(whoami)"}) == "debugwhoami"
+    assert (
+        manager._interpolate("--user-agent={user_agent}", {"user_agent": "--verbose|curl"})
+        == "--user-agent=verbosecurl"
+    )
+
+
 def test_plugin_list_exposes_runtime_capabilities(setup_test_environment, monkeypatch):
     """Plugin list payload includes consent and availability details."""
     manager = PluginManager(settings.plugins_dir)


### PR DESCRIPTION
## Summary
- call the existing `sanitize_input()` helper for every user-controlled plugin placeholder before command construction
- strip leading `-` prefixes from sanitized values so placeholder inputs cannot become tool flags like `--debug`
- add regression coverage for shell metacharacter stripping and leading-option-prefix removal during interpolation

Fixes #615

## Testing
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile backend/secuscan/plugins.py backend/secuscan/validation.py testing/backend/unit/test_plugins.py`
- direct targeted interpolation assertions with Python 3.12:
  - `sanitize_input('--debug;$(whoami)') == 'debugwhoami'`
  - `_interpolate('{templates}', {'templates': '--debug;$(whoami)'}) == 'debugwhoami'`
  - `_interpolate('--user-agent={user_agent}', {'user_agent': '--verbose|curl'}) == '--user-agent=verbosecurl'`
- `git diff --check`

## Note
I attempted the focused pytest command for `testing/backend/unit/test_plugins.py testing/backend/unit/test_validation.py`, but local dependency installation is blocked by the native `pycairo`/`cairo` requirement pulled through `xhtml2pdf`. The code-level targeted checks above pass under Python 3.12.
