### PR TITLE
fix(ci): resolve backend lint F821 and stale frontend test mocks

### DIFF
--- a/backend/secuscan/workflows.py
+++ b/backend/secuscan/workflows.py
@@ -72,6 +72,7 @@ class WorkflowScheduler:
         return elapsed >= schedule_seconds
     async def _run_workflow(self, workflow_id: str, steps: List[Dict[str, Any]]):
         logger.info("Running workflow %s with %d step(s)", workflow_id, len(steps))
+        db = await get_db()
         for step in steps:
             plugin_id = step.get("plugin_id")
             inputs = step.get("inputs") or {}

--- a/frontend/testing/unit/pages/ToolConfigDynamic.test.tsx
+++ b/frontend/testing/unit/pages/ToolConfigDynamic.test.tsx
@@ -79,9 +79,9 @@ describe('ToolConfig dynamic schema flow', () => {
       stream_url: '/api/v1/task/task-123/stream',
     })
     vi.mocked(getSettings).mockResolvedValue(null)
-    vi.mocked(listTargetPolicies).mockResolvedValue({ items: [] })
-    vi.mocked(listCredentialProfiles).mockResolvedValue({ items: [] })
-    vi.mocked(listSessionProfiles).mockResolvedValue({ items: [] })
+    vi.mocked(listTargetPolicies).mockResolvedValue({ items: [], total: 0 })
+    vi.mocked(listCredentialProfiles).mockResolvedValue({ items: [], total: 0 })
+    vi.mocked(listSessionProfiles).mockResolvedValue({ items: [], total: 0 })
   })
 
   it('renders dynamic fields and submits startTask with consent', async () => {

--- a/frontend/testing/unit/pages/ToolConfigDynamic.test.tsx
+++ b/frontend/testing/unit/pages/ToolConfigDynamic.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import ToolConfig from '../../../src/pages/ToolConfig'
-import { getPluginSchema, listPlugins, startTask } from '../../../src/api'
+import { getPluginSchema, listPlugins, startTask, getSettings, listTargetPolicies, listCredentialProfiles, listSessionProfiles } from '../../../src/api'
 import { routes } from '../../../src/routes'
 
 const addToast = vi.fn()
@@ -15,6 +15,10 @@ vi.mock('../../../src/api', () => ({
   listPlugins: vi.fn(),
   getPluginSchema: vi.fn(),
   startTask: vi.fn(),
+  getSettings: vi.fn(),
+  listTargetPolicies: vi.fn(),
+  listCredentialProfiles: vi.fn(),
+  listSessionProfiles: vi.fn(),
 }))
 
 describe('ToolConfig dynamic schema flow', () => {
@@ -74,6 +78,10 @@ describe('ToolConfig dynamic schema flow', () => {
       created_at: 'now',
       stream_url: '/api/v1/task/task-123/stream',
     })
+    vi.mocked(getSettings).mockResolvedValue(null)
+    vi.mocked(listTargetPolicies).mockResolvedValue({ items: [] })
+    vi.mocked(listCredentialProfiles).mockResolvedValue({ items: [] })
+    vi.mocked(listSessionProfiles).mockResolvedValue({ items: [] })
   })
 
   it('renders dynamic fields and submits startTask with consent', async () => {
@@ -108,6 +116,7 @@ describe('ToolConfig dynamic schema flow', () => {
         }),
         true,
         'quick',
+        expect.any(Object),
       )
     })
   })

--- a/frontend/testing/unit/pages/ToolConfigTimeout.test.tsx
+++ b/frontend/testing/unit/pages/ToolConfigTimeout.test.tsx
@@ -63,9 +63,9 @@ describe('ToolConfig timeout control', () => {
 
     vi.mocked(getSettings).mockResolvedValue({ sandbox: { default_timeout: 600 } })
     vi.mocked(startTask).mockResolvedValue({ task_id: 'task-1', status: 'queued', created_at: 'now', stream_url: '' })
-    vi.mocked(listTargetPolicies).mockResolvedValue({ items: [] })
-    vi.mocked(listCredentialProfiles).mockResolvedValue({ items: [] })
-    vi.mocked(listSessionProfiles).mockResolvedValue({ items: [] })
+    vi.mocked(listTargetPolicies).mockResolvedValue({ items: [], total: 0 })
+    vi.mocked(listCredentialProfiles).mockResolvedValue({ items: [], total: 0 })
+    vi.mocked(listSessionProfiles).mockResolvedValue({ items: [], total: 0 })
   })
 
   it('renders integer input with constrained min/max', async () => {

--- a/frontend/testing/unit/pages/ToolConfigTimeout.test.tsx
+++ b/frontend/testing/unit/pages/ToolConfigTimeout.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import ToolConfig from '../../../src/pages/ToolConfig'
-import { getPluginSchema, listPlugins, startTask, getSettings } from '../../../src/api'
+import { getPluginSchema, listPlugins, startTask, getSettings, listTargetPolicies, listCredentialProfiles, listSessionProfiles } from '../../../src/api'
 import { routes } from '../../../src/routes'
 
 const addToast = vi.fn()
@@ -16,6 +16,9 @@ vi.mock('../../../src/api', () => ({
   getPluginSchema: vi.fn(),
   startTask: vi.fn(),
   getSettings: vi.fn(),
+  listTargetPolicies: vi.fn(),
+  listCredentialProfiles: vi.fn(),
+  listSessionProfiles: vi.fn(),
 }))
 
 describe('ToolConfig timeout control', () => {
@@ -60,6 +63,9 @@ describe('ToolConfig timeout control', () => {
 
     vi.mocked(getSettings).mockResolvedValue({ sandbox: { default_timeout: 600 } })
     vi.mocked(startTask).mockResolvedValue({ task_id: 'task-1', status: 'queued', created_at: 'now', stream_url: '' })
+    vi.mocked(listTargetPolicies).mockResolvedValue({ items: [] })
+    vi.mocked(listCredentialProfiles).mockResolvedValue({ items: [] })
+    vi.mocked(listSessionProfiles).mockResolvedValue({ items: [] })
   })
 
   it('renders integer input with constrained min/max', async () => {

--- a/frontend/testing/unit/pages/Workflows.test.tsx
+++ b/frontend/testing/unit/pages/Workflows.test.tsx
@@ -130,7 +130,7 @@ describe('Workflows — create action', () => {
       name: 'Nightly Scan',
       schedule_seconds: 7200,
       enabled: true,
-      steps: [{ plugin_id: '', inputs: {} }],
+      steps: [{ plugin_id: '', inputs: {}, execution_context: { scan_profile: 'standard', validation_mode: 'proof', evidence_level: 'standard' } }],
     })
   })
 })


### PR DESCRIPTION
## Summary

Fixes two CI regressions introduced by commits `0e03877` and `a2a7e02` that are currently blocking all open PRs (backend-lint and frontend-checks failures).

## Root Causes

### 1. Backend lint failure — `F821 Undefined name 'db'` (`backend/secuscan/workflows.py:82`)

Commit `0e03877` added a `get_target_policy(db, ...)` call inside `WorkflowScheduler._run_workflow()`, but `db` was never acquired in that method. The `tick()` method correctly obtains `db = await get_db()` but does not pass it to `_run_workflow()`.

**Fix:** Added `db = await get_db()` at the top of `_run_workflow()`.

```python
# Before
async def _run_workflow(self, workflow_id: str, steps: List[Dict[str, Any]]):
    logger.info(...)
    for step in steps:
        ...
        target_policy = await get_target_policy(db, ...)  # NameError: db undefined

# After
async def _run_workflow(self, workflow_id: str, steps: List[Dict[str, Any]]):
    logger.info(...)
    db = await get_db()  # acquire database connection
    for step in steps:
        ...
        target_policy = await get_target_policy(db, ...)  # now resolved
```

### 2. Frontend test failures — stale mocks after `ToolConfig.tsx` and `Workflows.tsx` updates

Commit `a2a7e02` updated `ToolConfig.tsx` to call three new API functions in a `Promise.all`:
```ts
const [s, policies, credentials, sessions] = await Promise.all([
  getSettings(),
  listTargetPolicies(),   // new
  listCredentialProfiles(), // new
  listSessionProfiles(),  // new
])
```

Tests that only mocked the original API functions had these three return `undefined`, causing `Promise.all` to resolve with a rejected upstream, which prevented `setServerLimits` from running and broke `max`/`min` attribute assertions in `ToolConfigTimeout.test.tsx`.

The same commit also updated `startTask` to accept a 5th `executionContext` argument, breaking the `startTask` call assertion in `ToolConfigDynamic.test.tsx`.

`Workflows.tsx` changed `emptySteps` to include `execution_context` in each step object, making the `createWorkflow` assertion in `Workflows.test.tsx` fail with a shape mismatch.

**Fixes applied:**

| File | Change |
|------|--------|
| `ToolConfigDynamic.test.tsx` | Added `listTargetPolicies`, `listCredentialProfiles`, `listSessionProfiles`, `getSettings` to `vi.mock` factory and `beforeEach` mock returns; updated `startTask` assertion to accept 5th `executionContext` argument |
| `ToolConfigTimeout.test.tsx` | Added three new API functions to `vi.mock` factory and `beforeEach` so `Promise.all` resolves correctly |
| `Workflows.test.tsx` | Updated `createWorkflow` expectation to include `execution_context` in the `steps` array |

## Verification

- `ruff check backend/secuscan/workflows.py` passes with no errors
- All three frontend test assertions align with the current component behavior

## Impact

This unblocks all currently open PRs that are failing `backend-lint` and `frontend-checks` due to these pre-existing regressions.