### PR TITLE
Fix/613 default network policy

### DIFF
--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -63,7 +63,7 @@ class Settings(BaseSettings):
     admin_api_key: Optional[str] = None
 
     # Network Policy Configuration
-    network_allowlist: List[str] = []  # IPs/networks to allow (CIDR)
+    network_allowlist: List[str] = []  # IPs/networks to allow (CIDR); empty = deny all egress
     network_denylist: List[str] = [    # IPs/networks to deny (CIDR)
         "169.254.169.254/32",          # AWS metadata
         "169.254.0.0/16",              # Reserved/metadata

--- a/backend/secuscan/network_policy.py
+++ b/backend/secuscan/network_policy.py
@@ -398,11 +398,9 @@ def _init_default_policies(engine: NetworkPolicyEngine) -> None:
         except ValueError:
             logger.warning(f"Skipping invalid allowlist CIDR: {cidr}")
 
-    # Add system defaults (if allowlist is empty, add public internet)
+    # Warn if allowlist is empty ? network policy defaults to deny-all egress
     if not settings.network_allowlist:
         logger.warning(
-            "SECUSCAN_NETWORK_ALLOWLIST is empty. Allowing all public IPs. "
-            "Configure this environment variable to restrict egress."
+            "SECUSCAN_NETWORK_ALLOWLIST is empty. All external network egress is blocked. "
+            "Configure this environment variable with CIDR ranges to allow outbound traffic."
         )
-        engine.add_allow_rule("0.0.0.0/0", reason="Default allow all (configure SECUSCAN_NETWORK_ALLOWLIST)")
-        engine.add_allow_rule("::/0", reason="Default allow all IPv6")

--- a/testing/backend/unit/test_network_policy.py
+++ b/testing/backend/unit/test_network_policy.py
@@ -7,7 +7,7 @@ from unittest.mock import patch, MagicMock
 
 from backend.secuscan.network_policy import (
     NetworkPolicyEngine, NetworkPolicy, PolicyAction, AuditLogEntry,
-    get_policy_engine
+    get_policy_engine, _init_default_policies
 )
 from backend.secuscan.config import settings
 
@@ -42,6 +42,30 @@ class TestDenyByDefault:
 
         assert not allowed
         assert "denylist" in reason.lower()
+
+
+class TestInitDefaultPolicies:
+    """Test _init_default_policies logic"""
+
+    def test_empty_allowlist_does_not_add_allow_all(self, tmp_path):
+        """Empty allowlist must NOT create 0.0.0.0/0 or ::/0 rules"""
+        audit_log = tmp_path / "audit.log"
+        engine = NetworkPolicyEngine(audit_log_path=str(audit_log))
+        _init_default_policies(engine)
+        assert len(engine.allowlist) == 0
+        allowed, _, _ = engine.check_access("8.8.8.8", plugin_id="test")
+        assert not allowed
+
+    def test_explicit_allowlist_entries_are_loaded(self, monkeypatch, tmp_path):
+        """Entries in SECUSCAN_NETWORK_ALLOWLIST should appear in engine.allowlist"""
+        monkeypatch.setattr(
+            "backend.secuscan.config.settings.network_allowlist",
+            ["8.8.8.8/32", "1.1.1.1/32"],
+        )
+        audit_log = tmp_path / "audit.log"
+        engine = NetworkPolicyEngine(audit_log_path=str(audit_log))
+        _init_default_policies(engine)
+        assert len(engine.allowlist) == 2
 
 
 class TestAllowlistPrecedence:


### PR DESCRIPTION
## Description
`settings.network_allowlist` defaults to `[]` (empty list). When the allowlist is empty, `_init_default_policies()` automatically adds `0.0.0.0/0` and `::/0` as "Default allow all" rules. This means every network connection from any scanner to any public internet host is permitted unless the operator explicitly sets `SECUSCAN_NETWORK_ALLOWLIST`. The deny-by-default security model is illusory.

Fix: remove the default allow-all rules. An empty allowlist now means deny-all egress. Operators must explicitly configure `SECUSCAN_NETWORK_ALLOWLIST` to permit outbound traffic.

## Related Issues
- #613

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Verified that `_init_default_policies` no longer adds `0.0.0.0/0` or `::/0` when `network_allowlist` is empty. The denylist (RFC 1918, cloud metadata) continues to be applied as before.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.