### PR TITLE
Add help text for YARA scan plugin fields

### DIFF
--- a/plugins/yara_scan/metadata.json
+++ b/plugins/yara_scan/metadata.json
@@ -36,14 +36,16 @@
       "label": "YARA Rules Path",
       "type": "string",
       "required": true,
-      "placeholder": "/opt/rules/malware.yar"
+      "placeholder": "/opt/rules/malware.yar",
+      "help": "Path to a YARA rule file (.yar or .yara) used to match signatures against the target."
     },
     {
       "id": "print_strings",
       "label": "Print Matching Strings",
       "type": "boolean",
       "required": false,
-      "default": false
+      "default": false,
+      "help": "Include matching string values from triggered YARA rules in the scan output."
     }
   ],
   "presets": {
@@ -71,5 +73,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "411d3d894c61a405a16dcbe86ae9075720922b10e238161284def026f5e0baac"
+  "checksum": "ee0abeb31db5963b5d6f1dba11a88fb9d9a9a398a21a6c33429b07c337d857d7"
 }

--- a/plugins/yara_scan/metadata.json
+++ b/plugins/yara_scan/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd2c",
+  "icon": "🔬",
   "engine": {
     "type": "cli",
     "binary": "yara"
@@ -73,5 +73,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "ee0abeb31db5963b5d6f1dba11a88fb9d9a9a398a21a6c33429b07c337d857d7"
+  "checksum": "5cbd915870a7bae34f6d1b9d960e654221a0236e805a300024f38297be956ac5"
 }


### PR DESCRIPTION
## Description

Added missing field-level help text to the YARA scan plugin metadata to improve guidance in the generated UI.

### Changes

* Added help text for the **YARA Rules Path** field explaining the expected `.yar` / `.yara` rule file input.
* Added help text for the **Print Matching Strings** field explaining that matching strings from triggered YARA rules will be included in the scan output.
* Refreshed the plugin checksum after updating metadata.

## Related Issues

Issue #536 

## Type of Change

* [x] Documentation update

## How Has This Been Tested?

* Verified the metadata file contains help text for all user-facing fields.
* Refreshed the plugin checksum using:

```bash
python scripts/refresh_plugin_checksum.py --plugin yara_scan
```

* Confirmed the metadata structure remains valid and the plugin configuration loads correctly.

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
