### PR TITLE
Added a structured request-logging smoke test through app startup #572

### DIFF
--- a/backend/secuscan/main.py
+++ b/backend/secuscan/main.py
@@ -176,6 +176,7 @@ async def health_check():
     import platform
     import sys
     
+    logger.info("Health check endpoint accessed")
     return {
         "status": "operational",
         "version": "0.1.0-alpha",

--- a/testing/backend/integration/test_request_logging_smoke.py
+++ b/testing/backend/integration/test_request_logging_smoke.py
@@ -1,0 +1,61 @@
+# testing/backend/integration/test_request_logging_smoke.py
+
+import io
+import json
+import logging
+import re
+
+import pytest
+from backend.secuscan.logging_utils import JSONFormatter, RequestIDFilter
+
+UUID4_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+@pytest.fixture
+def log_capture():
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.addFilter(RequestIDFilter())
+    handler.setFormatter(JSONFormatter())
+    handler.setLevel(logging.DEBUG)
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        yield buf
+    finally:
+        root.removeHandler(handler)
+        handler.close()
+
+def _parse_log_lines(buf):
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+def test_request_id_appears_in_json_logs(test_client, log_capture):
+    response = test_client.get("/api/v1/health")
+    assert response.status_code == 200
+
+    request_id = response.headers.get("X-Request-ID")
+    assert request_id, "Middleware must echo X-Request-ID header"
+    assert UUID4_RE.match(request_id), "Request ID must be a valid UUID4"
+
+    entries = _parse_log_lines(log_capture)
+    assert entries, "At least one JSON log line must be emitted"
+
+    for entry in entries:
+        for key in ("timestamp", "level", "request_id", "logger", "message"):
+            assert key in entry, f"Log entry missing key '{key}': {entry}"
+
+    correlated = [e for e in entries if e["request_id"] == request_id]
+    assert correlated, (
+        f"No log line carries request_id={request_id!r}. "
+        f"Seen IDs: {[e['request_id'] for e in entries]}"
+    )
+
+def test_passthrough_request_id(test_client, log_capture):
+    custom_id = "smoke-test-trace-abc123"
+    response = test_client.get("/api/v1/health", headers={"X-Request-ID": custom_id})
+    assert response.headers.get("X-Request-ID") == custom_id
+
+    entries = _parse_log_lines(log_capture)
+    correlated = [e for e in entries if e["request_id"] == custom_id]
+    assert correlated, "Passthrough request ID must appear in logs"


### PR DESCRIPTION
Closes #572 


## Description
This PR introduces a top-level integration/smoke test to ensure that request IDs and structured JSON logging are correctly integrated and function end-to-end through application startup.

Specifically, the following changes were made:
- Added a `logger.info("Health check endpoint accessed")` call inside the `/api/v1/health` endpoint in `main.py` to ensure request-level logs are emitted during the request cycle.
- Created `testing/backend/integration/test_request_logging_smoke.py` containing:
  - An integration test (`test_request_id_appears_in_json_logs`) checking that a generated request ID matches the one returned in response headers and is successfully correlated in the output JSON logs.
  - A passthrough test (`test_passthrough_request_id`) verifying that pre-existing request IDs sent in headers are propagated and correctly logged.
  - An in-memory logging capture fixture (`log_capture`) using the real application's `RequestIDFilter` and `JSONFormatter`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
The smoke test was run and verified locally:
```powershell
python -m pytest testing/backend/integration/test_request_logging_smoke.py
