### PR TITLE
test: cover preferred export format hook

### DIFF
--- a/frontend/testing/unit/hooks/usePreferredExportFormat.test.ts
+++ b/frontend/testing/unit/hooks/usePreferredExportFormat.test.ts
@@ -1,0 +1,36 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { usePreferredExportFormat } from '../../../src/hooks/usePreferredExportFormat'
+
+const STORAGE_KEY = 'secuscan:preferred-export-format'
+
+describe('usePreferredExportFormat', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('starts with no preferred format when storage is empty', () => {
+    const { result } = renderHook(() => usePreferredExportFormat())
+
+    expect(result.current.preferred).toBeNull()
+  })
+
+  it('restores a stored preferred format on first render', () => {
+    localStorage.setItem(STORAGE_KEY, 'pdf')
+
+    const { result } = renderHook(() => usePreferredExportFormat())
+
+    expect(result.current.preferred).toBe('pdf')
+  })
+
+  it('persists a newly selected preferred format', () => {
+    const { result } = renderHook(() => usePreferredExportFormat())
+
+    act(() => {
+      result.current.savePreference('csv')
+    })
+
+    expect(result.current.preferred).toBe('csv')
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('csv')
+  })
+})


### PR DESCRIPTION
## Summary
- add direct unit coverage for `usePreferredExportFormat`
- assert empty default state, stored preference restoration, and `savePreference` persistence
- keep the coverage isolated from page-level report components

Fixes #559

## Validation
- `npm test -- --run testing/unit/hooks/usePreferredExportFormat.test.ts`
- `git diff --check`
