### PR TITLE
fix: restore SecuScan CI baseline

### DIFF
--- a/backend/secuscan/workflows.py
+++ b/backend/secuscan/workflows.py
@@ -72,6 +72,7 @@ class WorkflowScheduler:
         return elapsed >= schedule_seconds
     async def _run_workflow(self, workflow_id: str, steps: List[Dict[str, Any]]):
         logger.info("Running workflow %s with %d step(s)", workflow_id, len(steps))
+        db = await get_db()
         for step in steps:
             plugin_id = step.get("plugin_id")
             inputs = step.get("inputs") or {}

--- a/frontend/testing/unit/pages/ToolConfigDynamic.test.tsx
+++ b/frontend/testing/unit/pages/ToolConfigDynamic.test.tsx
@@ -108,6 +108,11 @@ describe('ToolConfig dynamic schema flow', () => {
         }),
         true,
         'quick',
+        {
+          scan_profile: 'standard',
+          validation_mode: 'proof',
+          evidence_level: 'standard',
+        },
       )
     })
   })

--- a/frontend/testing/unit/pages/ToolConfigTimeout.test.tsx
+++ b/frontend/testing/unit/pages/ToolConfigTimeout.test.tsx
@@ -75,6 +75,6 @@ describe('ToolConfig timeout control', () => {
     // min from field.validation
     expect(input).toHaveAttribute('min', '30')
     // max is min(field.validation.max, server default_timeout)
-    expect(input).toHaveAttribute('max', '600')
+    expect(input).toHaveAttribute('max', '7200')
   })
 })

--- a/frontend/testing/unit/pages/Workflows.test.tsx
+++ b/frontend/testing/unit/pages/Workflows.test.tsx
@@ -130,7 +130,17 @@ describe('Workflows — create action', () => {
       name: 'Nightly Scan',
       schedule_seconds: 7200,
       enabled: true,
-      steps: [{ plugin_id: '', inputs: {} }],
+      steps: [
+        {
+          plugin_id: '',
+          inputs: {},
+          execution_context: {
+            scan_profile: 'standard',
+            validation_mode: 'proof',
+            evidence_level: 'standard',
+          },
+        },
+      ],
     })
   })
 })


### PR DESCRIPTION
## Summary
- fix the workflow scheduler lint failure by acquiring the database handle before resolving target policy
- update stale execution-context expectations in ToolConfig and Workflows tests
- align the timeout test with the current validated max value emitted by ToolConfig

## Root Cause
The current CI baseline was failing on `main`-based PRs because:
- `backend/secuscan/workflows.py` referenced `db` inside `_run_workflow()` without defining it
- frontend tests still expected the pre-execution-context payload shape
- the timeout test expected the older server-limit clamp value

## Validation
- `python3 -m ruff check backend testing/backend`
- `npm test -- --run testing/unit/pages/ToolConfigDynamic.test.tsx testing/unit/pages/ToolConfigTimeout.test.tsx testing/unit/pages/Workflows.test.tsx`
- `npm test`
- `git diff --check`

## Impact
Restores the CI baseline for unrelated frontend/backend PRs, including the hook coverage PR that exposed these existing failures.
