### PR TITLE
feat: add help text for sitemap_gen metadata fields

### DIFF
--- a/plugins/sitemap_gen/metadata.json
+++ b/plugins/sitemap_gen/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee0\ufe0f",
+  "icon": "🛠️",
   "engine": {
     "type": "cli",
     "binary": "katana"
@@ -70,5 +70,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "ce9ab00a3694cfdfef189543f9f10b6bf3177466ee0c7de30f0b8b26c96f289a"
+  "checksum": "ccef2e01d3b41f185a19fc937b08c32c343cc05c4b5160fe3bd1e97ab01a1f9d"
 }

--- a/plugins/sitemap_gen/metadata.json
+++ b/plugins/sitemap_gen/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "🛠️",
+  "icon": "\ud83d\udee0\ufe0f",
   "engine": {
     "type": "cli",
     "binary": "katana"

--- a/plugins/sitemap_gen/metadata.json
+++ b/plugins/sitemap_gen/metadata.json
@@ -27,6 +27,7 @@
     {
       "id": "target",
       "label": "Target URL",
+      "help": "Enter the HTTP(S) URL to crawl and generate a sitemap from.",
       "type": "string",
       "required": true,
       "placeholder": "https://secuscan.in",
@@ -38,6 +39,7 @@
     {
       "id": "depth",
       "label": "Depth",
+      "help": "Maximum crawl depth. Higher values discover more pages but may take longer to complete.",
       "type": "integer",
       "required": false,
       "default": 4
@@ -68,5 +70,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "1555d4793ba9f18eaec55b737fcf28ca7f4236d2b253b1637485ae952409d512"
+  "checksum": "ce9ab00a3694cfdfef189543f9f10b6bf3177466ee0c7de30f0b8b26c96f289a"
 }


### PR DESCRIPTION
## Description

Added help text for all user-facing fields in `plugins/sitemap_gen/metadata.json` to improve clarity when configuring the `sitemap_gen` plugin.

Changes made:

* Added help text for the `target` field describing the expected URL input.
* Added help text for the `depth` field explaining its effect on sitemap generation.
* Refreshed the plugin checksum after updating the metadata.

## Related Issues

Closes #531

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## How Has This Been Tested?

* Ran:

  ```bash
  python scripts/refresh_plugin_checksum.py --plugin sitemap_gen
  ```

* Verified the metadata changes using:

  ```bash
  git diff
  ```

* Confirmed the checksum was updated successfully and only the intended metadata fields were modified.

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
