### PR TITLE
feat: add help text for people-email-discovery metadata

### DIFF
--- a/plugins/people-email-discovery/metadata.json
+++ b/plugins/people-email-discovery/metadata.json
@@ -26,6 +26,7 @@
     {
       "id": "target",
       "label": "Target Domain",
+      "help": "Enter the domain name to search for associated email addresses and public profiles.",
       "type": "string",
       "required": true,
       "placeholder": "secuscan.in"
@@ -53,5 +54,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "0f0889733638a60dc134a94a668c6683cbdb435560d60f61e7735d47114334c6"
+  "checksum": "704b89c320e0ee31973d2375fb833adbb81741d07e2e3f96f67eabb9d6c0679c"
 }

--- a/plugins/people-email-discovery/metadata.json
+++ b/plugins/people-email-discovery/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "🔎",
+  "icon": "\ud83d\udd0e",
   "engine": {
     "type": "cli",
     "binary": "theHarvester"

--- a/plugins/people-email-discovery/metadata.json
+++ b/plugins/people-email-discovery/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "theHarvester"
@@ -54,5 +54,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "704b89c320e0ee31973d2375fb833adbb81741d07e2e3f96f67eabb9d6c0679c"
+  "checksum": "b637adaf26113ae2e6225ad26b61bc60bd3777a6c3e8fac58d0ec78b21ebd4e1"
 }


### PR DESCRIPTION
## Description

Added help text for the user-facing field in `plugins/people-email-discovery/metadata.json` to improve clarity when configuring the plugin.

Changes made:

* Added help text for the `Target Domain` field.
* Refreshed the plugin checksum after updating the metadata.

## Related Issues

Closes #529 

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## How Has This Been Tested?

* Ran:

  ```bash
  python scripts/refresh_plugin_checksum.py --plugin people-email-discovery
  ```

* Verified the metadata changes and checksum update using:

  ```bash
  git diff
  ```

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
