### PR TITLE
feat: add help text for katana metadata

### DIFF
--- a/plugins/katana/metadata.json
+++ b/plugins/katana/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "katana"
@@ -54,5 +54,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "368a406cc84ff67becacc51c398697e0cf627df03a866397088b7e242e1219f2"
+  "checksum": "b93432ec2f315aa2afd2943374c00706963984bfc1dbf78c057ffed6f96234ab"
 }

--- a/plugins/katana/metadata.json
+++ b/plugins/katana/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "🔎",
+  "icon": "\ud83d\udd0e",
   "engine": {
     "type": "cli",
     "binary": "katana"

--- a/plugins/katana/metadata.json
+++ b/plugins/katana/metadata.json
@@ -25,6 +25,7 @@
     {
       "id": "target",
       "label": "Target URL",
+      "help": "Enter the HTTP(S) URL to crawl for endpoint and route discovery.",
       "type": "string",
       "required": true,
       "placeholder": "https://secuscan.in"
@@ -53,5 +54,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "6c03736ab9bf88e97d7656ae4816922f68c3ef2a07a66b1ccfa7cb2c570b6a1a"
+  "checksum": "368a406cc84ff67becacc51c398697e0cf627df03a866397088b7e242e1219f2"
 }


### PR DESCRIPTION
## Description

Added help text for the user-facing field in `plugins/katana/metadata.json` to improve clarity when configuring the plugin.

Changes made:

* Added help text for the `Target URL` field.
* Refreshed the plugin checksum after updating the metadata.

## Related Issues

Closes #526

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## How Has This Been Tested?

* Ran:

  ```bash
  python scripts/refresh_plugin_checksum.py --plugin katana
  ```

* Verified the metadata changes and checksum update using:

  ```bash
  git diff
  ```

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
