### PR TITLE
Split backend unit and integration test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,19 @@ jobs:
       - name: Run integration tests
         run: pytest testing/backend/integration -q -m "not benchmark"
 
+  backend-tests:
+    needs:
+      - backend-unit
+      - backend-integration
+    runs-on: ubuntu-latest
+    if: |
+      always() &&
+      (needs.backend-unit.result == 'success' || needs.backend-unit.result == 'skipped') &&
+      (needs.backend-integration.result == 'success' || needs.backend-integration.result == 'skipped')
+    steps:
+      - name: Backend test suites completed
+        run: echo "backend-unit and backend-integration completed"
+        
   backend-audit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run backend lint baseline
         run: ruff check backend testing/backend
 
-  backend-unit-tests:
+  backend-unit:
     needs: [detect-changes, backend-lint, formatting-hygiene]
     if: |
       always() &&
@@ -83,7 +83,7 @@ jobs:
       - name: Run unit tests
         run: pytest testing/backend/unit -q -m "not benchmark"
 
-  backend-integration-tests:
+  backend-integration:
     needs: [detect-changes, backend-lint, formatting-hygiene]
     if: |
       always() &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run backend lint baseline
         run: ruff check backend testing/backend
 
-  backend-tests:
+  backend-unit-tests:
     needs: [detect-changes, backend-lint, formatting-hygiene]
     if: |
       always() &&
@@ -80,8 +80,30 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt -r backend/requirements-dev.txt
-      - name: Run backend tests
-        run: pytest testing/backend -q -m "not benchmark"
+      - name: Run unit tests
+        run: pytest testing/backend/unit -q -m "not benchmark"
+
+  backend-integration-tests:
+    needs: [detect-changes, backend-lint, formatting-hygiene]
+    if: |
+      always() &&
+      needs.detect-changes.outputs.run_backend == 'true' &&
+      (needs.backend-lint.result == 'success' || needs.backend-lint.result == 'skipped') &&
+      (needs.formatting-hygiene.result == 'success' || needs.formatting-hygiene.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install backend system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcairo2-dev pkg-config
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt -r backend/requirements-dev.txt
+      - name: Run integration tests
+        run: pytest testing/backend/integration -q -m "not benchmark"
 
   backend-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,6 @@ jobs:
     steps:
       - name: Backend test suites completed
         run: echo "backend-unit and backend-integration completed"
-        
   backend-audit:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Split backend test execution into separate unit and integration jobs
- Preserved benchmark exclusion with `-m "not benchmark"`
- Improved CI failure visibility by reporting unit and integration failures independently

## Validation
- Unit test suite runs independently
- Integration test suite runs independently
- Benchmark exclusion behavior unchanged