### PR TITLE
fix(validation): prevent mixed IPv4/IPv6 allowlist crashes

### DIFF
--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -70,6 +70,8 @@ def _net_within_allowed_networks(net: ipaddress._BaseNetwork) -> bool:
         for pattern in patterns:
             try:
                 allowed_net = ipaddress.ip_network(pattern, strict=False)
+                if net.version != allowed_net.version:
+                    continue
                 if net.subnet_of(allowed_net) or net.overlaps(allowed_net):
                     return True
             except ValueError:

--- a/testing/backend/unit/test_validation.py
+++ b/testing/backend/unit/test_validation.py
@@ -1,5 +1,7 @@
+# pyrefly: ignore [missing-import]
 import pytest
 import socket
+from backend.secuscan.config import settings
 from backend.secuscan.validation import (
     validate_target, validate_port, validate_port_range, validate_url,
     sanitize_input, is_safe_path, match_pattern
@@ -56,6 +58,32 @@ def test_validate_target_safe_mode_blocks_dns_rebinding_union(monkeypatch):
 
 def test_validate_target_safe_mode_blocks_url_ip_literal():
     assert validate_target("http://8.8.8.8", safe_mode=True)[0] is False
+
+def test_validate_target_ipv4_with_ipv6_allowed_network_does_not_crash(monkeypatch):
+    monkeypatch.setattr(settings, "allowed_networks", ["fc00::/7"])
+    ok, msg = validate_target("127.0.0.1", safe_mode=True)
+
+    assert ok is False
+    assert msg == "Target not within allowed networks in safe mode (SecuScan Guardrail)"
+
+
+def test_validate_target_ipv6_with_ipv4_allowed_network_does_not_crash(monkeypatch):
+    monkeypatch.setattr(settings, "allowed_networks", ["127.0.0.0/8"])
+    ok, msg = validate_target("::1", safe_mode=True)
+
+    assert ok is False
+    assert msg in {
+        "Public IPs/networks not allowed in safe mode (SecuScan Guardrail)",
+        "Target not within allowed networks in safe mode (SecuScan Guardrail)",
+    }
+
+
+def test_validate_target_mixed_allowed_networks_uses_later_same_version_entry(monkeypatch):
+    monkeypatch.setattr(settings, "allowed_networks", ["fc00::/7", "127.0.0.0/8"])
+    ok, msg = validate_target("127.0.0.1", safe_mode=True)
+
+    assert ok is True
+    assert msg == ""
 
 def test_validate_port():
     assert validate_port(80) == (True, "")

--- a/testing/backend/unit/test_validation.py
+++ b/testing/backend/unit/test_validation.py
@@ -1,6 +1,7 @@
-# pyrefly: ignore [missing-import]
 import pytest
 import socket
+import ipaddress
+from backend.secuscan import validation as validation_module
 from backend.secuscan.config import settings
 from backend.secuscan.validation import (
     validate_target, validate_port, validate_port_range, validate_url,
@@ -72,15 +73,21 @@ def test_validate_target_ipv6_with_ipv4_allowed_network_does_not_crash(monkeypat
     ok, msg = validate_target("::1", safe_mode=True)
 
     assert ok is False
-    assert msg in {
-        "Public IPs/networks not allowed in safe mode (SecuScan Guardrail)",
-        "Target not within allowed networks in safe mode (SecuScan Guardrail)",
-    }
+    assert msg == "Public IPs/networks not allowed in safe mode (SecuScan Guardrail)"
 
 
 def test_validate_target_mixed_allowed_networks_uses_later_same_version_entry(monkeypatch):
     monkeypatch.setattr(settings, "allowed_networks", ["fc00::/7", "127.0.0.0/8"])
     ok, msg = validate_target("127.0.0.1", safe_mode=True)
+
+    assert ok is True
+    assert msg == ""
+
+def test_validate_target_mixed_allowed_networks_uses_later_same_version_ipv6_entry(monkeypatch):
+    monkeypatch.setattr(validation_module, "ALLOWED_PRIVATE", [ipaddress.ip_network("fc00::/7")])
+    monkeypatch.setattr(settings, "allowed_networks", ["127.0.0.0/8", "fc00::/7"])
+
+    ok, msg = validate_target("fd00::1", safe_mode=True)
 
     assert ok is True
     assert msg == ""


### PR DESCRIPTION
## Description
This PR fixes a safe-mode validation bug where mixed IPv4 and IPv6 entries in `allowed_networks` could raise an uncaught `TypeError` during target validation.

Changes included:

- Added an IP-version guard before calling `subnet_of()` and `overlaps()` in `_net_within_allowed_networks()`
- Skips mixed-version network comparisons safely instead of raising an exception
- Preserves existing same-version CIDR and wildcard matching behavior
- Added regression tests for:
  - IPv4 target with IPv6 allowlist
  - IPv6 target with IPv4 allowlist
  - Mixed allowlists where a later same-version entry still allows the target
      
## Related Issues

Fixes #607

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Executed:

```bash
py -3.11 -m pytest testing/backend/unit/test_validation.py -q
```

Result:

42 passed

Verified that:

-  Mixed IPv4/IPv6 allowlist entries no longer raise a `TypeError`
-  Same-version CIDR matching behavior remains unchanged
-  A later same-version allowlist entry is still evaluated correctly after mixed-version entries are skipped

## Checklist

-  [x] My code follows the code style of this project.
-  [x] I have performed a self-review of my own code.
-  [ ] I have commented my code, particularly in hard-to-understand areas.
-  [ ] I have made corresponding changes to the documentation.
-  [x] My changes generate no new warnings.
