### PR TITLE
Add help text for Kubernetes scanner cluster context field

### DIFF
--- a/plugins/kubernetes_scanner/metadata.json
+++ b/plugins/kubernetes_scanner/metadata.json
@@ -28,7 +28,7 @@
       "type": "string",
       "required": true,
       "placeholder": "prod-cluster",
-      "help_text": "Enter the Kubernetes cluster context name from your kubeconfig, for example prod-cluster."
+      "help": "Enter the Kubernetes cluster context name from your kubeconfig, for example prod-cluster."
     }
   ],
   "presets": {

--- a/plugins/kubernetes_scanner/metadata.json
+++ b/plugins/kubernetes_scanner/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee0\ufe0f",
+  "icon": "🛠️",
   "engine": {
     "type": "cli",
     "binary": "python3"
@@ -27,7 +27,8 @@
       "label": "Cluster Context",
       "type": "string",
       "required": true,
-      "placeholder": "prod-cluster"
+      "placeholder": "prod-cluster",
+      "help_text": "Enter the Kubernetes cluster context name from your kubeconfig, for example prod-cluster."
     }
   ],
   "presets": {
@@ -53,5 +54,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "830b2c5f4e397d2d2ad28f71ec8d1a3a5f9bd3e439d8318f71a5b8a371f7ccdb"
+  "checksum": "c1188c318df1eb9160074f26cb4d6bc02cec49b65c97b1da0d3456f96e22640b"
 }

--- a/plugins/kubernetes_scanner/metadata.json
+++ b/plugins/kubernetes_scanner/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "🛠️",
+  "icon": "\ud83d\udee0\ufe0f",
   "engine": {
     "type": "cli",
     "binary": "python3"


### PR DESCRIPTION
## Description
Added help text for the Cluster Context field in
plugins/kubernetes_scanner/metadata.json so users know what value is expected.

## Related Issues
Fixes #527

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- Updated the plugin metadata with a descriptive help_text.
- Refreshed the plugin checksum using:
  `python scripts/refresh_plugin_checksum.py --plugin kubernetes_scanner`
- Verified the metadata changes in the plugin file.


## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my changes
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
