### PR TITLE
fix(plugins): declare CLI dependency binaries

### DIFF
--- a/plugins/nuclei/metadata.json
+++ b/plugins/nuclei/metadata.json
@@ -126,9 +126,11 @@
     "tutorial_url": "https://docs.secuscan.local/plugins/nuclei"
   },
   "dependencies": {
-    "binaries": [],
+    "binaries": [
+      "nuclei"
+    ],
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "ecdacab5d26ebd95d07fe61cc781768e046ab004438a254f2ed80efd167c728d"
+  "checksum": "8304cb4226938c354aa831943de4da3dfa57e2fe4cc9c200d448f49b56f74590"
 }

--- a/plugins/sqlmap/metadata.json
+++ b/plugins/sqlmap/metadata.json
@@ -120,9 +120,11 @@
     "tutorial_url": "https://docs.secuscan.local/plugins/sqlmap"
   },
   "dependencies": {
-    "binaries": [],
+    "binaries": [
+      "sqlmap"
+    ],
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "7312d73eb00289dfe5bc1c2cdb6491054a3a348f198a65b36f69f125c9ae3d50"
+  "checksum": "109abd6dbca360a17bb9afbcbc5fb8d2493e76749f7e8d16d704fcb490b925c7"
 }

--- a/plugins/whois_lookup/metadata.json
+++ b/plugins/whois_lookup/metadata.json
@@ -51,12 +51,14 @@
     "tutorial_url": "https://docs.secuscan.local/plugins/whois_lookup"
   },
   "dependencies": {
-    "binaries": [],
+    "binaries": [
+      "python3"
+    ],
     "python_packages": [
       "python-whois"
     ],
     "system_packages": []
   },
   "docker_image": "alpine:latest",
-  "checksum": "ecda30e7a979e1a0200d6f58c6c01fe6bae7dbe985cc0f47c5047165c46f3a53"
+  "checksum": "6d4436abc7bb499843ec8d46a7100565631ff35a368885017c4a5f3136fbfaa1"
 }

--- a/testing/backend/unit/test_plugin_integrity.py
+++ b/testing/backend/unit/test_plugin_integrity.py
@@ -23,6 +23,24 @@ def test_plugins_have_checksums():
         assert data.get("checksum"), f"Missing checksum in {path}"
 
 
+def test_cli_plugins_declare_engine_binary_as_dependency():
+    metadata_files = list(Path(settings.plugins_dir).glob("*/metadata.json"))
+    assert metadata_files, "Expected plugin metadata files"
+
+    for path in metadata_files:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        engine = data.get("engine", {})
+        if engine.get("type") != "cli":
+            continue
+
+        binary = engine.get("binary")
+        dependency_binaries = data.get("dependencies", {}).get("binaries", [])
+        assert binary in dependency_binaries, (
+            f"{path.parent.name} must declare engine binary {binary!r} "
+            "in dependencies.binaries"
+        )
+
+
 def test_plugin_metadata_ids_and_names_are_unique():
     metadata_files = list(Path(settings.plugins_dir).glob("*/metadata.json"))
     assert metadata_files, "Expected plugin metadata files"


### PR DESCRIPTION
## Description

The plugin availability check reads `dependencies.binaries`, but the `nuclei`, `sqlmap`, and `whois_lookup` CLI plugins did not declare the binaries their engines execute. That allowed unavailable tools to pass dependency validation and fail later at runtime.

This PR keeps the change scoped to the assigned plugin metadata issue:

- declares `nuclei` and `sqlmap` as their CLI dependencies
- declares `python3` for `whois_lookup` alongside `python-whois`
- refreshes all three metadata integrity checksums
- adds regression coverage requiring every CLI plugin to declare its engine binary

## Related Issues

Closes #540

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- focused plugin integrity tests: 4 passed
- full backend suite: 1131 passed, 11 deselected
- plugin checksum verification: 60 succeeded, 0 failed

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

This is for GSSoC 2026 and stays scoped to the assigned issue. Please add the appropriate GSSoC approval label during review.
