### PR TITLE
feat(plugins): add descriptive help text for uncover metadata fields

### DIFF
--- a/plugins/uncover/metadata.json
+++ b/plugins/uncover/metadata.json
@@ -29,14 +29,16 @@
       "label": "Search Query",
       "type": "string",
       "required": true,
-      "placeholder": "org:secuscan.in"
+      "placeholder": "org:secuscan.in",
+      "help": "Enter search queries using Uncover syntax. Supported operators: org:, domain:, port:, asn:, etc. Example: 'org:secuscan.in' searches for assets belonging to that organization."
     },
     {
       "id": "limit",
       "label": "Result Limit",
       "type": "integer",
       "required": false,
-      "default": 100
+      "default": 100,
+      "help": "Maximum number of results to fetch(default: 100). Higher limits may increase query time and resource usage."
     }
   ],
   "presets": {
@@ -63,5 +65,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "f66a6bcd537fe6a4c23d38fe7daeac3174e088c158de8dbf98230dd7891c5026"
+  "checksum": "db1e801d6a027a09ce9c726d593f9dda4b79ab2775a5e824bdeb43df3ba9364d"
 }


### PR DESCRIPTION
- Added help text to 'Search Query' field explaining syntax options
- Added help text to 'Result Limit' field documenting default thresholds
- Refreshed plugin signatures safely

Fixes #533

## Description
Adds clear user-facing help text guidance to both the 'Search Query' and 'Result Limit' configuration inputs within the uncover plugin metadata profile.

## Related Issues
Closes #533

## Type of Change
- [x] Documentation update (Adds missing help text metadata)

## How Has This Been Tested?
1.  Ran local validation script: `python scripts/validate_plugin.py --plugin plugins/uncover` and verified it passes completely.  
2. Checked that plugin signatures are refreshed locally.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Visual Proof
### Terminal Validation Output:
✓ Plugin validation passed

<img width="857" height="409" alt="image" src="https://github.com/user-attachments/assets/6ef1fd24-3c9a-43fd-805e-bf24e6d462d5" />
