### PR TITLE
test: add unit tests for usePreferredExportFormat hook

### DIFF
--- a/frontend/testing/unit/hooks/usePreferredExportFormat.test.ts
+++ b/frontend/testing/unit/hooks/usePreferredExportFormat.test.ts
@@ -1,0 +1,37 @@
+import { renderHook, act } from '@testing-library/react'
+import { usePreferredExportFormat } from "../../../src/hooks/usePreferredExportFormat";
+
+const STORAGE_KEY = 'secuscan:preferred-export-format'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('usePreferredExportFormat', () => {
+  it('returns null as default when no preference is stored', () => {
+    const { result } = renderHook(() => usePreferredExportFormat())
+    expect(result.current.preferred).toBeNull()
+  })
+
+  it('returns stored preference from localStorage on mount', () => {
+    localStorage.setItem(STORAGE_KEY, 'pdf')
+    const { result } = renderHook(() => usePreferredExportFormat())
+    expect(result.current.preferred).toBe('pdf')
+  })
+
+  it('saves preference to localStorage when savePreference is called', () => {
+    const { result } = renderHook(() => usePreferredExportFormat())
+    act(() => {
+      result.current.savePreference('csv')
+    })
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('csv')
+  })
+
+  it('updates preferred state when savePreference is called', () => {
+    const { result } = renderHook(() => usePreferredExportFormat())
+    act(() => {
+      result.current.savePreference('json')
+    })
+    expect(result.current.preferred).toBe('json')
+  })
+})


### PR DESCRIPTION
## Description
Adds direct unit test coverage for the `usePreferredExportFormat` hook in `frontend/src/hooks/usePreferredExportFormat.ts`. Tests cover default behavior and localStorage persistence, kept isolated from page components.

## Related Issues
Fixes #559

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Ran tests locally using Vitest:

npm test -- usePreferredExportFormat

All 4 tests passed:
- returns null as default when no preference is stored
- returns stored preference from localStorage on mount
- saves preference to localStorage when savePreference is called
- updates preferred state when savePreference is called

[ATTACH TERMINAL SCREENSHOT HERE]

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
<img width="1245" height="405" alt="Screenshot 2026-06-07 223221" src="https://github.com/user-attachments/assets/a3adabfb-42e6-4579-ad40-088870f3b53b" />
