### PR TITLE
534 virtual host finder help text

### DIFF
--- a/frontend/testing/unit/hooks/usePreferredExportFormat.test.ts
+++ b/frontend/testing/unit/hooks/usePreferredExportFormat.test.ts
@@ -1,0 +1,37 @@
+import { renderHook, act } from '@testing-library/react'
+import { usePreferredExportFormat } from "../../../src/hooks/usePreferredExportFormat";
+
+const STORAGE_KEY = 'secuscan:preferred-export-format'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('usePreferredExportFormat', () => {
+  it('returns null as default when no preference is stored', () => {
+    const { result } = renderHook(() => usePreferredExportFormat())
+    expect(result.current.preferred).toBeNull()
+  })
+
+  it('returns stored preference from localStorage on mount', () => {
+    localStorage.setItem(STORAGE_KEY, 'pdf')
+    const { result } = renderHook(() => usePreferredExportFormat())
+    expect(result.current.preferred).toBe('pdf')
+  })
+
+  it('saves preference to localStorage when savePreference is called', () => {
+    const { result } = renderHook(() => usePreferredExportFormat())
+    act(() => {
+      result.current.savePreference('csv')
+    })
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('csv')
+  })
+
+  it('updates preferred state when savePreference is called', () => {
+    const { result } = renderHook(() => usePreferredExportFormat())
+    act(() => {
+      result.current.savePreference('json')
+    })
+    expect(result.current.preferred).toBe('json')
+  })
+})

--- a/plugins/virtual-host-finder/metadata.json
+++ b/plugins/virtual-host-finder/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "ffuf"
@@ -33,14 +33,16 @@
       "label": "Target Host/IP",
       "type": "string",
       "required": true,
-      "placeholder": "secuscan.in"
+      "placeholder": "secuscan.in",
+      "help": "Enter the target domain or IP address to probe for virtual hosts. Example: secuscan.in or 192.168.1.1. Ensure you have authorization before scanning."
     },
     {
       "id": "wordlist",
       "label": "Subdomain Wordlist",
       "type": "string",
       "required": false,
-      "default": "/usr/share/seclists/Discovery/DNS/subdomains-top1million-110000.txt"
+      "default": "/usr/share/seclists/Discovery/DNS/subdomains-top1million-110000.txt",
+      "help": "Absolute path to a wordlist file containing subdomain names to fuzz. Defaults to the SecLists top 1 million subdomains list. Use a smaller list for faster scans."
     }
   ],
   "presets": {
@@ -66,5 +68,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "4f1b41fc1b9a02462f05122f660660cb096b8762a9a7986064e4acf6da9c5175"
+  "checksum": "9bf5ebb201ca600cf5a103bbe5b0256382c583461b0e9dfaf9e9c788315d1665"
 }

--- a/plugins/virtual-host-finder/metadata.json
+++ b/plugins/virtual-host-finder/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "🔎",
+  "icon": "\ud83d\udd0e",
   "engine": {
     "type": "cli",
     "binary": "ffuf"
@@ -68,5 +68,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "9bf5ebb201ca600cf5a103bbe5b0256382c583461b0e9dfaf9e9c788315d1665"
+  "checksum": "fb787f5f51da9f62c7a87d04694d5fa8624b0cf656f0d464436c7a8de45a58df"
 }


### PR DESCRIPTION
## Description
Added concise `help` text for both user-facing fields in `plugins/virtual-host-finder/metadata.json`. Also refreshed the plugin checksum after editing the metadata.

## Related Issues
Fixes #534

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?
- Verified JSON is valid with no syntax errors
- Refreshed plugin checksum using `python scripts/refresh_plugin_checksum.py --plugin virtual-host-finder`
- Checksum updated successfully from old to new value

[ATTACH SCREENSHOT OF METADATA.JSON HERE]

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
<img width="1296" height="481" alt="Screenshot 2026-06-07 224804" src="https://github.com/user-attachments/assets/21b3d3fa-5504-4553-99a5-812336b4e053" />
