### PR TITLE
554 pagination test coverage

### DIFF
--- a/frontend/testing/unit/components/Pagination.test.tsx
+++ b/frontend/testing/unit/components/Pagination.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import Pagination from "../../../src/components/Pagination";
+
+describe("Pagination", () => {
+  const defaultProps = {
+    page: 1,
+    total: 100,
+    limit: 10,
+    loading: false,
+    onPrev: vi.fn(),
+    onNext: vi.fn(),
+  };
+
+  // Range math tests
+  it("shows correct start and end for first page", () => {
+    render(<Pagination {...defaultProps} page={1} total={100} limit={10} />);
+    expect(screen.getByText("1–10")).toBeInTheDocument();
+  });
+
+  it("shows correct start and end for middle page", () => {
+    render(<Pagination {...defaultProps} page={3} total={100} limit={10} />);
+    expect(screen.getByText("21–30")).toBeInTheDocument();
+  });
+
+  it("shows correct end on last page with partial results", () => {
+    render(<Pagination {...defaultProps} page={5} total={42} limit={10} />);
+    expect(screen.getByText("41–42")).toBeInTheDocument();
+  });
+
+  it("shows 0 start and 0 end when total is 0", () => {
+    render(<Pagination {...defaultProps} page={1} total={0} limit={10} />);
+    expect(screen.getByText("0–0")).toBeInTheDocument();
+  });
+
+  // Disabled state tests
+  it("disables prev button on first page", () => {
+    render(<Pagination {...defaultProps} page={1} />);
+    expect(screen.getByText("Prev_Page").closest("button")).toBeDisabled();
+  });
+
+  it("enables next button when not on last page", () => {
+    render(<Pagination {...defaultProps} page={1} total={100} limit={10} />);
+    expect(screen.getByText("Next_Page").closest("button")).not.toBeDisabled();
+  });
+
+  it("disables next button on last page", () => {
+    render(<Pagination {...defaultProps} page={10} total={100} limit={10} />);
+    expect(screen.getByText("Next_Page").closest("button")).toBeDisabled();
+  });
+
+  it("disables both buttons when total is 0", () => {
+    render(<Pagination {...defaultProps} page={1} total={0} limit={10} />);
+    expect(screen.getByText("Prev_Page").closest("button")).toBeDisabled();
+    expect(screen.getByText("Next_Page").closest("button")).toBeDisabled();
+  });
+
+  it("disables both buttons when loading", () => {
+    render(<Pagination {...defaultProps} loading={true} />);
+    expect(screen.getByText("Prev_Page").closest("button")).toBeDisabled();
+    expect(screen.getByText("Next_Page").closest("button")).toBeDisabled();
+  });
+})

--- a/frontend/testing/unit/hooks/usePreferredExportFormat.test.ts
+++ b/frontend/testing/unit/hooks/usePreferredExportFormat.test.ts
@@ -1,0 +1,37 @@
+import { renderHook, act } from '@testing-library/react'
+import { usePreferredExportFormat } from "../../../src/hooks/usePreferredExportFormat";
+
+const STORAGE_KEY = 'secuscan:preferred-export-format'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('usePreferredExportFormat', () => {
+  it('returns null as default when no preference is stored', () => {
+    const { result } = renderHook(() => usePreferredExportFormat())
+    expect(result.current.preferred).toBeNull()
+  })
+
+  it('returns stored preference from localStorage on mount', () => {
+    localStorage.setItem(STORAGE_KEY, 'pdf')
+    const { result } = renderHook(() => usePreferredExportFormat())
+    expect(result.current.preferred).toBe('pdf')
+  })
+
+  it('saves preference to localStorage when savePreference is called', () => {
+    const { result } = renderHook(() => usePreferredExportFormat())
+    act(() => {
+      result.current.savePreference('csv')
+    })
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('csv')
+  })
+
+  it('updates preferred state when savePreference is called', () => {
+    const { result } = renderHook(() => usePreferredExportFormat())
+    act(() => {
+      result.current.savePreference('json')
+    })
+    expect(result.current.preferred).toBe('json')
+  })
+})


### PR DESCRIPTION
## Description
Adds direct unit test coverage for the Pagination component. Tests cover record range calculations and disabled states for prev/next buttons across empty, first-page, and last-page scenarios.

## Related Issues
Fixes #554

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?
Ran tests locally using Vitest:

npm test -- Pagination

All 9 tests passed:
- shows correct start and end for first page
- shows correct start and end for middle page
- shows correct end on last page with partial results
- shows 0 start and 0 end when total is 0
- disables prev button on first page
- enables next button when not on last page
- disables next button on last page
- disables both buttons when total is 0
- disables both buttons when loading

<img width="1197" height="451" alt="image" src="https://github.com/user-attachments/assets/15ba684a-79bc-4c1b-9fec-b8bbbb173af9" />


## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.