### PR TITLE
Fix/nuclearpurge localstorage

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -292,7 +292,9 @@ export default function Settings() {
             message: "CRITICAL: THIS WILL PURGE ALL HISTORY AND ASSETS. PROCEED?",
             type: "danger",
             onConfirm: () => {
-                localStorage.clear()
+                Object.keys(localStorage)
+                    .filter(key => key.startsWith('secuscan') || key === 'sidebar-expanded')
+                    .forEach(key => localStorage.removeItem(key))
                 window.location.reload()
                 setModalState(prev => ({ ...prev, isOpen: false }))
             }

--- a/frontend/testing/unit/pages/SettingsSaveReset.test.tsx
+++ b/frontend/testing/unit/pages/SettingsSaveReset.test.tsx
@@ -73,11 +73,15 @@ describe('Settings save/reset behavior', () => {
   })
   it('nuclear purge removes only secuscan-owned keys and preserves unrelated keys', async () => {
   // Set up SecuScan keys
+  // Set up SecuScan keys
   window.localStorage.setItem('secuscan-config', JSON.stringify(DEFAULT_CONFIG))
   window.localStorage.setItem('secuscan_api_key', 'test-api-key')
   window.localStorage.setItem('secuscan-saved-views', JSON.stringify([]))
+  window.localStorage.setItem('secuscan-finding-review-state', JSON.stringify({}))
+  window.localStorage.setItem('secuscan:preferred-export-format', 'html')
+  window.localStorage.setItem('secuscan_recent_tools', JSON.stringify([]))
+  window.localStorage.setItem('secuscan-theme', 'dark')
   window.localStorage.setItem('sidebar-expanded', 'true')
-
   // Set up an unrelated key
   window.localStorage.setItem('some-other-app-key', 'should-not-be-deleted')
 
@@ -93,6 +97,10 @@ describe('Settings save/reset behavior', () => {
   expect(window.localStorage.getItem('secuscan-config')).toBeNull()
   expect(window.localStorage.getItem('secuscan_api_key')).toBeNull()
   expect(window.localStorage.getItem('secuscan-saved-views')).toBeNull()
+  expect(window.localStorage.getItem('secuscan-finding-review-state')).toBeNull()
+  expect(window.localStorage.getItem('secuscan:preferred-export-format')).toBeNull()
+  expect(window.localStorage.getItem('secuscan_recent_tools')).toBeNull()
+  expect(window.localStorage.getItem('secuscan-theme')).toBeNull()
   expect(window.localStorage.getItem('sidebar-expanded')).toBeNull()
 
   // Unrelated key should still be there

--- a/frontend/testing/unit/pages/SettingsSaveReset.test.tsx
+++ b/frontend/testing/unit/pages/SettingsSaveReset.test.tsx
@@ -71,4 +71,31 @@ describe('Settings save/reset behavior', () => {
     const concurrentOps = getInputByLabelText(/Concurrent_Operations/i)
     expect(concurrentOps.value).toBe('8')
   })
+  it('nuclear purge removes only secuscan-owned keys and preserves unrelated keys', async () => {
+  // Set up SecuScan keys
+  window.localStorage.setItem('secuscan-config', JSON.stringify(DEFAULT_CONFIG))
+  window.localStorage.setItem('secuscan_api_key', 'test-api-key')
+  window.localStorage.setItem('secuscan-saved-views', JSON.stringify([]))
+  window.localStorage.setItem('sidebar-expanded', 'true')
+
+  // Set up an unrelated key
+  window.localStorage.setItem('some-other-app-key', 'should-not-be-deleted')
+
+  const user = userEvent.setup()
+  renderSettings()
+
+  await user.click(screen.getByRole('button', { name: /NUCLEAR_PURGE/i }))
+
+  const confirmButton = await screen.findByRole('button', { name: /confirm/i })
+  await user.click(confirmButton)
+
+  // SecuScan keys should be gone
+  expect(window.localStorage.getItem('secuscan-config')).toBeNull()
+  expect(window.localStorage.getItem('secuscan_api_key')).toBeNull()
+  expect(window.localStorage.getItem('secuscan-saved-views')).toBeNull()
+  expect(window.localStorage.getItem('sidebar-expanded')).toBeNull()
+
+  // Unrelated key should still be there
+  expect(window.localStorage.getItem('some-other-app-key')).toBe('should-not-be-deleted')
+})
 })


### PR DESCRIPTION
## Description
The handleNuclearPurge function was calling localStorage.clear() which wiped all browser storage indiscriminately, including keys that don't belong to SecuScan. This fix replaces it with a targeted approach that only removes SecuScan-owned keys.

## Related Issues
Closes #464 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Added a unit test in SettingsSaveReset.test.tsx that:
- Sets up SecuScan-owned keys (secuscan-config, secuscan_api_key, secuscan-saved-views, sidebar-expanded) and an unrelated key (some-other-app-key).
- Triggers the Nuclear Purge and confirms the action.
- Verifies all SecuScan keys are removed.
- Verifies the unrelated keys are preserved.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
