### PR TITLE
Add request ID middleware unit tests

### DIFF
--- a/testing/backend/unit/test_request_middleware.py
+++ b/testing/backend/unit/test_request_middleware.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+
+from backend.secuscan.main import app
+
+
+class TestRequestIDMiddleware:
+    def test_preserves_existing_request_id(self):
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/v1/health",
+                headers={"X-Request-ID": "test-request-123"},
+            )
+
+        assert response.status_code == 200
+        assert response.headers["X-Request-ID"] == "test-request-123"
+
+    def test_generates_request_id_when_missing(self):
+        with TestClient(app) as client:
+            response = client.get("/api/v1/health")
+
+        assert response.status_code == 200
+        assert "X-Request-ID" in response.headers
+        assert response.headers["X-Request-ID"]
+
+    def test_response_always_contains_request_id_header(self):
+        with TestClient(app) as client:
+            response = client.get("/api/v1/health")
+
+        assert response.status_code == 200
+        assert "X-Request-ID" in response.headers


### PR DESCRIPTION
## Description

Added unit test coverage for `RequestIDMiddleware`.

Changes include:

* Testing preservation of an incoming `X-Request-ID` header.
* Testing automatic request ID generation when the header is missing.
* Testing that responses always include an `X-Request-ID` header.

## Related Issues

Closes #565

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran the middleware test suite locally:

```bash
python -m pytest testing/backend/unit/test_request_middleware.py
```

Verified:

* Existing `X-Request-ID` values are preserved.
* A request ID is generated when one is not provided.
* Responses always contain an `X-Request-ID` header.

Result:

* 3 tests passed.

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.

