### PR TITLE
test: add settings persistence coverage

### DIFF
--- a/frontend/testing/e2e/settings-persistence.spec.ts
+++ b/frontend/testing/e2e/settings-persistence.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Settings persistence", () => {
+
+  test("theme persists after reload", async ({ page }) => {
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "secuscan_api_key",
+        "6abeafd82cdb0eebea98dc3817b0bb5f9f8773f60402bccad9eaad7870ae8f58"
+      );
+    });
+
+    await page.goto("/settings");
+
+    await page.waitForLoadState("networkidle");
+
+    const themeSelect = page.getByLabel(/visual spectrum theme/i);
+
+    await themeSelect.selectOption("light");
+
+    await page.getByRole("button", {
+      name: /commit_engine_changes/i,
+    }).click();
+
+    await page.reload();
+
+    await expect(
+      page.getByLabel(/visual spectrum theme/i)
+    ).toHaveValue("light");
+  });
+
+  test("theme reset path is available", async ({ page }) => {
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      localStorage.setItem("secuscan_api_key",  "6abeafd82cdb0eebea98dc3817b0bb5f9f8773f60402bccad9eaad7870ae8f58");
+    });
+
+    await page.goto("/settings");
+
+    const resetButton = page.getByRole("button", {
+      name: /reset to system default/i,
+    });
+
+    await expect(resetButton).toBeVisible();
+
+
+  });
+
+});


### PR DESCRIPTION
## Description
Added Playwright E2E coverage for Settings persistence functionality.

Changes included:
- Added a test for theme persistence after page reload.
- Added a test to verify the theme reset path is available in the UI.
- Verified settings persistence behavior through Playwright.

## Related Issues
Closes #562 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Executed:

```bash
npx playwright test testing/e2e/settings-persistence.spec.ts --headed
```

Result:

```text
Running 2 tests using 1 worker

✓ Settings persistence › theme persists after reload
✓ Settings persistence › theme reset path is available

2 passed
```

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
