### PR TITLE
test: add logging utils unit coverage

### DIFF
--- a/testing/backend/unit/test_logging_utils.py
+++ b/testing/backend/unit/test_logging_utils.py
@@ -1,0 +1,70 @@
+import json
+import logging
+
+from backend.secuscan.logging_utils import RequestIDFilter, JSONFormatter
+
+
+def test_request_id_filter_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "backend.secuscan.logging_utils.get_request_id",
+        lambda: None,
+    )
+
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+
+    filt = RequestIDFilter()
+    assert filt.filter(record) is True
+    assert record.request_id == "no-request-id"
+
+
+def test_json_formatter_serializes_log_record():
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello world",
+        args=(),
+        exc_info=None,
+    )
+    record.request_id = "req-123"
+
+    formatter = JSONFormatter()
+    result = json.loads(formatter.format(record))
+
+    assert result["level"] == "INFO"
+    assert result["logger"] == "test_logger"
+    assert result["message"] == "hello world"
+    assert result["request_id"] == "req-123"
+    assert "timestamp" in result
+
+
+def test_json_formatter_serializes_exception():
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        exc_info = __import__("sys").exc_info()
+
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="failure",
+        args=(),
+        exc_info=exc_info,
+    )
+
+    formatter = JSONFormatter()
+    result = json.loads(formatter.format(record))
+
+    assert "exception" in result
+    assert "ValueError" in result["exception"]


### PR DESCRIPTION
## Description
Added direct unit test coverage for `backend/secuscan/logging_utils.py`.

Changes:
- Added test coverage for `RequestIDFilter`.
- Verified fallback behavior when no request ID is available.
- Added test coverage for `JSONFormatter`.
- Verified JSON log serialization.
- Verified exception information is serialized into the JSON payload.

## Related Issues
Closes #566 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Executed:

python -m pytest testing/backend/unit/test_logging_utils.py -v

Result:

3 passed

Tests cover:
- Request ID fallback behavior
- JSON log serialization
- Exception serialization

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
