### PR TITLE
refactor(plugins): migrate url-fuzzer-2 validation from raw regex to named preset #539

### DIFF
--- a/plugins/url-fuzzer-2/metadata.json
+++ b/plugins/url-fuzzer-2/metadata.json
@@ -74,5 +74,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "ef9286921aac3a11c5583f60ee706f385e40b9930da8d95788ba963c2194318b"
+  "checksum": "4fada9f7e171899e44ddccdb66be22500f086a7afe1c69b46a01c16e5803e66c"
 }

--- a/plugins/url-fuzzer-2/metadata.json
+++ b/plugins/url-fuzzer-2/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "ffuf"
@@ -33,7 +33,7 @@
       "required": true,
       "placeholder": "https://secuscan.in",
       "validation": {
-        "pattern": "^https?://",
+        "validation_type": "url",
         "message": "Must be a valid HTTP(S) URL"
       }
     },
@@ -74,5 +74,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "92487e75582ea0ca9680f5626a2aa93bcb8ecc72c64a35a78f8704175033ddc5"
+  "checksum": "ef9286921aac3a11c5583f60ee706f385e40b9930da8d95788ba963c2194318b"
 }

--- a/plugins/url-fuzzer-2/metadata.json
+++ b/plugins/url-fuzzer-2/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "🔎",
+  "icon": "\ud83d\udd0e",
   "engine": {
     "type": "cli",
     "binary": "ffuf"
@@ -74,5 +74,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "4fada9f7e171899e44ddccdb66be22500f086a7afe1c69b46a01c16e5803e66c"
+  "checksum": "ef9286921aac3a11c5583f60ee706f385e40b9930da8d95788ba963c2194318b"
 }

--- a/scripts/refresh_plugin_checksum.py
+++ b/scripts/refresh_plugin_checksum.py
@@ -49,11 +49,11 @@ def compute_plugin_digest(metadata_file: Path, parser_file: Path) -> str:
     metadata_digest = hashlib.sha256(metadata_canonical.encode("utf-8")).hexdigest()
 
     # Hash parser.py if it exists, otherwise use empty string
-    parser_digest = (
-        hashlib.sha256(parser_file.read_bytes()).hexdigest()
-        if parser_file.exists()
-        else ""
-    )
+    parser_digest = ""
+    if parser_file.exists():
+        parser_bytes = parser_file.read_bytes()
+        parser_bytes_normalized = parser_bytes.replace(b"\r\n", b"\n")
+        parser_digest = hashlib.sha256(parser_bytes_normalized).hexdigest()
 
     # Final digest combines both
     return hashlib.sha256(

--- a/scripts/refresh_plugin_checksum.py
+++ b/scripts/refresh_plugin_checksum.py
@@ -49,11 +49,11 @@ def compute_plugin_digest(metadata_file: Path, parser_file: Path) -> str:
     metadata_digest = hashlib.sha256(metadata_canonical.encode("utf-8")).hexdigest()
 
     # Hash parser.py if it exists, otherwise use empty string
-    parser_digest = ""
-    if parser_file.exists():
-        parser_bytes = parser_file.read_bytes()
-        parser_bytes_normalized = parser_bytes.replace(b"\r\n", b"\n")
-        parser_digest = hashlib.sha256(parser_bytes_normalized).hexdigest()
+    parser_digest = (
+        hashlib.sha256(parser_file.read_bytes()).hexdigest()
+        if parser_file.exists()
+        else ""
+    )
 
     # Final digest combines both
     return hashlib.sha256(


### PR DESCRIPTION
Closes #539


## Description
Migrated the target URL input validation in `plugins/url-fuzzer-2/metadata.json` from a raw regex pattern check (`^https?://`) to the named `url` preset (`validation_type: "url"`). 
This replaces the bare regex-only check with the project's standard named preset validation, improving consistency and rejecting malformed URLs. The contributor-friendly custom error message has been preserved, and the plugin's integrity checksum has been successfully recalculated.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
To verify the correctness of the validation logic and the updated plugin integrity checksum, the following tests were executed:

1. **Plugin Schema and Validator Check:**
   Validated the plugin structure using the schema validator script:
   ```bash
   python scripts/validate_plugins.py