### PR TITLE
docs: add help text for amass metadata

### DIFF
--- a/plugins/amass/metadata.json
+++ b/plugins/amass/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "amass"
@@ -31,7 +31,7 @@
       "type": "string",
       "required": true,
       "placeholder": "secuscan.in",
-      "help_text": "Enter the root domain to enumerate subdomains for (for example: example.com). Do not include http://, https://, paths, or subdomains."
+      "help": "Enter the root domain to enumerate subdomains for (for example: example.com). Do not include http://, https://, paths, or subdomains."
     }
   ],
   "presets": {
@@ -56,5 +56,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "3f5cc0b7791448b3418ca14a8bec020984f97138a5dc1f4499ad72dfbbb1c415"
+  "checksum": "5a0ea8ff2a07b965685a2772bb2557afde4ef50e23dc423c99c27ce518494747"
 }

--- a/plugins/amass/metadata.json
+++ b/plugins/amass/metadata.json
@@ -30,7 +30,8 @@
       "label": "Root Domain",
       "type": "string",
       "required": true,
-      "placeholder": "secuscan.in"
+      "placeholder": "secuscan.in",
+      "help_text": "Enter the root domain to enumerate subdomains for (for example: example.com). Do not include http://, https://, paths, or subdomains."
     }
   ],
   "presets": {
@@ -55,5 +56,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "d15de85963abb77d529487e5000519ef554171826f37d3a223b44f67725b6312"
+  "checksum": "3f5cc0b7791448b3418ca14a8bec020984f97138a5dc1f4499ad72dfbbb1c415"
 }


### PR DESCRIPTION
Fixes #522

## Changes

* Added help text for the Root Domain field in `plugins/amass/metadata.json`
* Clarified the expected input format for Amass subdomain enumeration
* Refreshed the plugin checksum

## Verification

* Updated metadata successfully
* Refreshed checksum using `scripts/refresh_plugin_checksum.py`
* Verified JSON structure remains valid
