### PR TITLE
docs: clarify output directory in repository map

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The project is designed to be:
 - `.github/`: GitHub Actions workflows, issue templates, and contributor automation
 - `assets/`: project branding assets and images
 - `data/`: shared raw and generated project data
-- `output/`: generated reports and exported scan artifacts (runtime-generated)
+- `output/`: runtime-generated reports and exported scan artifacts; created during scans and not part of the checked-in repository tree
 - `wordlists/`: wordlists used by scanning and enumeration plugins
 - `scratch/`: experimental utilities and temporary development helpers
 


### PR DESCRIPTION
## Summary

Clarified the `output/` entry in the README repository map to indicate that it is a runtime-generated directory and not part of the checked-in repository tree.

## Changes

* Updated the description of `output/`
* Clarified that the directory is created during scans
* Improved distinction between source directories and generated artifacts

Fixes #587
