### PR TITLE
test(frontend): add AppShell unit coverage

### DIFF
--- a/frontend/testing/unit/components/AppShell.test.tsx
+++ b/frontend/testing/unit/components/AppShell.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+let pathname = '/'
+
+vi.mock('react-router-dom', () => ({
+  NavLink: ({ children, to }: any) => (
+    <a href={to}>{children}</a>
+  ),
+  useLocation: () => ({
+    pathname,
+  }),
+}))
+
+vi.mock('../../../src/components/Sidebar', () => ({
+  default: () => <div data-testid="sidebar" />,
+}))
+
+vi.mock('../../../src/components/Background', () => ({
+  default: () => <div data-testid="background" />,
+}))
+
+vi.mock('../../../src/hooks/useShortcuts', () => ({
+  useShortcuts: vi.fn(),
+}))
+
+import AppShell from '../../../src/components/AppShell'
+
+describe('AppShell', () => {
+  beforeEach(() => {
+    pathname = '/'
+    localStorage.clear()
+  })
+
+  it('renders children content', () => {
+    render(
+      <AppShell>
+        <div>Test Content</div>
+      </AppShell>
+    )
+
+    expect(screen.getByText('Test Content')).toBeTruthy()
+  })
+
+  it('opens and closes mobile drawer from menu button', () => {
+    render(
+      <AppShell>
+        <div>Content</div>
+      </AppShell>
+    )
+
+    const button = screen.getByLabelText(/toggle navigation menu/i)
+
+    fireEvent.click(button)
+
+    expect(screen.getByText('Settings')).toBeTruthy()
+
+    fireEvent.click(button)
+
+    expect(screen.queryByText('Settings')).toBeNull()
+  })
+
+  it('renders bottom navigation items', () => {
+    render(
+      <AppShell>
+        <div>Content</div>
+      </AppShell>
+    )
+
+    expect(screen.getByText('Dashboard')).toBeTruthy()
+    expect(screen.getByText('Scans')).toBeTruthy()
+    expect(screen.getByText('Findings')).toBeTruthy()
+    expect(screen.getByText('Reports')).toBeTruthy()
+    expect(screen.getByText('Workflows')).toBeTruthy()
+  })
+
+  it('renders drawer navigation items when menu is opened', () => {
+    render(
+      <AppShell>
+        <div>Content</div>
+      </AppShell>
+    )
+
+    fireEvent.click(
+      screen.getByLabelText(/toggle navigation menu/i)
+    )
+
+    expect(screen.getByText('Settings')).toBeTruthy()
+    expect(screen.getAllByText('Dashboard').length).toBeGreaterThan(0)
+  })
+
+  it('closes mobile drawer when route changes', () => {
+    const { rerender } = render(
+      <AppShell>
+        <div>Content</div>
+      </AppShell>
+    )
+
+    fireEvent.click(
+      screen.getByLabelText(/toggle navigation menu/i)
+    )
+
+    expect(screen.getByText('Settings')).toBeTruthy()
+
+    pathname = '/reports'
+
+    rerender(
+      <AppShell>
+        <div>Content</div>
+      </AppShell>
+    )
+
+    expect(screen.queryByText('Settings')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Description
- Added direct unit coverage for `AppShell`.
- Added tests for mobile menu open/close behavior.
- Added tests to verify the mobile drawer closes when the route changes.
- Added tests for mobile drawer and bottom navigation rendering.
- Added behavior-focused assertions instead of render-only checks.

## Related Issues
Closes #552 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

```bash
cd frontend
npm run test

npx vitest run testing/unit/components/AppShell.test.tsx
```

Result:

```text
Test Files  1 passed (1)
Tests       5 passed (5)
```

Verified:
- Mobile menu toggle behavior.
- Mobile drawer closes on route changes.
- Mobile drawer rendering.
- Bottom navigation rendering.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
