### PR TITLE
feat(plugins): add help text to spider metadata fields

### DIFF
--- a/plugins/spider/metadata.json
+++ b/plugins/spider/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee0\ufe0f",
+  "icon": "🛠️",
   "engine": {
     "type": "cli",
     "binary": "katana"
@@ -30,7 +30,7 @@
       "label": "Target URL",
       "type": "string",
       "required": true,
-      "help": "Enter the full website URL to scan (e.g: https://example.com)Compulsorily include the protocol (http/https).",
+      "help": "Enter the full website URL to scan, including the http:// or https:// protocol.",
       "placeholder": "https://secuscan.in",
       "validation": {
         "pattern": "^https?://",
@@ -71,5 +71,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "8b0111447c9ebc7d1487e2a8fafd4b2ee9c23e191eab39a124e372632b288254"
+  "checksum": "d4cda8a353aa7b8bbd35e993bd4bcf93be9a6835d0021a53d2f4b40a09ac591e"
 }

--- a/plugins/spider/metadata.json
+++ b/plugins/spider/metadata.json
@@ -30,6 +30,7 @@
       "label": "Target URL",
       "type": "string",
       "required": true,
+      "help": "Enter the full website URL to scan (e.g: https://example.com)Compulsorily include the protocol (http/https).",
       "placeholder": "https://secuscan.in",
       "validation": {
         "pattern": "^https?://",
@@ -41,6 +42,7 @@
       "label": "Depth",
       "type": "integer",
       "required": false,
+      "help": "Range of crawl depth: 1-10. Higher values scan deeper but take longer. Default: 3. Recommended: 1-5.",
       "default": 3
     }
   ],


### PR DESCRIPTION
Added help description for target field(include protocol http/https) and depth field (1-5 recommended for performance)

## Description
Added help text explaining target url requirement and crawl depth behavior.

- Updated plugins/spider/metadata.json with help text for both fields
- Help text references Katana tool behavior and performance trade-offs

## Related Issues
closes #532 

## Type of Change
- [x] Documentation update

## How Has This Been Tested?
- JSON validated using jsonlint.com
- Plugin validation executed successfully
- Regenerated plugin checksum using `python scripts/refresh_plugin_checksum.py --plugin spider`
- Verified checksum was updated successfully without errors

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
