### PR TITLE
Add help text for password auditor plugin fields

### DIFF
--- a/plugins/password_auditor/metadata.json
+++ b/plugins/password_auditor/metadata.json
@@ -27,7 +27,8 @@
       "label": "Target",
       "type": "string",
       "required": true,
-      "placeholder": "secuscan.in"
+      "placeholder": "secuscan.in",
+      "help": "Enter the hostname, domain, or service endpoint to review for weak credential and password policy risks."
     }
   ],
   "presets": {
@@ -53,5 +54,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "d3606fc8426a11a890874be7159b75b534da6c0f5aa56f8291578feb29934358"
+  "checksum": "e4806b82ed17444385bee8f2c9c1beae8cb7113fdb37368937589f32c8be1183"
 }

--- a/plugins/password_auditor/metadata.json
+++ b/plugins/password_auditor/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee0\ufe0f",
+  "icon": "🛠️",
   "engine": {
     "type": "cli",
     "binary": "python3"
@@ -54,5 +54,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "e4806b82ed17444385bee8f2c9c1beae8cb7113fdb37368937589f32c8be1183"
+  "checksum": "303a6a52375f996d47c526a147b33362af5600d1eaa326497108868ee6b65ea5"
 }


### PR DESCRIPTION
## Description

Adds missing help text for the `target` field in `plugins/password_auditor/metadata.json` to improve guidance in the generated UI.

### Changes

* Added help text explaining the expected target input.
* Refreshed the plugin checksum after updating metadata.

## Related Issues

Closes #650

## Type of Change

* [x] Documentation update

## How Has This Been Tested?

* Refreshed the plugin checksum using:
  `python scripts/refresh_plugin_checksum.py --plugin password_auditor`
* Verified the checksum is up to date.

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
