### PR TITLE
refactor(plugins): use url validation preset for api_scanner (closes #537)

### DIFF
--- a/plugins/api_scanner/metadata.json
+++ b/plugins/api_scanner/metadata.json
@@ -32,7 +32,7 @@
       "required": true,
       "placeholder": "https://api.secuscan.in",
       "validation": {
-        "pattern": "^https?://",
+        "validation_type": "url",
         "message": "Must be a valid HTTP(S) URL"
       }
     }
@@ -65,5 +65,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "90ba2af201a01543cc1064b4d489cfe2c4a5e94e9d7fb0750e18779ffb280a99"
+  "checksum": "d425be32c71b9da140ba95be80564374deac80a2b42592fe392413d1903789f8"
 }

--- a/testing/backend/test_api_scanner_plugin.py
+++ b/testing/backend/test_api_scanner_plugin.py
@@ -82,15 +82,14 @@ def test_api_scanner_has_required_target_field():
     assert fields["target"]["required"] is True
 
 
-def test_api_scanner_target_field_requires_http_url():
-    """The 'target' field must have a validation pattern requiring http(s)://."""
+def test_api_scanner_target_field_uses_url_validation_preset():
+    """The 'target' field must use the named url validation preset (issue #537)."""
     data = json.loads((PLUGIN_DIR / "metadata.json").read_text(encoding="utf-8"))
     fields = {f["id"]: f for f in data["fields"]}
     target_validation = fields["target"].get("validation", {})
-    pattern = target_validation.get("pattern", "")
-    assert "https?" in pattern or "http" in pattern, (
-        "target field must validate for HTTP(S) URL format"
-    )
+    assert target_validation.get("validation_type") == "url"
+    assert target_validation.get("message") == "Must be a valid HTTP(S) URL"
+    assert "pattern" not in target_validation
 
 
 def test_api_scanner_output_parser_is_custom():


### PR DESCRIPTION
Migrates api_scanner target validation from raw regex to validation_type: url, updates contract test, refreshes checksum. Closes #537.