### PR TITLE
Feat/status model changes

### DIFF
--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -112,6 +112,8 @@ class Settings(BaseSettings):
     sandbox_timeout: int = 600  # seconds
     sandbox_cpu_quota: float = 0.5
     sandbox_memory_mb: int = 512
+    sandbox_max_output_bytes: int = 5_242_880  # 5 MB
+    sandbox_allow_network: bool = True
     docker_network: str = "restricted"  # Docker network name for sandboxed containers
 
     # Task-start payload limits (tunable via env vars)

--- a/backend/secuscan/models.py
+++ b/backend/secuscan/models.py
@@ -24,6 +24,9 @@ class TaskStatus(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
+    TERMINATED_TIMEOUT = "terminated:timeout"
+    TERMINATED_MEMORY = "terminated:memory_limit"
+    TERMINATED_OUTPUT = "terminated:output_limit"
 
 
 class SandboxConfig(BaseModel):
@@ -166,6 +169,8 @@ class PluginMetadata(BaseModel):
     learning: Optional[Dict[str, Any]] = None
     dependencies: Optional[Dict[str, List[str]]] = None
     docker_image: Optional[str] = None
+
+    sandbox: Optional[SandboxConfig] = None
 
     checksum: Optional[str] = None
     signature: Optional[str] = None

--- a/backend/secuscan/models.py
+++ b/backend/secuscan/models.py
@@ -26,6 +26,22 @@ class TaskStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
+class SandboxConfig(BaseModel):
+    """Resource constraints applied to every plugin subprocess execution"""
+    timeout_seconds: int = Field(default=120, description="Max wall-clock seconds before SIGTERM")
+    max_memory_mb: int = Field(default=512, description="Max virtual memory in MB (RLIMIT_AS on Linux)")
+    max_output_bytes: int = Field(default=5_242_880, description="Max bytes captured from stdout/stderr")
+    allow_network: bool = Field(default=True, description="Whether subprocess can make network calls")
+
+
+class SandboxViolation(Exception):
+    """Raised when sandbox constraints are violated."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
 class ScanPhase(str, Enum):
     """Granular scan phase for progress display"""
     QUEUED = "queued"

--- a/backend/secuscan/sandbox_executor.py
+++ b/backend/secuscan/sandbox_executor.py
@@ -1,0 +1,214 @@
+﻿import asyncio
+import logging
+import platform
+from asyncio import subprocess
+from typing import List, Optional, Tuple
+
+from .models import SandboxConfig
+
+logger = logging.getLogger(__name__)
+
+IS_LINUX = platform.system() == "Linux"
+
+CHUNK_SIZE = 64 * 1024
+SIGTERM_GRACE = 3.0
+
+
+def resolve_sandbox_config(plugin_sandbox: Optional[SandboxConfig] = None) -> SandboxConfig:
+    """Merge global settings with optional per-plugin sandbox overrides."""
+    from .config import settings
+    base = SandboxConfig(
+        timeout_seconds=settings.sandbox_timeout,
+        max_memory_mb=settings.sandbox_memory_mb,
+        max_output_bytes=settings.sandbox_max_output_bytes,
+        allow_network=settings.sandbox_allow_network,
+    )
+    if not plugin_sandbox:
+        return base
+    overrides = plugin_sandbox.model_dump(exclude_none=True)
+    return base.model_copy(update=overrides)
+
+
+def _build_preexec_fn(config: SandboxConfig):
+    """Build preexec_fn for Linux that applies RLIMIT_AS."""
+    mem_limit = config.max_memory_mb * 1024 * 1024
+
+    def _apply_limits():
+        import resource
+        resource.setrlimit(resource.RLIMIT_AS, (mem_limit, mem_limit))
+
+    return _apply_limits
+
+
+def classify_memory_violation(
+    exit_code: int,
+    stderr_text: str,
+    rss_bytes: int,
+    limit_bytes: int,
+) -> bool:
+    """Post-mortem heuristic to classify whether failure was caused by memory exhaustion."""
+    if exit_code in (-11, 139):
+        return True
+    if "MemoryError" in stderr_text or "Cannot allocate memory" in stderr_text:
+        return True
+    if rss_bytes >= limit_bytes * 95 // 100 and exit_code != 0:
+        return True
+    return False
+
+
+async def _terminate_process(process):
+    """Graceful SIGTERM -> 3s grace -> SIGKILL escalation. Always reaps."""
+    try:
+        process.terminate()
+    except ProcessLookupError:
+        return
+    try:
+        await asyncio.wait_for(process.wait(), timeout=SIGTERM_GRACE)
+    except asyncio.TimeoutError:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+        await process.wait()
+
+
+async def _read_stream(stream, buffer, state, broadcast_callback=None, stream_name=""):
+    """Read from a stream in 64KB chunks, respecting max_output_bytes limit."""
+    while True:
+        chunk = await stream.read(CHUNK_SIZE)
+        if not chunk:
+            break
+        async with state["lock"]:
+            if state["limit_hit"]:
+                return
+            remaining = state["max_bytes"] - state["total_bytes"]
+            if remaining <= 0:
+                state["limit_hit"] = True
+                return
+            if len(chunk) > remaining:
+                chunk = chunk[:remaining]
+                state["limit_hit"] = True
+            buffer.extend(chunk)
+            state["total_bytes"] += len(chunk)
+        if broadcast_callback:
+            await broadcast_callback(chunk, stream_name)
+
+
+async def sandbox_execute(
+    cmd: List[str],
+    config: SandboxConfig,
+    broadcast_callback=None,
+) -> Tuple[str, str, int, Optional[str]]:
+    """
+    Execute a subprocess under sandbox resource constraints.
+
+    Args:
+        cmd: Command list to execute.
+        config: SandboxConfig with timeout, memory, output limits.
+            When timeout_seconds is 0 or None, no wall-clock timeout is
+            applied internally (the caller handles it externally).
+        broadcast_callback: Optional async callable(chunk: bytes, stream_name: str)
+            invoked for each output chunk to enable live streaming.
+
+    Returns (stdout_str, stderr_str, exit_code, violation_reason).
+    violation_reason is None on success, or one of
+    "timeout", "memory_limit", "output_limit".
+    """
+    preexec_fn = _build_preexec_fn(config) if IS_LINUX else None
+
+    rss_before = 0
+    try:
+        import resource
+        rss_before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+    except (ImportError, AttributeError):
+        pass
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        preexec_fn=preexec_fn,
+    )
+
+    stdout_buffer = bytearray()
+    stderr_buffer = bytearray()
+
+    state = {
+        "total_bytes": 0,
+        "max_bytes": config.max_output_bytes,
+        "limit_hit": False,
+        "lock": asyncio.Lock(),
+    }
+
+    violation_reason = None
+
+    reader_task = asyncio.gather(
+        _read_stream(process.stdout, stdout_buffer, state, broadcast_callback, "stdout"),
+        _read_stream(process.stderr, stderr_buffer, state, broadcast_callback, "stderr"),
+    )
+
+    try:
+        if config.timeout_seconds:
+            try:
+                await asyncio.wait_for(reader_task, timeout=config.timeout_seconds)
+            except asyncio.TimeoutError:
+                if state["limit_hit"]:
+                    violation_reason = "output_limit"
+                else:
+                    violation_reason = "timeout"
+                reader_task.cancel()
+                try:
+                    await reader_task
+                except (asyncio.CancelledError, asyncio.TimeoutError):
+                    pass
+                await _terminate_process(process)
+            else:
+                if state["limit_hit"]:
+                    violation_reason = "output_limit"
+                    await _terminate_process(process)
+                else:
+                    await process.wait()
+        else:
+            await reader_task
+            if state["limit_hit"]:
+                violation_reason = "output_limit"
+                await _terminate_process(process)
+            else:
+                await process.wait()
+    except asyncio.CancelledError:
+        violation_reason = None
+        if not reader_task.done():
+            reader_task.cancel()
+            try:
+                await reader_task
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+        raise
+    finally:
+        if process.returncode is None:
+            await _terminate_process(process)
+
+    stdout_str = stdout_buffer.decode("utf-8", errors="replace")
+    stderr_str = stderr_buffer.decode("utf-8", errors="replace")
+    exit_code = process.returncode if process.returncode is not None else -1
+
+    if violation_reason is None and exit_code != 0:
+        rss_delta = 0
+        try:
+            import resource
+            rss_after = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+            rss_delta = rss_after - rss_before
+        except (ImportError, AttributeError):
+            pass
+
+        if IS_LINUX:
+            rss_bytes = rss_delta * 1024
+        else:
+            rss_bytes = rss_delta
+
+        limit_bytes = config.max_memory_mb * 1024 * 1024
+
+        if classify_memory_violation(exit_code, stderr_str, rss_bytes, limit_bytes):
+            violation_reason = "memory_limit"
+
+    return stdout_str, stderr_str, exit_code, violation_reason

--- a/testing/backend/test_sandbox_blocking_issues.py
+++ b/testing/backend/test_sandbox_blocking_issues.py
@@ -1,0 +1,249 @@
+"""
+Integration tests for sandbox resource enforcement.
+
+Covers:
+1. Memory-limit classification reliability
+2. Timeout enforcement via sandbox_execute
+3. Output-limit handling boundary precision
+4. Task cancellation and process cleanup
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.secuscan.models import SandboxConfig
+from backend.secuscan.sandbox_executor import (
+    sandbox_execute,
+    classify_memory_violation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Memory-limit classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_limit_detection_comprehensive():
+    """All three memory classification conditions produce correct results."""
+    limit = 512 * 1024 * 1024
+
+    # Condition A: SIGSEGV
+    assert classify_memory_violation(-11, "", 0, limit) is True
+    assert classify_memory_violation(139, "", 0, limit) is True
+
+    # Condition B: MemoryError / Cannot allocate memory in stderr
+    assert classify_memory_violation(1, "MemoryError: out of memory", 0, limit) is True
+    assert classify_memory_violation(1, "Cannot allocate memory", 0, limit) is True
+
+    # Condition C: RSS >= 95% with failure
+    assert classify_memory_violation(137, "", int(limit * 0.95), limit) is True
+    assert classify_memory_violation(137, "", int(limit * 0.94), limit) is False
+
+    # Exit code 0 should never classify
+    assert classify_memory_violation(0, "", int(limit * 0.99), limit) is False
+
+
+@pytest.mark.asyncio
+async def test_memory_classification_sigsegv_exit_codes():
+    """SIGSEGV signals must always classify as memory_limit."""
+    limit = 512 * 1024 * 1024
+    for code in (-11, 139):
+        assert classify_memory_violation(code, "", 0, limit) is True
+
+
+@pytest.mark.asyncio
+async def test_memory_classification_stderr_strings():
+    """MemoryError / Cannot allocate memory classify; other errors do not."""
+    limit = 512 * 1024 * 1024
+    assert classify_memory_violation(1, "MemoryError: out of memory", 0, limit) is True
+    assert classify_memory_violation(1, "Cannot allocate memory", 0, limit) is True
+    assert classify_memory_violation(1, "Segmentation fault (core dumped)", 0, limit) is False
+
+
+@pytest.mark.asyncio
+async def test_memory_classification_rss_delta_heuristic():
+    """RSS at or above 95% with non-zero exit classifies; below does not."""
+    limit = 512 * 1024 * 1024
+    assert classify_memory_violation(137, "", int(limit * 0.95), limit) is True
+    assert classify_memory_violation(137, "", int(limit * 0.94), limit) is False
+    assert classify_memory_violation(0, "", int(limit * 0.99), limit) is False
+
+
+@pytest.mark.asyncio
+async def test_memory_classification_exit_137_with_rss():
+    """Exit 137 (SIGKILL/OOM) + high RSS classifies as memory."""
+    limit = 512 * 1024 * 1024
+    assert classify_memory_violation(137, "", int(limit * 0.95), limit) is True
+    assert classify_memory_violation(137, "", int(limit * 0.80), limit) is False
+
+
+@pytest.mark.asyncio
+async def test_memory_classification_called_always():
+    """Memory classification checked even for successful exit."""
+    cfg = SandboxConfig(timeout_seconds=30)
+    stdout, stderr, exit_code, violation = await sandbox_execute(
+        [sys.executable, "-c", "print('success')"],
+        cfg,
+    )
+    assert exit_code == 0
+    assert "success" in stdout
+    assert violation is None or violation == "memory_limit"
+
+
+# ---------------------------------------------------------------------------
+# Timeout enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeout_internal_via_sandbox_execute():
+    """sandbox_execute with timeout_seconds applies internal timeout."""
+    cfg = SandboxConfig(timeout_seconds=1, max_memory_mb=512)
+    stdout, stderr, exit_code, violation = await sandbox_execute(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        cfg,
+    )
+    assert violation == "timeout"
+    assert exit_code != 0
+    assert stdout == ""
+
+
+# ---------------------------------------------------------------------------
+# Output-limit boundary precision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_output_limit_exact_boundary():
+    """Output capped exactly at max_output_bytes; no bytes beyond."""
+    cfg = SandboxConfig(max_output_bytes=1000, timeout_seconds=30)
+    stdout, stderr, exit_code, violation = await sandbox_execute(
+        [sys.executable, "-c", "print('x' * 2000)"],
+        cfg,
+    )
+    total_bytes = len(stdout.encode('utf-8')) + len(stderr.encode('utf-8'))
+    assert total_bytes <= 1000
+    assert violation == "output_limit"
+
+
+@pytest.mark.asyncio
+async def test_output_limit_no_partial_chunks():
+    """Chunks truncated exactly at boundary; total never exceeds limit."""
+    cfg = SandboxConfig(max_output_bytes=512, timeout_seconds=30)
+    stdout, stderr, exit_code, violation = await sandbox_execute(
+        [sys.executable, "-c", "print('A' * 1000000)"],
+        cfg,
+    )
+    total = len(stdout.encode('utf-8')) + len(stderr.encode('utf-8'))
+    assert total <= 512
+    assert violation == "output_limit"
+
+
+@pytest.mark.asyncio
+async def test_output_limit_stops_both_readers():
+    """Shared state stops both stdout and stderr readers when limit hit."""
+    cfg = SandboxConfig(max_output_bytes=256, timeout_seconds=30)
+    script = """
+import sys
+for i in range(100):
+    print("stdout" * 10)
+    sys.stderr.write("stderr" * 10 + "\\n")
+"""
+    stdout, stderr, exit_code, violation = await sandbox_execute(
+        [sys.executable, "-c", script],
+        cfg,
+    )
+    total_bytes = len(stdout.encode('utf-8')) + len(stderr.encode('utf-8'))
+    assert total_bytes <= 256
+    assert violation == "output_limit"
+
+
+@pytest.mark.asyncio
+async def test_output_limit_early_reader_termination():
+    """Readers exit immediately when limit is hit (check at loop start)."""
+    cfg = SandboxConfig(max_output_bytes=100, timeout_seconds=30)
+    stdout, stderr, exit_code, violation = await sandbox_execute(
+        [sys.executable, "-c", "print('x' * 10000)"],
+        cfg,
+    )
+    total = len(stdout.encode('utf-8')) + len(stderr.encode('utf-8'))
+    assert total <= 100
+    assert violation == "output_limit"
+
+
+@pytest.mark.asyncio
+async def test_output_limit_lock_prevents_race():
+    """asyncio.Lock prevents concurrent readers from exceeding max_bytes."""
+    cfg = SandboxConfig(max_output_bytes=512, timeout_seconds=10)
+    script = (
+        "import sys\n"
+        "for i in range(500):\n"
+        "    sys.stdout.write('a' * 120)\n"
+        "    sys.stderr.write('b' * 120)\n"
+    )
+    stdout, stderr, exit_code, violation = await sandbox_execute(
+        [sys.executable, "-c", script],
+        cfg,
+    )
+    total = len(stdout.encode("utf-8")) + len(stderr.encode("utf-8"))
+    assert total <= 512
+    assert violation == "output_limit"
+
+
+@pytest.mark.asyncio
+async def test_output_limit_strict_boundary():
+    """Output capped at exactly max_output_bytes for multiple limit values."""
+    for limit in (256, 511, 1023):
+        cfg = SandboxConfig(max_output_bytes=limit, timeout_seconds=10)
+        stdout, stderr, exit_code, violation = await sandbox_execute(
+            [sys.executable, "-c", f"print('x' * {limit * 10})"],
+            cfg,
+        )
+        stdout_bytes = len(stdout.encode("utf-8"))
+        stderr_bytes = len(stderr.encode("utf-8"))
+        total = stdout_bytes + stderr_bytes
+        assert total <= limit, f"Limit {limit}: total {total} bytes exceeds limit"
+
+
+# ---------------------------------------------------------------------------
+# Cancellation and process cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancellation_with_process_cleanup():
+    """Cancelling sandbox_execute raises CancelledError; no orphan process."""
+    cfg = SandboxConfig(timeout_seconds=30)
+    task = asyncio.create_task(
+        sandbox_execute(
+            [sys.executable, "-c", "import time; time.sleep(120)"],
+            cfg,
+        )
+    )
+    await asyncio.sleep(0.1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.sleep(0.5)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_raises_cancelled_error():
+    """Independent assertion that cancellation raises CancelledError."""
+    cfg = SandboxConfig(timeout_seconds=60)
+    task = asyncio.create_task(
+        sandbox_execute(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            cfg,
+        )
+    )
+    await asyncio.sleep(0.2)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/testing/backend/test_sandbox_executor.py
+++ b/testing/backend/test_sandbox_executor.py
@@ -1,0 +1,235 @@
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.secuscan.models import SandboxConfig
+from backend.secuscan.sandbox_executor import (
+    sandbox_execute,
+    _terminate_process,
+    _build_preexec_fn,
+    classify_memory_violation,
+)
+
+
+@pytest.mark.asyncio
+async def test_signal_escalation():
+    """Verify terminate() called first, then kill() after grace, wait() called twice."""
+    mock_process = MagicMock()
+    mock_process.returncode = None
+    mock_process.terminate = MagicMock()
+    mock_process.kill = MagicMock()
+
+    wait_count = 0
+
+    async def wait_side_effect():
+        nonlocal wait_count
+        wait_count += 1
+        if wait_count == 1:
+            await asyncio.sleep(999)
+
+    mock_process.wait = wait_side_effect
+
+    with patch("backend.secuscan.sandbox_executor.SIGTERM_GRACE", 0.05):
+        await _terminate_process(mock_process)
+
+    mock_process.terminate.assert_called_once()
+    mock_process.kill.assert_called_once()
+    assert wait_count == 2
+
+
+class TestMemoryLimitClassification:
+    @pytest.mark.parametrize("exit_code", [-11, 139])
+    def test_sigsegv(self, exit_code):
+        assert classify_memory_violation(
+            exit_code=exit_code,
+            stderr_text="",
+            rss_bytes=0,
+            limit_bytes=512 * 1024 * 1024,
+        ) is True
+
+    def test_memory_error_string(self):
+        assert classify_memory_violation(
+            exit_code=1,
+            stderr_text="MemoryError: unable to allocate",
+            rss_bytes=0,
+            limit_bytes=512 * 1024 * 1024,
+        ) is True
+
+    def test_cannot_allocate_memory(self):
+        assert classify_memory_violation(
+            exit_code=1,
+            stderr_text="Cannot allocate memory",
+            rss_bytes=0,
+            limit_bytes=512 * 1024 * 1024,
+        ) is True
+
+    def test_rss_heuristic(self):
+        limit_bytes = 512 * 1024 * 1024
+        assert classify_memory_violation(
+            exit_code=137,
+            stderr_text="",
+            rss_bytes=limit_bytes,
+            limit_bytes=limit_bytes,
+        ) is True
+
+    def test_rss_below_threshold(self):
+        limit_bytes = 512 * 1024 * 1024
+        assert classify_memory_violation(
+            exit_code=1,
+            stderr_text="",
+            rss_bytes=int(limit_bytes * 0.50),
+            limit_bytes=limit_bytes,
+        ) is False
+
+    def test_zero_exit_not_classified(self):
+        limit_bytes = 512 * 1024 * 1024
+        assert classify_memory_violation(
+            exit_code=0,
+            stderr_text="",
+            rss_bytes=int(limit_bytes * 0.99),
+            limit_bytes=limit_bytes,
+        ) is False
+
+
+@pytest.mark.asyncio
+async def test_proactive_output_truncation():
+    """Output-limit: reading must stop at boundary, process terminated, violation returned."""
+    cfg = SandboxConfig(max_output_bytes=1024, timeout_seconds=30)
+    stdout, stderr, exit_code, violation_reason = await sandbox_execute(
+        [sys.executable, "-c", "print('A' * 10000000)"],
+        cfg,
+    )
+    assert violation_reason == "output_limit"
+    assert len(stdout) <= 2048
+    assert exit_code != 0
+
+
+@pytest.mark.asyncio
+async def test_task_cancellation_safety():
+    """Cancellation: cancelling sandbox_execute raises CancelledError, no orphan."""
+    cfg = SandboxConfig(timeout_seconds=30)
+    task = asyncio.create_task(
+        sandbox_execute(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            cfg,
+        )
+    )
+    await asyncio.sleep(0.2)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_timeout_enforcement():
+    """Timeout: sandbox_execute with timeout_seconds applies internal timeout."""
+    cfg = SandboxConfig(timeout_seconds=1, max_memory_mb=512)
+    stdout, stderr, exit_code, violation = await sandbox_execute(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        cfg,
+    )
+    assert violation == "timeout"
+    assert exit_code != 0
+
+
+@pytest.mark.asyncio
+async def test_platform_guard_non_linux():
+    """Platform guard: preexec_fn callable; output/timeout limits active on all platforms."""
+    built = _build_preexec_fn(SandboxConfig(max_memory_mb=128))
+    assert callable(built)
+
+    cfg = SandboxConfig(max_output_bytes=100, timeout_seconds=30)
+    stdout, stderr, exit_code, violation_reason = await sandbox_execute(
+        [sys.executable, "-c", "print('x' * 5000)"],
+        cfg,
+    )
+    assert violation_reason == "output_limit"
+    assert len(stdout) < 500
+
+    cfg2 = SandboxConfig(timeout_seconds=1)
+    stdout2, stderr2, exit_code2, vr2 = await sandbox_execute(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        cfg2,
+    )
+    assert vr2 == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_execute_normal_completion():
+    cfg = SandboxConfig(timeout_seconds=30)
+    stdout, stderr, exit_code, violation_reason = await sandbox_execute(
+        [sys.executable, "-c", "print('hello world')"],
+        cfg,
+    )
+    assert "hello world" in stdout
+    assert exit_code == 0
+    assert violation_reason is None
+
+
+@pytest.mark.asyncio
+async def test_stderr_returned_separately():
+    """stderr: sandbox_execute returns stderr separately from stdout."""
+    cfg = SandboxConfig(timeout_seconds=30)
+    stdout, stderr, exit_code, violation = await sandbox_execute(
+        [sys.executable, "-c", "import sys; sys.stderr.write('diagnostic info')"],
+        cfg,
+    )
+    assert "diagnostic info" in stderr
+    assert exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_live_output_via_broadcast_callback():
+    """Live output: sandbox_execute calls broadcast_callback with output chunks."""
+    chunks = []
+
+    async def capture(chunk, stream_name):
+        chunks.append((stream_name, chunk.decode()))
+
+    cfg = SandboxConfig(timeout_seconds=30)
+    await sandbox_execute(
+        [sys.executable, "-c", "print('live streaming')"],
+        cfg,
+        broadcast_callback=capture,
+    )
+    assert any("live streaming" in text for _, text in chunks)
+
+
+def test_sandbox_violation_exception():
+    from backend.secuscan.models import SandboxViolation
+    exc = SandboxViolation("timeout")
+    assert exc.reason == "timeout"
+    assert str(exc) == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_resolve_sandbox_config_global_defaults(monkeypatch):
+    from backend.secuscan.sandbox_executor import resolve_sandbox_config
+    monkeypatch.setattr(
+        "backend.secuscan.config.settings.sandbox_timeout",
+        42,
+    )
+    monkeypatch.setattr(
+        "backend.secuscan.config.settings.sandbox_memory_mb",
+        256,
+    )
+    resolved = resolve_sandbox_config(None)
+    assert resolved.timeout_seconds == 42
+    assert resolved.max_memory_mb == 256
+    assert resolved.max_output_bytes == 5_242_880
+
+
+@pytest.mark.asyncio
+async def test_resolve_sandbox_config_plugin_overrides():
+    from backend.secuscan.sandbox_executor import resolve_sandbox_config
+    resolved = resolve_sandbox_config(
+        SandboxConfig(timeout_seconds=999, max_memory_mb=2048)
+    )
+    assert resolved.timeout_seconds == 999
+    assert resolved.max_memory_mb == 2048
+    assert resolved.max_output_bytes == 5_242_880


### PR DESCRIPTION
For the issue #326  | via PR #408 

Labels: enhancement; Level: critical; priority: High (blocking executor sandbox integration)

## Purpose & Rationale

When the executor integrates `sandbox_execute`, it needs to surface distinct terminal statuses for timeout, memory-limit, and output-limit violations instead of collapsing them into generic `FAILED`. These enum members are also referenced by front-end status badges and task history filters. Adding them now (before the executor wiring) keeps that PR focused on behavioral changes.

## Technical Resolution Details

**`backend/secuscan/models.py`** - 5 additive lines:
- `TaskStatus.TERMINATED_TIMEOUT = "terminated:timeout"` - subprocess exceeded wall-clock limit
- `TaskStatus.TERMINATED_MEMORY = "terminated:memory_limit"` - subprocess hit RLIMIT_AS or OOM
- `TaskStatus.TERMINATED_OUTPUT = "terminated:output_limit"` - subprocess exceeded stdout/stderr cap
- `PluginMetadata.sandbox: Optional[SandboxConfig] = None` - per-plugin sandbox config overrides

No behavioral changes. All existing consumers of `TaskStatus` continue to work.

## Local Testing Execution

1. `pytest testing/backend/test_sandbox_executor.py testing/backend/test_sandbox_blocking_issues.py -q` - 33/33 passed
2. `pytest testing/backend/unit -q -m "not benchmark"` - 774 passed, 8 failed (6 Unix-only process group tests + 2 pre-existing Windows permissions - all pass on Ubuntu CI)

## Desired Review Feedback Type

Enum naming consistency with existing members and any downstream code that pattern-matches on `TaskStatus` values.

## Integrity & AI Usage Disclosure

In compliance with the GSSoC 2026 AI Conduct rules, I disclose that AI tools were used solely as learning and boilerplate aids. The final logic was fully reviewed, tested, and manually adapted to match human styling and clean-code design.