### PR TITLE
feat(findings): prioritize contextual risk scores

### DIFF
--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -125,7 +125,7 @@ const filterLabelClass = 'text-[10px] font-black uppercase tracking-[0.2em] text
 const filterControlClass =
   'h-11 w-full border-2 border-silver-bright/10 bg-charcoal-dark px-3 text-xs font-mono text-silver-bright focus:border-rag-red focus:outline-none'
 
-type SortMode = 'severity' | 'newest' | 'oldest' | 'target'
+type SortMode = 'risk' | 'severity' | 'newest' | 'oldest' | 'target'
 
 // ─── Virtual row types ────────────────────────────────────────────────────────
 
@@ -151,7 +151,7 @@ export default function Findings() {
   const [filterAsset, setFilterAsset] = useState('all')
   const [filterValidatedOnly, setFilterValidatedOnly] = useState(false)
   const [filterHighConfidence, setFilterHighConfidence] = useState(false)
-  const [sortMode, setSortMode] = useState<SortMode>('severity')
+  const [sortMode, setSortMode] = useState<SortMode>('risk')
   const [dateFrom, setDateFrom] = useState('')
   const [dateTo, setDateTo] = useState('')
   const [selectedFindingId, setSelectedFindingId] = useState<string | null>(null)
@@ -320,6 +320,12 @@ export default function Findings() {
   const sortedFindings = useMemo(() => {
     const items = [...filteredFindings]
     switch (sortMode) {
+      case 'risk':
+        return items.sort((a, b) => {
+          const ra = a.risk_score ?? 0
+          const rb = b.risk_score ?? 0
+          return rb - ra
+        })
       case 'newest':
         return items.sort((a, b) => {
           const da = parseDateSafe(a.discovered_at)?.getTime() ?? 0
@@ -415,7 +421,7 @@ export default function Findings() {
     if (filterAnalystStatus !== 'all') chips.push({ key: 'analyst', label: `Analyst: ${filterAnalystStatus}` })
     if (filterValidatedOnly) chips.push({ key: 'validated', label: 'Validated Only' })
     if (filterHighConfidence) chips.push({ key: 'confidence', label: 'High Confidence' })
-    if (sortMode !== 'severity') chips.push({ key: 'sort',    label: `Sort: ${sortMode}` })
+    if (sortMode !== 'risk') chips.push({ key: 'sort',    label: `Sort: ${sortMode}` })
     if (dateFrom)                chips.push({ key: 'from',    label: `From: ${dateFrom}` })
     if (dateTo)                  chips.push({ key: 'to',      label: `To: ${dateTo}` })
     return chips
@@ -430,7 +436,7 @@ export default function Findings() {
     setFilterAnalystStatus('all')
     setFilterValidatedOnly(false)
     setFilterHighConfidence(false)
-    setSortMode('severity')
+    setSortMode('risk')
     setDateFrom('')
     setDateTo('')
     setSearchQuery('')
@@ -671,6 +677,7 @@ export default function Findings() {
                     onChange={(e) => setSortMode(e.target.value as SortMode)}
                     className={filterControlClass}
                   >
+                    <option value="risk">Risk Score (High → Low)</option>
                     <option value="severity">Severity (High → Low)</option>
                     <option value="newest">Newest First</option>
                     <option value="oldest">Oldest First</option>


### PR DESCRIPTION
## Description

Addresses issue #702 by prioritizing contextual risk scores instead of relying solely on raw severity ratings.

## Changes Made

- Added Risk Score sorting option to Findings page
- Made Risk Score the default sorting mode
- Updated reset behavior to restore Risk Score sorting
- Updated active filter chip logic to treat Risk Score as the default view
- Preserved existing severity-based sorting as an optional mode

## Why

The backend already computes contextual risk using severity, exploitability, asset exposure, confidence, and recency. However, the Findings page was still prioritizing findings using raw severity alone.

This change aligns frontend prioritization with the existing contextual risk model so findings affecting public-facing assets can be surfaced ahead of equally severe internal findings when their calculated risk is higher.

## Validation

- TypeScript typecheck passed
- Test suite passed (344 tests)
- Production build passed