### PR TITLE
fix(executor): unify is_filesystem_target to prevent safe-mode bypass via CIDR (#741)

### DIFF
--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -403,10 +403,11 @@ class TaskExecutor:
                 if plugin and plugin.category == "code":
                     should_validate = False
 
-                # Check for filesystem targets using the same best-effort detection
-                is_fs = target.startswith(("/", "./", "../", "~")) or \
-                        bool(re.match(r"^[A-Za-z]:[\\/]", target)) or \
-                        ("/" in target and not target.startswith(("http://", "https://")))
+
+                # Use shared is_filesystem_target from validation to ensure
+                # consistent filesystem detection across route and executor layers.
+                from .validation import is_filesystem_target
+                is_fs = is_filesystem_target(target)
 
                 if should_validate and not is_fs:
                     from .validation import validate_target

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -110,35 +110,7 @@ def _json_payload(value: Any, fallback: str) -> str:
     return json.dumps(value if value is not None else json.loads(fallback))
 
 
-def is_filesystem_target(target: str) -> bool:
-    """Best-effort detection for path-based targets that should bypass host validation."""
-    # Absolute or relative filesystem roots only — not CIDR notation (e.g. 8.8.8.8/32)
-    if target.startswith(("/", "./", "../", "~/")):
-        return True
-    # Windows drive paths (C:\ or C:/)
-    """
-    Return True only for genuine local filesystem paths.
-
-    Explicit roots accepted:
-      - Unix absolute paths:   /home/user/repo
-      - Unix relative paths:   ./src, ../lib
-      - Home-relative paths:   ~/projects
-      - Windows paths:         C:\\Users\\repo, D:/work
-
-    Anything else — including CIDR notation (8.8.8.8/32, 192.168.1.0/24),
-    bare hostnames, URLs, and domain paths — returns False and will be
-    subject to the full validate_target() check including safe-mode enforcement.
-
-    CIDR notation is handled correctly by ipaddress.ip_network() inside
-    validate_target() and does NOT need special-casing here.
-    """
-    # Unix absolute, relative, and home-relative paths
-    if target.startswith(("/", "./", "../", "~/")):
-        return True
-    # Windows paths: C:\ or C:/
-    if re.match(r"^[A-Za-z]:[\\/]", target):
-        return True
-    return False
+from .validation import is_filesystem_target  # noqa: E402
 
 def _slugify_filename_part(value: str, fallback: str) -> str:
     cleaned = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")

--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -532,13 +532,23 @@ def _check_field(key: str, value: Any) -> Tuple[bool, int, str]:
 
     return True, 0, ""
 
-def _is_filesystem_target(target: str) -> bool:
-    """Best-effort detection for path-based targets that should bypass host validation."""
-    if target.startswith(("/", "./", "../", "~")):
+def is_filesystem_target(target: str) -> bool:
+    """Best-effort detection for path-based targets that should bypass host validation.
+
+    Returns True only for genuine local filesystem paths:
+      - Unix absolute paths:   /home/user/repo
+      - Unix relative paths:   ./src, ../lib
+      - Home-relative paths:   ~/projects
+      - Windows paths:         C:\\Users\\repo, D:/work
+
+    CIDR notation (e.g. 8.8.8.8/32), bare hostnames, URLs, and
+    domain paths all return False and are subject to validate_target().
+    """
+    # Unix absolute, relative, and home-relative paths
+    if target.startswith(("/", "./", "../", "~/")):
         return True
+    # Windows paths: C:\\ or C:/
     if re.match(r"^[A-Za-z]:[\\/]", target):
-        return True
-    if "/" in target and not target.startswith(("http://", "https://")):
         return True
     return False
 
@@ -622,7 +632,7 @@ def validate_command_network_egress(command: list[str], safe_mode: bool, plugin_
             continue
         if arg_str.startswith("-"):
             continue  # Ignore flags
-        if _is_filesystem_target(arg_str):
+        if is_filesystem_target(arg_str):
             continue  # Ignore local paths
 
         # Check if it looks like a URL


### PR DESCRIPTION
## Related Issues
Closes #741

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix

## Summary
The executor contained an inline filesystem detection block with a dangerous
third condition — `"/" in target and not target.startswith(("http://", "https://"))` 
— that was absent from routes.py. This caused CIDR targets like `8.8.8.8/32` to
be treated as filesystem paths, bypassing safe-mode validation entirely.

## Changes Made

### Fix 1 — validation.py
- Renamed `_is_filesystem_target` to `is_filesystem_target` (public export)
- Removed the dangerous third condition that matched CIDR/path-containing targets
- Added detailed docstring explaining what is and is not a filesystem target
- Updated internal reference in `validate_command_network_egress`

### Fix 2 — executor.py
- Removed the inconsistent inline `is_fs` detection block (lines 407-409)
- Replaced with `from .validation import is_filesystem_target` and a single call

### Fix 3 — routes.py
- Removed the local `is_filesystem_target` function definition
- Replaced with `from .validation import is_filesystem_target`
- Both routes and executor now use identical logic from a single source of truth

## Files Changed
- `backend/secuscan/validation.py`
- `backend/secuscan/executor.py`
- `backend/secuscan/routes.py`

## Checklist
- [x] I have performed a self-review of my own code
- [x] Single source of truth for filesystem target detection
- [x] CIDR notation no longer bypasses safe-mode validation
- [x] No functional changes to legitimate filesystem path detection