### PR TITLE
[FRONTEND] Replace AppShell 100ms localStorage polling with event-based sidebar sync

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -20,17 +20,20 @@ export default function AppShell({ children }: AppShellProps) {
         return saved !== null ? JSON.parse(saved) : true
     })
 
-    // Brief hack to sync sidebar state without a full context provider
     useEffect(() => {
         const handleStorage = () => {
             const saved = localStorage.getItem('sidebar-expanded')
             if (saved !== null) setSidebarExpanded(JSON.parse(saved))
         }
+        const handleSidebarChange = (e: Event) => {
+            const detail = (e as CustomEvent).detail
+            if (typeof detail === 'boolean') setSidebarExpanded(detail)
+        }
         window.addEventListener('storage', handleStorage)
-        const interval = setInterval(handleStorage, 100)
+        window.addEventListener('sidebar-state-changed', handleSidebarChange)
         return () => {
             window.removeEventListener('storage', handleStorage)
-            clearInterval(interval)
+            window.removeEventListener('sidebar-state-changed', handleSidebarChange)
         }
     }, [])
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -108,6 +108,7 @@ export default function Sidebar() {
 
     useEffect(() => {
         localStorage.setItem('sidebar-expanded', JSON.stringify(isExpanded))
+        window.dispatchEvent(new CustomEvent('sidebar-state-changed', { detail: isExpanded }))
     }, [isExpanded])
 
     return (

--- a/frontend/testing/unit/components/AppShell.test.tsx
+++ b/frontend/testing/unit/components/AppShell.test.tsx
@@ -75,3 +75,41 @@ describe('AppShell', () => {
     expect(screen.getByRole('link', { name: /workflows/i })).toBeInTheDocument()
   })
 })
+
+
+describe('sidebar state synchronization', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    it('responds to sidebar-state-changed custom event (same-tab)', async () => {
+        renderShell()
+
+        const main = document.querySelector('main')!
+        // Default: expanded → --sidebar-width = 220px
+        expect(main.style.getPropertyValue('--sidebar-width')).toBe('220px')
+
+        // Collapse via custom event
+        window.dispatchEvent(new CustomEvent('sidebar-state-changed', { detail: false }))
+        expect(main.style.getPropertyValue('--sidebar-width')).toBe('64px')
+
+        // Expand via custom event
+        window.dispatchEvent(new CustomEvent('sidebar-state-changed', { detail: true }))
+        expect(main.style.getPropertyValue('--sidebar-width')).toBe('220px')
+    })
+
+    it('responds to storage event (cross-tab)', async () => {
+        renderShell()
+
+        const main = document.querySelector('main')!
+
+        // Simulate another tab writing to localStorage
+        localStorage.setItem('sidebar-expanded', 'false')
+        window.dispatchEvent(new Event('storage'))
+        expect(main.style.getPropertyValue('--sidebar-width')).toBe('64px')
+
+        localStorage.setItem('sidebar-expanded', 'true')
+        window.dispatchEvent(new Event('storage'))
+        expect(main.style.getPropertyValue('--sidebar-width')).toBe('220px')
+    })
+})


### PR DESCRIPTION
## ✦ Description
Replaced the 100ms `setInterval` polling loop in `AppShell` that was continuously reading `localStorage` to detect sidebar expansion state changes. Instead, the `Sidebar` component now dispatches a `sidebar-state-changed` CustomEvent when its expanded state changes, and `AppShell` listens for both the CustomEvent (same-tab) and the native `storage` event (cross-tab).

### Changes
- **AppShell.tsx**: Removed 100ms polling interval; kept the cross-tab `storage` event listener; added same-tab `sidebar-state-changed` CustomEvent listener.
- **Sidebar.tsx**: Added `window.dispatchEvent(new CustomEvent('sidebar-state-changed', { detail: isExpanded }))` whenever the sidebar's expanded state changes.
- **AppShell.test.tsx**: Added focused tests for same-tab sync via CustomEvent and cross-tab sync via `storage` event.

### Why
The previous approach used a `setInterval` that ran every 100ms to poll `localStorage`, which is wasteful and brittle. The new approach uses explicit event-based communication that only fires when the state actually changes, while preserving cross-tab synchronization through the browser-native `storage` event.

Fixes #553

---

## ⟡ Type of Change
- [x] Refactor / Performance improvement

## ✦ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] Sidebar state stays synchronized across the shell
- [x] Existing persistence behavior still works

---

## Testing
### Same-tab sync
Directly dispatches a `sidebar-state-changed` CustomEvent on `window` and expects the `<main>` element's `--sidebar-width` CSS variable to update immediately.

### Cross-tab sync
Sets `localStorage`, fires a native `storage` event, and verifies the sidebar width updates accordingly.