### PR TITLE
fix(scans): show timeout failure notifications

### DIFF
--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -22,6 +22,7 @@ interface Task {
   started_at?: string;
   completed_at?: string;
   duration_seconds?: number;
+  error_message?: string;
   inputs?: any;
   preset?: string;
   execution_context?: ExecutionContext;
@@ -492,6 +493,50 @@ export default function Scans() {
                           )}
                         </div>
                       </div>
+
+                      {/* Error Notification Panel */}
+                      {task.status === "failed" && task.error_message && (() => {
+                        const isTimeoutFailure =
+                          task.error_message?.toLowerCase().includes("timeout") ||
+                          task.error_message?.toLowerCase().includes("timed out");
+                        return (
+                          <div
+                            className={`mt-6 border-4 border-black p-5 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] ${
+                              isTimeoutFailure
+                                ? "bg-rag-amber/10 border-l-rag-amber"
+                                : "bg-rag-red/10 border-l-rag-red"
+                            }`}
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <div className="flex items-start gap-4">
+                              <span
+                                className={`material-symbols-outlined text-lg shrink-0 mt-0.5 ${
+                                  isTimeoutFailure ? "text-rag-amber" : "text-rag-red"
+                                }`}
+                              >
+                                {isTimeoutFailure ? "timer_off" : "error"}
+                              </span>
+                              <div className="space-y-2 min-w-0">
+                                <p
+                                  className={`text-[10px] font-black uppercase tracking-[0.3em] ${
+                                    isTimeoutFailure ? "text-rag-amber" : "text-rag-red"
+                                  }`}
+                                >
+                                  {isTimeoutFailure ? "SCAN_TIMEOUT_DETECTED" : "SCAN_FAILED"}
+                                </p>
+                                {isTimeoutFailure && (
+                                  <p className="text-[10px] font-mono text-silver/60 uppercase tracking-widest">
+                                    This scan exceeded its execution limit and was terminated automatically.
+                                  </p>
+                                )}
+                                <p className="text-[10px] font-mono text-silver/50 break-words">
+                                  {task.error_message}
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })()}
 
                       {/* Expandable Details Block */}
                       <AnimatePresence>


### PR DESCRIPTION
Closes #705

## Description

This PR improves user visibility when scans fail due to timeout-related errors.

### Problem

Scan timeout failures were being recorded by the backend and stored in `error_message`, but users only saw a generic failed status (`SYSTEM_FAILURE`) in the Scans view. The actual timeout reason was only visible after navigating to the Task Details page, making timeout failures appear silent from the primary scan monitoring interface.

### Changes Made

* Added support for displaying task `error_message` directly in scan cards
* Detects timeout-related failures using backend error messages
* Introduced a dedicated timeout notification state:

```text
SCAN_TIMEOUT_DETECTED
```

* Displays a clear explanation when a scan exceeds its execution limit
* Shows the original backend error message for troubleshooting
* Added a generic failure notification panel for non-timeout scan failures
* Kept styling consistent with the existing SecuScan neo-brutalist design language

### Impact

Users can now immediately identify timeout-related failures directly from the Scans page without opening individual task details, improving visibility and reducing confusion around failed scans.

### Validation

* ✅ TypeScript typecheck passed
* ✅ Production build passed
* ✅ No backend changes required
* ✅ Existing scan workflow remains unchanged
