### PR TITLE
fix: enforce owner scoping for vault secrets

### DIFF
--- a/.audit-config.yaml
+++ b/.audit-config.yaml
@@ -17,7 +17,11 @@ policy:
 
 # Documented exceptions with business justification
 # Format: CVE-XXXX-XXXXX or GHSA-xxxx-xxxx-xxxx
-exceptions: {}
+exceptions:
+  GHSA-gv7w-rqvm-qjhr:
+    package: esbuild
+    expires_at: "2026-12-31"
+    reason: "Pre-existing upstream devDependency vulnerability in esbuild used by Vite."
 
 # Packages to exclude from audits (use sparingly!)
 excluded_packages: []

--- a/.audit-config.yaml
+++ b/.audit-config.yaml
@@ -17,11 +17,7 @@ policy:
 
 # Documented exceptions with business justification
 # Format: CVE-XXXX-XXXXX or GHSA-xxxx-xxxx-xxxx
-exceptions:
-  GHSA-gv7w-rqvm-qjhr:
-    package: esbuild
-    expires_at: "2026-12-31"
-    reason: "Pre-existing upstream devDependency vulnerability in esbuild used by Vite."
+exceptions: {}
 
 # Packages to exclude from audits (use sparingly!)
 excluded_packages: []

--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -390,7 +390,7 @@ class Database:
         # Migration logic: ensure latest columns exist in 'tasks' table
         tasks_columns = await self.fetchall("PRAGMA table_info(tasks)")
         existing_cols = {col["name"] for col in tasks_columns}
-        
+
         needed_cols = {
             # Per-user ownership for BOLA prevention (issue #401). NOT NULL with a
             # constant default backfills every existing row to the shared default
@@ -482,13 +482,13 @@ class Database:
                     print(f"Added missing column {col_name} to asset_services table.")
                 except Exception as e:
                     print(f"Failed to add column {col_name} to asset_services: {e}")
-                    
+
 
         # Reports table migration: ensure owner_id exists (issue #401)
         reports_columns = await self.fetchall("PRAGMA table_info(reports)")
         existing_report_cols = {col["name"] for col in reports_columns}
-        
-        
+
+
         if "owner_id" not in existing_report_cols:
             try:
                 await self.execute(
@@ -497,12 +497,12 @@ class Database:
                 print("Added missing column 'owner_id' to reports table.")
             except Exception as e:
                 print(f"Failed to add 'owner_id' to reports: {e}")
-                
+
         # Vault table migration
         vault_columns = await self.fetchall("PRAGMA table_info(credential_vault)")
         existing_vault_cols = {col["name"] for col in vault_columns}
-        
-        
+
+
         if "owner_id" not in existing_vault_cols:
             try:
                 await self.execute(
@@ -520,10 +520,10 @@ class Database:
            CREATE INDEX IF NOT EXISTS idx_findings_owner ON findings(owner_id);
            CREATE INDEX IF NOT EXISTS idx_reports_owner ON reports(owner_id);
            CREATE INDEX IF NOT EXISTS idx_credential_vault_owner ON credential_vault(owner_id);
-           
+
           """
         )
-       
+
     async def _run_migrations(self):
         migrations_dir = Path(__file__).parent / "migrations"
 

--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -266,11 +266,13 @@ class Database:
 
             CREATE TABLE IF NOT EXISTS credential_vault (
                 id TEXT PRIMARY KEY,
-                name TEXT NOT NULL UNIQUE,
+                owner_id TEXT NOT NULL DEFAULT 'default',
+                name TEXT NOT NULL,
                 encrypted_value TEXT NOT NULL,
                 created_at TIMESTAMP NOT NULL DEFAULT (datetime('now')),
                 updated_at TIMESTAMP NOT NULL DEFAULT (datetime('now'))
             );
+            CREATE INDEX IF NOT EXISTS idx_credential_vault_owner ON credential_vault(owner_id);
 
             CREATE TABLE IF NOT EXISTS workflows (
                 id TEXT PRIMARY KEY,
@@ -480,10 +482,13 @@ class Database:
                     print(f"Added missing column {col_name} to asset_services table.")
                 except Exception as e:
                     print(f"Failed to add column {col_name} to asset_services: {e}")
+                    
 
         # Reports table migration: ensure owner_id exists (issue #401)
         reports_columns = await self.fetchall("PRAGMA table_info(reports)")
         existing_report_cols = {col["name"] for col in reports_columns}
+        
+        
         if "owner_id" not in existing_report_cols:
             try:
                 await self.execute(
@@ -492,16 +497,33 @@ class Database:
                 print("Added missing column 'owner_id' to reports table.")
             except Exception as e:
                 print(f"Failed to add 'owner_id' to reports: {e}")
+                
+        # Vault table migration
+        vault_columns = await self.fetchall("PRAGMA table_info(credential_vault)")
+        existing_vault_cols = {col["name"] for col in vault_columns}
+        
+        
+        if "owner_id" not in existing_vault_cols:
+            try:
+                await self.execute(
+                    "ALTER TABLE credential_vault "
+                    "ADD COLUMN owner_id TEXT NOT NULL DEFAULT 'default'"
+                            )
+                print("Added missing column 'owner_id' to credential_vault table.")
+            except Exception as e:
+                print(f"Failed to add 'owner_id' to credential_vault: {e}")
 
         # Owner indexes must run after ALTER TABLE backfills owner_id on legacy DBs.
         await self.connection.executescript(
-            """
-            CREATE INDEX IF NOT EXISTS idx_tasks_owner ON tasks(owner_id);
-            CREATE INDEX IF NOT EXISTS idx_findings_owner ON findings(owner_id);
-            CREATE INDEX IF NOT EXISTS idx_reports_owner ON reports(owner_id);
-            """
+           """
+           CREATE INDEX IF NOT EXISTS idx_tasks_owner ON tasks(owner_id);
+           CREATE INDEX IF NOT EXISTS idx_findings_owner ON findings(owner_id);
+           CREATE INDEX IF NOT EXISTS idx_reports_owner ON reports(owner_id);
+           CREATE INDEX IF NOT EXISTS idx_credential_vault_owner ON credential_vault(owner_id);
+           
+          """
         )
-
+       
     async def _run_migrations(self):
         migrations_dir = Path(__file__).parent / "migrations"
 

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -1382,7 +1382,7 @@ async def get_settings():
 async def list_vault_secrets(
      owner: str = Depends(get_current_owner),
 ):
-    
+
     db = await get_db()
     rows = await db.fetchall(
         "SELECT id, name, created_at, updated_at FROM credential_vault WHERE owner_id =? ORDER BY name ASC",

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -1379,16 +1379,21 @@ async def get_settings():
 
 
 @router.get("/vault", dependencies=[Depends(vault_limiter)])
-async def list_vault_secrets():
+async def list_vault_secrets(
+     owner: str = Depends(get_current_owner),
+):
+    
     db = await get_db()
     rows = await db.fetchall(
-        "SELECT id, name, created_at, updated_at FROM credential_vault ORDER BY name ASC"
+        "SELECT id, name, created_at, updated_at FROM credential_vault WHERE owner_id =? ORDER BY name ASC",
+        (owner,),
     )
     return {"items": rows, "total": len(rows)}
 
 
 @router.put("/vault/{name}", dependencies=[Depends(vault_limiter)])
-async def upsert_vault_secret(name: str, payload: Dict[str, str]):
+async def upsert_vault_secret(name: str, payload: Dict[str, str],owner: str = Depends(get_current_owner),
+):
     value = str(payload.get("value", ""))
     if not value:
         raise HTTPException(status_code=400, detail="Secret value is required")
@@ -1398,24 +1403,24 @@ async def upsert_vault_secret(name: str, payload: Dict[str, str]):
     encrypted = crypto.encrypt(value)
     secret_id = str(uuid.uuid4())
 
-    existing = await db.fetchone("SELECT id FROM credential_vault WHERE name = ?", (name,))
+    existing = await db.fetchone("SELECT id FROM credential_vault WHERE owner_id = ? AND name = ?", (owner,name,),)
     if existing:
         await db.execute(
-            "UPDATE credential_vault SET encrypted_value = ?, updated_at = datetime('now') WHERE name = ?",
-            (encrypted, name),
+            "UPDATE credential_vault SET encrypted_value = ?, updated_at = datetime('now') WHERE owner_id = ? AND name = ?",
+            (encrypted,owner,name),
         )
     else:
         await db.execute(
-            "INSERT INTO credential_vault (id, name, encrypted_value) VALUES (?, ?, ?)",
-            (secret_id, name, encrypted),
+            "INSERT INTO credential_vault (id, owner_id, name, encrypted_value) VALUES (?, ?, ?, ?)",
+            (secret_id, owner, name, encrypted),
         )
     return {"name": name, "stored": True}
 
 
 @router.get("/vault/{name}", dependencies=[Depends(vault_limiter)])
-async def get_vault_secret(name: str):
+async def get_vault_secret(name: str,owner: str = Depends(get_current_owner)):
     db = await get_db()
-    row = await db.fetchone("SELECT encrypted_value FROM credential_vault WHERE name = ?", (name,))
+    row = await db.fetchone("SELECT encrypted_value FROM credential_vault WHERE owner_id = ? AND name = ?", (owner,name,))
     if not row:
         raise HTTPException(status_code=404, detail="Secret not found")
     crypto = VaultCrypto(settings.resolved_vault_key)
@@ -1423,9 +1428,9 @@ async def get_vault_secret(name: str):
 
 
 @router.delete("/vault/{name}", dependencies=[Depends(vault_limiter)])
-async def delete_vault_secret(name: str):
+async def delete_vault_secret(name: str,owner: str = Depends(get_current_owner),):
     db = await get_db()
-    await db.execute("DELETE FROM credential_vault WHERE name = ?", (name,))
+    await db.execute("DELETE FROM credential_vault WHERE owner_id = ? AND name = ?", (owner,name),)
     return {"name": name, "deleted": True}
 
 

--- a/testing/backend/unit/test_vault_owner_isolation.py
+++ b/testing/backend/unit/test_vault_owner_isolation.py
@@ -9,10 +9,21 @@ secrets.
 import asyncio
 import pytest
 
-from backend.secuscan.ratelimit import reset_all_endpoint_limiters
+from backend.secuscan.config import settings
+from backend.secuscan.ratelimit import (
+    reset_all_endpoint_limiters,
+    vault_limiter,
+)
+
 
 @pytest.fixture(autouse=True)
-def reset_limiters():
+def isolate_vault_tests(monkeypatch):
+    monkeypatch.setattr(settings, "rate_limit_vault_limit", 100)
+    monkeypatch.setattr(settings, "rate_limit_vault_window", 60)
+
+    vault_limiter.limit = 100
+    vault_limiter.window_seconds = 60
+
     asyncio.run(reset_all_endpoint_limiters())
 
 

--- a/testing/backend/unit/test_vault_owner_isolation.py
+++ b/testing/backend/unit/test_vault_owner_isolation.py
@@ -1,0 +1,109 @@
+"""
+Vault owner-isolation tests.
+
+Verifies that credential vault operations are scoped by owner_id and
+that one owner cannot read, list, overwrite, or delete another owner's
+secrets.
+"""
+
+
+class TestVaultOwnerIsolation:
+    OWNER_A = {"X-User-Id": "alice"}
+    OWNER_B = {"X-User-Id": "bob"}
+
+    def test_owner_cannot_read_other_owner_secret(self, test_client):
+        name = "owner-isolation-read"
+
+        r = test_client.put(
+            f"/api/v1/vault/{name}",
+            json={"value": "alice-secret"},
+            headers=self.OWNER_A,
+        )
+        assert r.status_code == 200
+
+        r = test_client.get(
+            f"/api/v1/vault/{name}",
+            headers=self.OWNER_B,
+        )
+
+        assert r.status_code == 404
+        
+    def test_owner_list_only_returns_owned_secrets(self, test_client):
+        test_client.put(
+            "/api/v1/vault/alice-secret",
+            json={"value": "a"},
+            headers=self.OWNER_A,
+        )
+
+        test_client.put(
+            "/api/v1/vault/bob-secret",
+            json={"value": "b"},
+            headers=self.OWNER_B,
+        )
+
+        r = test_client.get(
+            "/api/v1/vault",
+            headers=self.OWNER_B,
+        )
+
+        assert r.status_code == 200
+        print(r.json())
+        
+        names = {item["name"] for item in r.json()["items"]}
+
+        assert "bob-secret" in names
+        assert "alice-secret" not in names
+        
+    def test_owner_cannot_overwrite_other_owner_secret(self, test_client):
+        name = "shared-name"
+
+        test_client.put(
+            f"/api/v1/vault/{name}",
+            json={"value": "alice-value"},
+            headers=self.OWNER_A,
+        )
+
+        test_client.put(
+            f"/api/v1/vault/{name}",
+            json={"value": "bob-value"},
+            headers=self.OWNER_B,
+        )
+
+        alice = test_client.get(
+            f"/api/v1/vault/{name}",
+            headers=self.OWNER_A,
+        )
+
+        bob = test_client.get(
+            f"/api/v1/vault/{name}",
+            headers=self.OWNER_B,
+        )
+
+        assert alice.status_code == 200
+        assert bob.status_code == 200
+
+        assert alice.json()["value"] == "alice-value"
+        assert bob.json()["value"] == "bob-value"
+        
+    def test_owner_cannot_delete_other_owner_secret(self, test_client):
+        name = "owner-isolation-delete"
+
+        test_client.put(
+            f"/api/v1/vault/{name}",
+            json={"value": "alice-secret"},
+            headers=self.OWNER_A,
+        )
+
+        delete_r = test_client.delete(
+           f"/api/v1/vault/{name}",
+           headers=self.OWNER_B,
+      )
+        assert delete_r.status_code in (200, 404)
+
+        r = test_client.get(
+            f"/api/v1/vault/{name}",
+            headers=self.OWNER_A,
+        )
+
+        assert r.status_code == 200
+        assert r.json()["value"] == "alice-secret"

--- a/testing/backend/unit/test_vault_owner_isolation.py
+++ b/testing/backend/unit/test_vault_owner_isolation.py
@@ -27,7 +27,7 @@ class TestVaultOwnerIsolation:
         )
 
         assert r.status_code == 404
-        
+
     def test_owner_list_only_returns_owned_secrets(self, test_client):
         test_client.put(
             "/api/v1/vault/alice-secret",
@@ -48,12 +48,12 @@ class TestVaultOwnerIsolation:
 
         assert r.status_code == 200
         print(r.json())
-        
+
         names = {item["name"] for item in r.json()["items"]}
 
         assert "bob-secret" in names
         assert "alice-secret" not in names
-        
+
     def test_owner_cannot_overwrite_other_owner_secret(self, test_client):
         name = "shared-name"
 
@@ -84,7 +84,7 @@ class TestVaultOwnerIsolation:
 
         assert alice.json()["value"] == "alice-value"
         assert bob.json()["value"] == "bob-value"
-        
+
     def test_owner_cannot_delete_other_owner_secret(self, test_client):
         name = "owner-isolation-delete"
 

--- a/testing/backend/unit/test_vault_owner_isolation.py
+++ b/testing/backend/unit/test_vault_owner_isolation.py
@@ -6,6 +6,15 @@ that one owner cannot read, list, overwrite, or delete another owner's
 secrets.
 """
 
+import asyncio
+import pytest
+
+from backend.secuscan.ratelimit import reset_all_endpoint_limiters
+
+@pytest.fixture(autouse=True)
+def reset_limiters():
+    asyncio.run(reset_all_endpoint_limiters())
+
 
 class TestVaultOwnerIsolation:
     OWNER_A = {"X-User-Id": "alice"}


### PR DESCRIPTION
## Summary

Fix a Broken Object Level Authorization (BOLA) vulnerability in vault secret management.

### Changes

* Added `owner_id` support to the `credential_vault` schema.
* Added migration logic to backfill `owner_id` for existing deployments.
* Added an owner-scoped index for vault lookups.
* Scoped vault listing to the authenticated owner.
* Scoped vault secret retrieval to the authenticated owner.
* Scoped vault secret updates to the authenticated owner.
* Scoped vault secret deletion to the authenticated owner.

### Security Impact

Previously, vault operations were not ownership-aware, allowing users sharing an API key to access, modify, or delete secrets belonging to other workspaces. This change enforces owner-based isolation across all vault CRUD operations and prevents cross-tenant secret access.
