### PR TITLE
fix: improve findings filter layout responsiveness

### DIFF
--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -121,7 +121,7 @@ function filterPillClasses(isActive: boolean) {
     : 'border-silver-bright/10 bg-charcoal-dark text-silver/65 hover:border-silver-bright/30 hover:text-silver-bright'
 }
 
-const filterLabelClass = 'text-[10px] font-black uppercase tracking-[0.2em] text-silver-bright'
+const filterLabelClass ='block text-[10px] font-black uppercase tracking-[0.2em] text-silver-bright'
 const filterControlClass =
   'h-11 w-full border-2 border-silver-bright/10 bg-charcoal-dark px-3 text-xs font-mono text-silver-bright focus:border-rag-red focus:outline-none'
 
@@ -599,7 +599,7 @@ export default function Findings() {
             </div>
 
             <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-end">
-              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-8">
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-8">
                 <div className="space-y-2">
                   <label className={filterLabelClass}>Target</label>
                   <select


### PR DESCRIPTION
## Summary

Fixes the Findings Desk search filter layout where labels and form controls overlap at standard browser zoom levels.

### Changes

* Added block-level rendering for filter labels to ensure proper separation from inputs.
* Updated the filter grid to use responsive breakpoints instead of forcing eight columns at typical desktop widths.
* Improved spacing and readability of filter controls across different screen sizes.

### Testing

* Verified with `npm run typecheck`
* Verified with `npm run build`

### Result

Filter labels and controls remain properly aligned and readable at 100% browser zoom and nearby zoom levels, preventing overlap and improving usability in the Findings Desk workspace.
