### PR TITLE
fix(frontend): prevent mobile navigation menu from overlapping page content

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -41,6 +41,15 @@ export default function AppShell({ children }: AppShellProps) {
         setMobileMenuOpen(false)
     }, [pathname])
 
+    useEffect(() => {
+        if (!mobileMenuOpen) return
+        const previousOverflow = document.body.style.overflow
+        document.body.style.overflow = 'hidden'
+        return () => {
+            document.body.style.overflow = previousOverflow
+        }
+    }, [mobileMenuOpen])
+
     const desktopSidebarWidth = sidebarExpanded ? 220 : 64
     const mobilePrimaryNav = [
         { to: routes.dashboard, icon: 'monitoring', label: 'Dashboard' },
@@ -66,7 +75,7 @@ export default function AppShell({ children }: AppShellProps) {
             <Background state="idle" />
             <div className="flex bg-charcoal-dark min-h-screen">
                 <Sidebar />
-                <div className="lg:hidden fixed inset-x-0 top-0 z-40 bg-secondary border-b border-accent-silver/10 h-14 px-4 flex items-center justify-between">
+                <div className="lg:hidden fixed inset-x-0 top-0 z-[60] bg-[var(--bg-secondary)] border-b border-accent-silver/10 h-14 px-4 flex items-center justify-between">
                     <button
                         onClick={() => setMobileMenuOpen((prev) => !prev)}
                         className="w-9 h-9 border border-accent-silver/20 flex items-center justify-center text-silver-bright bg-charcoal-dark"
@@ -81,11 +90,14 @@ export default function AppShell({ children }: AppShellProps) {
                 </div>
 
                 {mobileMenuOpen && (
-                    <div className="lg:hidden fixed inset-0 z-40 bg-black/60" onClick={() => setMobileMenuOpen(false)}>
-                        <div
-                            className="absolute top-14 left-0 right-0 bg-secondary border-b border-accent-silver/10 p-4"
-                            onClick={(e) => e.stopPropagation()}
-                        >
+                    <>
+                        <button
+                            type="button"
+                            className="lg:hidden fixed inset-0 z-50 bg-charcoal-dark/80 backdrop-blur-sm"
+                            onClick={() => setMobileMenuOpen(false)}
+                            aria-label="Close navigation menu"
+                        />
+                        <div className="lg:hidden fixed top-14 left-0 right-0 z-50 bg-[var(--bg-secondary)] border-b border-accent-silver/10 p-4 shadow-[0_12px_32px_rgba(0,0,0,0.6)]">
                             <nav className="grid grid-cols-2 gap-2">
                                 {mobileDrawerNav.map((item) => (
                                     <NavLink
@@ -104,7 +116,7 @@ export default function AppShell({ children }: AppShellProps) {
                                 ))}
                             </nav>
                         </div>
-                    </div>
+                    </>
                 )}
 
                 <main 
@@ -114,7 +126,7 @@ export default function AppShell({ children }: AppShellProps) {
                     {children}
                 </main>
 
-                <nav className="lg:hidden fixed bottom-0 inset-x-0 z-40 h-16 bg-secondary border-t border-accent-silver/10 grid grid-cols-5">
+                <nav className="lg:hidden fixed bottom-0 inset-x-0 z-40 h-16 bg-[var(--bg-secondary)] border-t border-accent-silver/10 grid grid-cols-5">
                     {mobilePrimaryNav.map((item) => (
                         <NavLink
                             key={item.to}

--- a/frontend/testing/unit/components/AppShell.test.tsx
+++ b/frontend/testing/unit/components/AppShell.test.tsx
@@ -52,6 +52,35 @@ describe('AppShell', () => {
     })
   })
 
+  it('closes the mobile drawer when the backdrop is clicked', async () => {
+    const user = userEvent.setup()
+    renderShell()
+
+    await user.click(screen.getByRole('button', { name: /toggle navigation menu/i }))
+    expect(screen.getByRole('link', { name: 'Settings' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /close navigation menu/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: 'Settings' })).not.toBeInTheDocument()
+    })
+  })
+
+  it('locks page scroll while the mobile drawer is open', async () => {
+    const user = userEvent.setup()
+    renderShell()
+
+    expect(document.body.style.overflow).toBe('')
+
+    await user.click(screen.getByRole('button', { name: /toggle navigation menu/i }))
+    expect(document.body.style.overflow).toBe('hidden')
+
+    await user.click(screen.getByRole('button', { name: /close navigation menu/i }))
+    await waitFor(() => {
+      expect(document.body.style.overflow).toBe('')
+    })
+  })
+
   it('closes the mobile drawer when navigation changes routes', async () => {
     const user = userEvent.setup()
     renderShell()


### PR DESCRIPTION
## Description

On mobile screens, opening the navigation menu on the Scans page caused page content (filter buttons like `SELECT_ALL`, `ALL_OPERATIONS`, etc.) to show through and overlap with menu items, making the UI hard to read and use.

**Root cause:** The mobile header and drawer used `bg-secondary`, which is not defined in the Tailwind theme, so those elements had no solid background. Page content could also scroll underneath the semi-transparent overlay.

**Approach:**
- Replaced invalid `bg-secondary` with opaque `bg-[var(--bg-secondary)]` using existing design tokens
- Split the overlay into a dedicated backdrop button and a fixed drawer panel
- Raised z-index so the header (`z-[60]`) and drawer (`z-50`) sit above page content
- Locked body scroll while the mobile menu is open
- Added unit tests for backdrop close and scroll-lock behavior

**Files changed:**
- `frontend/src/components/AppShell.tsx`
- `frontend/testing/unit/components/AppShell.test.tsx`

## Related Issues

Closes #794 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

**Automated tests:**
- [x] `cd frontend && npx vitest run testing/unit/components/AppShell.test.tsx` — 7 tests passed
- [ ] `cd frontend && npm run test` — *(run full suite before submitting if you can)*
- [ ] `cd frontend && npm run build` — *(run before submitting)*

**Manual verification:**
- Opened SecuScan in Chrome mobile emulator (~375px width)
- Navigated to Scans page and scrolled so filter buttons were visible
- Opened the hamburger menu — nav links are readable with no overlapping page text
- Confirmed backdrop dims page content behind the menu
- Closed menu via backdrop tap and X button — page scroll restored

## Screenshots 

### Before:
<img width="152" height="350" alt="image" src="https://github.com/user-attachments/assets/8202143b-77ab-43c8-8910-8531a376fb1e" />


### After: 
<img width="173" height="359" alt="image" src="https://github.com/user-attachments/assets/eb23b9b4-4290-4f5d-803d-f35a09a79b56" />


## Notes

- No documentation, migrations, environment variables, or breaking changes.
- Colors use existing design tokens (`--bg-secondary`, `charcoal-dark`, `rag-red`) — no new theme values added.
- Scope is limited to mobile navigation in `AppShell`; no changes to Scans page or project structure.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas. *(N/A — changes are straightforward)*
- [ ] I have made corresponding changes to the documentation. *(N/A — UI bug fix only)*
- [x] My changes generate no new warnings.