### PR TITLE
chore: add esbuild GHSA exception to audit config (CI pre-req)

### DIFF
--- a/.audit-config.yaml
+++ b/.audit-config.yaml
@@ -17,7 +17,10 @@ policy:
 
 # Documented exceptions with business justification
 # Format: CVE-XXXX-XXXXX or GHSA-xxxx-xxxx-xxxx
-exceptions: {}
+exceptions:
+  GHSA-gv7w-rqvm-qjhr: # esbuild (Deno-only)
+    reason: "Deno runtime module only; SecuScan uses esbuild via Vite 6.x for Node.js bundling. Fix requires Vite 8.x (breaking change)."
+    expires: 2026-08-31
 
 # Packages to exclude from audits (use sparingly!)
 excluded_packages: []


### PR DESCRIPTION
Pre-req for all open PRs: adds the esbuild Deno-only vuln exception to `.audit-config.yaml` so that frontend-checks CI passes.

See GHSA-gv7w-rqvm-qjhr — affects Deno module only, SecuScan uses esbuild via Vite 6.x for Node.js bundling. Fix requires Vite 8.x (breaking change).