### PR TITLE
test: add workflow owner persistence regression coverage

### DIFF
--- a/testing/backend/unit/test_workflow_history.py
+++ b/testing/backend/unit/test_workflow_history.py
@@ -322,3 +322,21 @@ class TestWorkflowRunLifecycle:
         run_id = await db.record_workflow_run(wf_id, None, None, ["t3"])
         status = await db.check_workflow_run_tasks(run_id)
         assert status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_workflow_run_history_preserves_triggered_by(self, db):
+        wf_id = await _insert_workflow(db)
+
+        run_id = await db.record_workflow_run(
+            wf_id,
+            None,
+            None,
+            [],
+            triggered_by="scheduler:user:test-owner",
+        )
+
+        history = await db.get_workflow_runs(wf_id)
+
+        assert history["total"] == 1
+        assert history["runs"][0]["id"] == run_id
+        assert history["runs"][0]["triggered_by"] == "scheduler:user:test-owner"


### PR DESCRIPTION
## Description
Added a regression test to verify that workflow run history preserves the `triggered_by` field.

## Related Issues
Closes #881 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
pytest testing/backend/unit/test_workflow_history.py -v

Result: 29 tests passed.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
