### PR TITLE
docs: add Quick Links section to README (#861)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ SecuScan/
 ├── wordlists/        Scanner wordlists
 └── .github/          CI, issue templates, automation
 ```
+## Quick Links
+
+- **Backend**: [`backend/`](backend/) — FastAPI app, scanners, executor. See [Backend Architecture](docs/backend-architecture.md)
+- **Frontend**: [`frontend/`](frontend/) — React + TypeScript UI
+- **Plugins**: [`plugins/`](plugins/) — Plugin metadata and parsers. See [Plugin Validation](docs/plugin-validation.md)
+- **Docs**: [`docs/`](docs/) — Product, deployment, auth, and contributor docs
+- **Scripts**: [`scripts/`](scripts/) — Validation, checksums, signing, benchmarks
+- **Testing**: [`testing/`](testing/) — Backend/shared test utilities
 
 ## Requirements
 


### PR DESCRIPTION
## Description
Adds a "Quick Links" section to README.md, placed after the Repository Map. It provides direct links from each major component (backend, frontend, plugins, docs, scripts, testing) to its folder, and cross-references to docs/backend-architecture.md and docs/plugin-validation.md where relevant.

## Related Issues
Closes #861

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
Verified the markdown renders correctly in the GitHub preview tab, and confirmed all linked paths (backend/, frontend/, plugins/, docs/, scripts/, testing/, docs/backend-architecture.md, docs/plugin-validation.md) exist in the repository.