### PR TITLE
fix: avoid graphql detection on 404 responses

### DIFF
--- a/backend/secuscan/scanners/api_scanner.py
+++ b/backend/secuscan/scanners/api_scanner.py
@@ -225,7 +225,7 @@ class APIScanner(BaseScanner):
                 continue
 
             allowed_methods = response.headers.get("allow", "")
-            if response.status_code < 500:
+            if response.status_code == 200:
                 endpoints.append(
                     {
                         "type": "graphql_endpoint",
@@ -235,22 +235,23 @@ class APIScanner(BaseScanner):
                         "source": "graphql",
                     }
                 )
-            if "GET" in allowed_methods.upper() and "POST" in allowed_methods.upper():
-                findings.append(
-                    {
-                        "title": f"GraphQL Endpoint Exposed at {path}",
-                        "category": "API Exposure",
-                        "severity": "low",
-                        "target": target,
-                        "description": "A GraphQL endpoint responded to method discovery and should be included in schema, authorization, and query-cost review.",
-                        "validated": True,
-                        "validation_method": "graphql_method_discovery",
-                        "confidence_reason": "The endpoint responded directly to an OPTIONS request with advertised methods.",
-                        "evidence": [
-                            {"type": "url", "label": "Endpoint", "value": url, "source": "graphql"},
-                            {"type": "methods", "label": "Allowed methods", "value": allowed_methods, "source": "graphql"},
-                        ],
-                        "metadata": {"url": url},
+
+                if "GET" in allowed_methods.upper() and "POST" in allowed_methods.upper():
+                    findings.append(
+                        {
+                            "title": f"GraphQL Endpoint Exposed at {path}",
+                            "category": "API Exposure",
+                            "severity": "low",
+                            "target": target,
+                            "description": "A GraphQL endpoint responded to method discovery and should be included in schema, authorization, and query-cost review.",
+                            "validated": True,
+                            "validation_method": "graphql_method_discovery",
+                            "confidence_reason": "The endpoint responded directly to an OPTIONS request with advertised methods.",
+                            "evidence": [
+                                {"type": "url", "label": "Endpoint", "value": url, "source": "graphql"},
+                                {"type": "methods", "label": "Allowed methods", "value": allowed_methods, "source": "graphql"},
+                            ],
+                            "metadata": {"url": url},
                     }
                 )
 

--- a/testing/backend/unit/test_api_scanner_graphql.py
+++ b/testing/backend/unit/test_api_scanner_graphql.py
@@ -1,0 +1,53 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.secuscan.scanners.api_scanner import APIScanner
+
+
+class MockResponse:
+    def __init__(self, status_code, headers=None, text=""):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = text
+
+
+@pytest.mark.asyncio
+async def test_graphql_404_response_not_classified_as_endpoint():
+    scanner = APIScanner("test-task", None)
+
+    client = AsyncMock()
+    client.options.return_value = MockResponse(
+        404,
+        headers={"allow": "GET, POST"},
+    )
+
+    findings, endpoints = await scanner._probe_graphql(
+        client,
+        "https://example.com",
+        allow_introspection=False,
+    )
+
+    assert endpoints == []
+    assert findings == []
+
+
+@pytest.mark.asyncio
+async def test_graphql_200_response_classified_as_endpoint():
+    scanner = APIScanner("test-task", None)
+
+    client = AsyncMock()
+    client.options.return_value = MockResponse(
+        200,
+        headers={"allow": "GET, POST"},
+    )
+
+    findings, endpoints = await scanner._probe_graphql(
+        client,
+        "https://example.com",
+        allow_introspection=False,
+    )
+
+    assert len(endpoints) > 0
+    assert any(item["type"] == "graphql_endpoint" for item in endpoints)
+    assert any("GraphQL Endpoint Exposed" in item["title"] for item in findings)


### PR DESCRIPTION
## Description
Fixed a false positive in GraphQL endpoint detection where HTTP 404 responses could be classified as valid GraphQL endpoints. Added regression tests covering both 404 and 200 response scenarios.

## Related Issues
Closes #893 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
pytest testing/backend/unit/test_api_scanner_graphql.py -v

Result:
2 tests passed successfully:
- test_graphql_404_response_not_classified_as_endpoint
- test_graphql_200_response_classified_as_endpoint

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
