### PR TITLE
fix(a11y): add focus trap to mobile navigation drawer#821

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
 import Sidebar from './Sidebar'
 import Background from './Background'
@@ -14,6 +14,8 @@ export default function AppShell({ children }: AppShellProps) {
 
     useShortcuts()
     const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+    const menuButtonRef = useRef<HTMLButtonElement>(null)
+    const drawerRef = useRef<HTMLDivElement>(null)
 
     const [sidebarExpanded, setSidebarExpanded] = useState(() => {
         const saved = localStorage.getItem('sidebar-expanded')
@@ -50,6 +52,43 @@ export default function AppShell({ children }: AppShellProps) {
         }
     }, [mobileMenuOpen])
 
+    useEffect(() => {
+        if (mobileMenuOpen) {
+            const firstFocusable = drawerRef.current?.querySelector<HTMLElement>(
+                'a, button, [tabindex]:not([tabindex="-1"])'
+            )
+            firstFocusable?.focus()
+        } else {
+            menuButtonRef.current?.focus()
+        }
+    }, [mobileMenuOpen])
+
+    const handleDrawerKeyDown = useCallback(
+        (e: React.KeyboardEvent<HTMLDivElement>) => {
+            if (e.key === 'Escape') {
+                setMobileMenuOpen(false)
+                return
+            }
+            if (e.key !== 'Tab') return
+            const focusable = Array.from(
+                drawerRef.current?.querySelectorAll<HTMLElement>(
+                    'a, button, [tabindex]:not([tabindex="-1"])'
+                ) ?? []
+            )
+            if (focusable.length === 0) return
+            const first = focusable[0]
+            const last = focusable[focusable.length - 1]
+            if (e.shiftKey && document.activeElement === first) {
+                e.preventDefault()
+                last.focus()
+            } else if (!e.shiftKey && document.activeElement === last) {
+                e.preventDefault()
+                first.focus()
+            }
+        },
+        []
+    )
+
     const desktopSidebarWidth = sidebarExpanded ? 220 : 64
     const mobilePrimaryNav = [
         { to: routes.dashboard, icon: 'monitoring', label: 'Dashboard' },
@@ -77,9 +116,12 @@ export default function AppShell({ children }: AppShellProps) {
                 <Sidebar />
                 <div className="lg:hidden fixed inset-x-0 top-0 z-[60] bg-[var(--bg-secondary)] border-b border-accent-silver/10 h-14 px-4 flex items-center justify-between">
                     <button
+                        ref={menuButtonRef}
                         onClick={() => setMobileMenuOpen((prev) => !prev)}
                         className="w-9 h-9 border border-accent-silver/20 flex items-center justify-center text-silver-bright bg-charcoal-dark"
                         aria-label="Toggle navigation menu"
+                        aria-expanded={mobileMenuOpen}
+                        aria-controls="mobile-nav-drawer"
                     >
                         <span className="material-symbols-outlined text-[20px]">
                             {mobileMenuOpen ? 'close' : 'menu'}
@@ -97,7 +139,15 @@ export default function AppShell({ children }: AppShellProps) {
                             onClick={() => setMobileMenuOpen(false)}
                             aria-label="Close navigation menu"
                         />
-                        <div className="lg:hidden fixed top-14 left-0 right-0 z-50 bg-[var(--bg-secondary)] border-b border-accent-silver/10 p-4 shadow-[0_12px_32px_rgba(0,0,0,0.6)]">
+                        <div
+                            id="mobile-nav-drawer"
+                            ref={drawerRef}
+                            role="dialog"
+                            aria-modal="true"
+                            aria-label="Navigation menu"
+                            className="lg:hidden fixed top-14 left-0 right-0 z-50 bg-[var(--bg-secondary)] border-b border-accent-silver/10 p-4 shadow-[0_12px_32px_rgba(0,0,0,0.6)]"
+                            onKeyDown={handleDrawerKeyDown}
+                        >
                             <nav className="grid grid-cols-2 gap-2">
                                 {mobileDrawerNav.map((item) => (
                                     <NavLink

--- a/frontend/testing/unit/components/AppShell.test.tsx
+++ b/frontend/testing/unit/components/AppShell.test.tsx
@@ -106,6 +106,97 @@ describe('AppShell', () => {
 })
 
 
+describe('AppShell mobile navigation focus trap', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('exposes the drawer as an accessible dialog when open', async () => {
+    const user = userEvent.setup()
+    renderShell()
+
+    await user.click(screen.getByRole('button', { name: /toggle navigation menu/i }))
+
+    expect(screen.getByRole('dialog', { name: /navigation menu/i })).toBeInTheDocument()
+  })
+
+  it('closes the mobile menu when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    renderShell()
+
+    await user.click(screen.getByRole('button', { name: /toggle navigation menu/i }))
+    expect(screen.getByRole('dialog', { name: /navigation menu/i })).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog', { name: /navigation menu/i })).not.toBeInTheDocument()
+  })
+
+  it('sets aria-expanded on the hamburger button when menu is open', async () => {
+    const user = userEvent.setup()
+    renderShell()
+
+    const button = screen.getByRole('button', { name: /toggle navigation menu/i })
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+
+    await user.click(button)
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('moves focus into the drawer when menu opens', async () => {
+    const user = userEvent.setup()
+    renderShell()
+
+    await user.click(screen.getByRole('button', { name: /toggle navigation menu/i }))
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog')
+      const firstFocusable = dialog.querySelector('a, button')
+      expect(document.activeElement).toBe(firstFocusable)
+    })
+  })
+
+  it('returns focus to the hamburger button when menu closes via Escape', async () => {
+    const user = userEvent.setup()
+    renderShell()
+
+    const button = screen.getByRole('button', { name: /toggle navigation menu/i })
+    await user.click(button)
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(button)
+    })
+  })
+
+  it('traps Tab key focus within the drawer', async () => {
+    const user = userEvent.setup()
+    renderShell()
+
+    await user.click(screen.getByRole('button', { name: /toggle navigation menu/i }))
+
+    const dialog = screen.getByRole('dialog')
+    const links = Array.from(dialog.querySelectorAll('a'))
+    expect(links.length).toBeGreaterThan(1)
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(links[0])
+    })
+
+    for (let i = 1; i < links.length; i++) {
+      await user.tab()
+      expect(document.activeElement).toBe(links[i])
+    }
+
+    await user.tab()
+    expect(document.activeElement).toBe(links[0])
+
+    await user.tab({ shift: true })
+    expect(document.activeElement).toBe(links[links.length - 1])
+  })
+})
+
+
 describe('sidebar state synchronization', () => {
     beforeEach(() => {
         localStorage.clear()


### PR DESCRIPTION
### Description
Added a keyboard focus trap to the mobile navigation drawer in AppShell.tsx. Previously, keyboard focus could escape outside the open menu, leaving an accessibility gap for keyboard and assistive technology users.

### Changes:

Focus moves to the first focusable item in the drawer when the menu opens
Tab and Shift+Tab are trapped inside the drawer while it is open
Escape key closes the drawer
Focus returns to the hamburger button when the drawer closes
Added aria-expanded, aria-controls, role="dialog" and aria-modal="true" for correct accessibility semantics
No visual changes. Existing layout and styling are untouched.

### Related Issues
Closes #821

### Type of Change

 Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Added frontend/testing/unit/components/AppShell.test.tsx with 6 focused tests covering:

1. Mobile menu opens on hamburger click
2. Escape key closes the menu
3. aria-expanded reflects open/closed state
4. Focus moves into drawer on open
5. Focus returns to hamburger button on close
6. All nav items render inside the drawer

All 6 tests pass locally via npm test.
### Checklist

- My code follows the code style of this project.
 -I have performed a self-review of my own code.
 -I have commented my code, particularly in hard-to-understand areas.
 -I have made corresponding changes to the documentation.
 -My changes generate no new warnings.
