### PR TITLE
test: add start.sh shell smoke coverage

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -28,6 +28,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  shell-smoke:
+    name: start.sh shell smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate start.sh syntax
+        run: bash -n start.sh
+
+      - name: Verify frontend failure message
+        run: |
+          mv frontend frontend_backup
+          trap 'mv frontend_backup frontend' EXIT
+
+          if bash start.sh > output.log 2>&1; then
+            echo "Expected start.sh to fail"
+            exit 1
+          fi
+
+          grep -q "ERROR: frontend directory not found." output.log \
+            || { echo "Expected frontend error message not found"; cat output.log; exit 1; }
   smoke-test:
     name: Fresh-clone smoke test (Ubuntu)
     runs-on: ubuntu-latest

--- a/start.sh
+++ b/start.sh
@@ -32,6 +32,17 @@ sleep 1
 echo "⚙  Setting up backend..."
 cd "$ROOT_DIR"
 
+# Validate project structure before any expensive setup
+if [ ! -f "$ROOT_DIR/backend/requirements.txt" ]; then
+  echo "ERROR: backend/requirements.txt not found."
+  exit 1
+fi
+
+if [ ! -d "$ROOT_DIR/frontend" ]; then
+  echo "ERROR: frontend directory not found."
+  exit 1
+fi
+
 if [ -d "venv" ]; then
   source venv/bin/activate
 else


### PR DESCRIPTION
## Description
Adds Linux shell smoke coverage for start.sh by introducing a dedicated CI job that:
- Validates start.sh shell syntax using bash -n
- Verifies the expected failure behavior when the frontend directory is missing
- Ensures the error message remains actionable for contributors and maintainers
Also updates start.sh to validate required project structure (backend/requirements.txt and frontend/) before performing expensive setup steps, allowing the smoke test to fail quickly and predictably.

## Related Issues
Closes #878

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Local validation
bash -n start.sh

- Failure-path validation
Temporarily renamed the frontend directory and verified that:
bash start.sh
fails with:
ERROR: frontend directory not found.

- CI coverage
Added a new shell-smoke workflow job that:
1. Checks start.sh syntax.
2. Temporarily removes the frontend directory.
3. Confirms start.sh exits with the expected error message.
4. Restores the directory after the test.

## Checklist
- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
