### PR TITLE
ci: upload benchmark threshold comparison artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,11 +193,14 @@ jobs:
         id: run_benchmarks
         run: python3 scripts/run_benchmarks.py
         continue-on-error: true
-      - name: Upload benchmark results artifact
+      - name: Upload benchmark comparison artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-results
-          path: benchmark_results.json
+          name: benchmark-threshold-comparison
+          path: |
+            benchmark_results.json
+            benchmark_threshold_comparison.json
       - name: Add warning annotation on failure
         if: steps.run_benchmarks.outcome == 'failure'
         run: |

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -6,7 +6,6 @@ and exits non-zero if any regressions are detected.
 """
 
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -24,6 +23,7 @@ def main():
         root_dir / "testing" / "backend" / "benchmarks" / "thresholds.json"
     )
     results_path = root_dir / "benchmark_results.json"
+    comparison_path = root_dir / "benchmark_threshold_comparison.json"
 
     # 1. Load thresholds
     if not thresholds_path.exists():
@@ -56,6 +56,9 @@ def main():
     # Run the tests. We capture output/errors normally.
     result = subprocess.run(cmd, cwd=str(root_dir))
 
+    if result.returncode != 0 and not results_path.exists():
+        sys.exit(result.returncode)
+
     # 3. Read results
     if not results_path.exists():
         print(f"\n{RED}Error: Benchmark run did not produce {results_path}{RESET}")
@@ -72,9 +75,18 @@ def main():
     print("-" * 82)
 
     has_regression = False
+    comparison_report = []
     for metric, threshold in thresholds.items():
         if metric not in results:
             print(f"{metric:<45} | {'N/A':<12} | {threshold:<12} | {RED}MISSING{RESET}")
+            comparison_report.append(
+                {
+                    "metric": metric,
+                    "measured": None,
+                    "threshold": threshold,
+                    "status": "MISSING",
+                }
+            )
             has_regression = True
             continue
 
@@ -98,9 +110,27 @@ def main():
             has_regression = True
 
         print(f"{metric:<45} | {val_fmt:<12} | {thresh_fmt:<12} | {status_str:<6}")
+        comparison_report.append(
+            {
+                "metric": metric,
+                "measured": value,
+                "threshold": threshold,
+                "status": "PASS" if passed else "FAIL",
+            }
+        )
 
     print("\n" + "=" * 82 + "\n")
 
+    with open(comparison_path, "w") as f:
+        json.dump(
+            {
+                "benchmarks": comparison_report,
+                "regression_detected": has_regression,
+            },
+            f,
+            indent=2,
+        )
+    print(f"Benchmark comparison saved to {comparison_path}")
     if has_regression:
         print(
             f"{RED}{BOLD}Performance regression detected! One or more metrics exceeded thresholds.{RESET}"


### PR DESCRIPTION
## Description
Added CI artifact upload support for benchmark threshold comparisons.
Changes:
- Updated benchmark runner to generate `benchmark_threshold_comparison.json`
- Added structured benchmark comparison output containing:
  - benchmark metric name
  - measured value
  - configured threshold
  - PASS/FAIL/MISSING status
  - regression detection status
- Updated CI workflow to upload benchmark comparison artifacts after benchmark runs
- Ensured artifacts are uploaded even when benchmark checks fail for easier debugging

## Related Issues
Closes #879

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested locally by running:
python scripts/run_benchmarks.py

Verified:
- Benchmark suite completes successfully
- `benchmark_threshold_comparison.json` is generated
- All benchmark metrics are compared against thresholds
- PASS status is recorded correctly
- Regression flag is generated correctly

Also verified Python syntax with:
python -m py_compile scripts/run_benchmarks.py

## Checklist
- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.