### PR TITLE
test: add generated docs anchor validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,17 @@ jobs:
       - name: Validate issue template labels
         run: python scripts/validate_issue_template_labels.py
 
+  doc-anchor-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate documentation anchors
+        run: python scripts/validate_doc_anchors.py
+
   backend-lint:
     needs: detect-changes
     if: needs.detect-changes.outputs.run_backend == 'true'

--- a/scripts/validate_doc_anchors.py
+++ b/scripts/validate_doc_anchors.py
@@ -1,0 +1,58 @@
+import pathlib
+import re
+import sys
+
+HEADING_RE = re.compile(r"^#+\s+(.+)$")
+LINK_RE = re.compile(r"\]\(([^)]+)\)")
+
+def slugify(text):
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"\s+", "-", text)
+    return text
+
+
+def collect_anchors(md_file):
+    anchors = set()
+
+    for line in md_file.read_text(encoding="utf-8").splitlines():
+        match = HEADING_RE.match(line)
+        if match:
+            anchors.add(slugify(match.group(1)))
+
+    return anchors
+
+def validate_file(md_file):
+    content = md_file.read_text(encoding="utf-8")
+
+    anchors = collect_anchors(md_file)
+
+    failures = []
+
+    for target in LINK_RE.findall(content):
+        if not target.startswith("#"):
+            continue
+
+        anchor = target[1:]
+
+        if anchor not in anchors:
+            failures.append(anchor)
+
+    return failures
+
+
+def main():
+    failed = False
+
+    for md_file in pathlib.Path("docs").rglob("*.md"):
+        missing = validate_file(md_file)
+
+        for anchor in missing:
+            print(f"ERROR: {md_file} -> missing anchor #{anchor}")
+            failed = True
+
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/backend/unit/test_validate_doc_anchors.py
+++ b/testing/backend/unit/test_validate_doc_anchors.py
@@ -1,0 +1,33 @@
+from scripts.validate_doc_anchors import slugify, validate_file
+
+def test_detects_missing_anchor(tmp_path):
+    doc = tmp_path / "sample.md"
+
+    doc.write_text(
+        "# Heading\n\n[Broken](#missing-anchor)\n",
+        encoding="utf-8",
+    )
+
+    failures = validate_file(doc)
+
+    assert failures == ["missing-anchor"]
+
+
+def test_valid_anchor_passes(tmp_path):
+    doc = tmp_path / "sample.md"
+
+    doc.write_text(
+        "# My Heading\n\n[Link](#my-heading)\n",
+        encoding="utf-8",
+    )
+
+    failures = validate_file(doc)
+
+    assert failures == []
+
+def test_slugify_heading():
+    assert slugify("Incident Response Runbook") == "incident-response-runbook"
+
+
+def test_slugify_special_chars():
+    assert slugify("Hello, World!") == "hello-world"


### PR DESCRIPTION
## Description
Adds automated validation for Markdown documentation anchors in CI.

###Changes made
- Added scripts/validate_doc_anchors.py to detect broken anchor references in documentation files.
- Added unit tests covering anchor validation and slug generation logic.
- Added a new GitHub Actions job (doc-anchor-validation) in .github/workflows/ci.yml.
- Ensures broken documentation anchors are caught automatically during CI runs.

## Related Issues
Closes #889 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
python scripts/validate_doc_anchors.py

pytest testing/backend/unit/test_validate_doc_anchors.py -v

Result:

4 passed

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
