### PR TITLE
test: add paginated api_scanner parser coverage

### DIFF
--- a/testing/backend/test_api_scanner_plugin.py
+++ b/testing/backend/test_api_scanner_plugin.py
@@ -243,3 +243,45 @@ def test_api_scanner_parser_preserves_raw_line_in_metadata():
     result = parse(single_line)
     assert result["findings"]
     assert result["findings"][0]["metadata"]["raw"] == "https://api.example.com/v1/tokens [GET] [exposed]"
+
+def test_api_scanner_parser_handles_paginated_fixture():
+    """
+    Simulate paginated scanner output arriving in multiple chunks.
+    The parser should process all lines across pages.
+    """
+    page_1 = (
+        "https://api.example.com/v1/users [GET] [found]\n"
+        "https://api.example.com/v1/admin [GET] [warning]\n"
+    )
+
+    page_2 = (
+        "https://api.example.com/v1/health [GET] [200 OK]\n"
+        "https://api.example.com/graphql [POST] [detected]\n"
+    )
+
+    combined_output = page_1 + page_2
+
+    result = parse(combined_output)
+
+    assert result["count"] == 4
+    assert len(result["findings"]) == 4
+    assert len(result["items"]) == 4
+
+def test_api_scanner_parser_handles_chunked_response_fixture():
+    """
+    Simulate chunked scanner output that is concatenated before parsing.
+    """
+    chunks = [
+        "https://api.example.com/a [GET] [found]\n",
+        "https://api.example.com/b [GET] [warning]\n",
+        "https://api.example.com/c [GET] [critical]\n",
+    ]
+
+    result = parse("".join(chunks))
+
+    assert result["count"] == 3
+
+    severities = {f["severity"] for f in result["findings"]}
+
+    assert "low" in severities
+    assert "high" in severities


### PR DESCRIPTION
## Description
Adds parser coverage for paginated and chunked api_scanner outputs.

The new tests verify that the parser correctly processes findings when scan results arrive across multiple pages or concatenated chunks, instead of only validating the happy-path output shape.

## Related Issues
Closes #853 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
pytest testing/backend/test_api_scanner_plugin.py -v

Result:

23 passed

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
