### PR TITLE
Ci/parser family matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,18 +115,43 @@ jobs:
       - name: Run integration tests
         run: pytest testing/backend/integration -q -m "not benchmark"
 
+parser-contracts:
+    needs: [detect-changes, backend-lint, formatting-hygiene]
+    if: |
+      always() &&
+      needs.detect-changes.outputs.run_backend == 'true' &&
+      (needs.backend-lint.result == 'success' || needs.backend-lint.result == 'skipped') &&
+      (needs.formatting-hygiene.result == 'success' || needs.formatting-hygiene.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install backend system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcairo2-dev pkg-config
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt -r backend/requirements-dev.txt
+      - name: Run parser contract tests for capability group ${{ matrix.capability_group }}
+        run: |
+          echo "Running parser contract tests for capability group: ${{ matrix.capability_group }}"
+          PARSER_CAPABILITY_GROUP=${{ matrix.capability_group }} pytest testing/backend/integration/test_parser_output_contract.py -q
   backend-tests:
     needs:
       - backend-unit
       - backend-integration
+      - parser-contracts
     runs-on: ubuntu-latest
     if: |
       always() &&
       (needs.backend-unit.result == 'success' || needs.backend-unit.result == 'skipped') &&
-      (needs.backend-integration.result == 'success' || needs.backend-integration.result == 'skipped')
+      (needs.backend-integration.result == 'success' || needs.backend-integration.result == 'skipped') &&
+      (needs.parser-contracts.result == 'success' || needs.parser-contracts.result == 'skipped')
     steps:
       - name: Backend test suites completed
-        run: echo "backend-unit and backend-integration completed"
+        run: echo "backend-unit, backend-integration, and parser-contracts completed"
   backend-audit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Run integration tests
         run: pytest testing/backend/integration -q -m "not benchmark"
 
-parser-contracts:
+  parser-contracts:
     needs: [detect-changes, backend-lint, formatting-hygiene]
     if: |
       always() &&
@@ -123,6 +123,13 @@ parser-contracts:
       (needs.backend-lint.result == 'success' || needs.backend-lint.result == 'skipped') &&
       (needs.formatting-hygiene.result == 'success' || needs.formatting-hygiene.result == 'skipped')
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        capability_group:
+          - network
+          - intrusive
+          - credentials
+          - exploit
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -230,7 +237,6 @@ parser-contracts:
         if: steps.run_benchmarks.outcome == 'failure'
         run: |
           echo "::warning::Performance benchmark thresholds exceeded or benchmarks failed to run. Check the job logs for details."
-
   frontend-checks:
     needs: [detect-changes, formatting-hygiene]
     if: |

--- a/testing/backend/integration/test_parser_output_contract.py
+++ b/testing/backend/integration/test_parser_output_contract.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 import asyncio
 
+from backend.secuscan.capabilities import effective_capabilities
 from backend.secuscan.config import settings
 from backend.secuscan.plugins import init_plugins
 from backend.secuscan.executor import executor
@@ -14,6 +15,15 @@ from backend.secuscan.executor import executor
 # ---------------------------------------------------------------------------
 # Dynamic Discovery of All Bundled Custom Parsers
 # ---------------------------------------------------------------------------
+
+KNOWN_PARSER_CAPABILITY_GROUPS = frozenset({"network", "intrusive", "credentials", "exploit"})
+SELECTED_PARSER_CAPABILITY_GROUP = os.getenv("PARSER_CAPABILITY_GROUP", "").strip().lower()
+if SELECTED_PARSER_CAPABILITY_GROUP and SELECTED_PARSER_CAPABILITY_GROUP not in KNOWN_PARSER_CAPABILITY_GROUPS:
+    raise RuntimeError(
+        f"Unsupported parser capability group '{SELECTED_PARSER_CAPABILITY_GROUP}'."
+        f"Valid groups: {sorted(KNOWN_PARSER_CAPABILITY_GROUPS)}"
+    )
+
 
 def get_all_custom_parsers() -> list[tuple[str, Path, Path]]:
     """
@@ -36,6 +46,57 @@ def get_all_custom_parsers() -> list[tuple[str, Path, Path]]:
     return sorted(parsers, key=lambda x: x[0])
 
 
+
+def get_parser_capability_group(metadata_path: Path) -> str:
+    """Return the highest-consequence capability group for CI grouping."""
+    data = json.loads(metadata_path.read_text(encoding="utf-8"))
+    caps = data.get("capabilities")
+    if caps is None:
+        safety_level = data.get("safety", {}).get("level", "safe")
+        caps = list(effective_capabilities(None, safety_level, data.get("id", "unknown")))
+
+    if "exploit" in caps:
+        return "exploit"
+    if "docker" in caps:
+        return "docker"
+    if "credentials" in caps:
+        return "credentials"
+    if "intrusive" in caps:
+        return "intrusive"
+    return "network"
+
+
+def get_selected_custom_parsers() -> list[tuple[str, Path, Path]]:
+    """Return plugin parsers filtered by the requested capability group."""
+    if not SELECTED_PARSER_CAPABILITY_GROUP:
+        return get_all_custom_parsers()
+
+    selected = [
+        item
+        for item in get_all_custom_parsers()
+        if get_parser_capability_group(item[2]) == SELECTED_PARSER_CAPABILITY_GROUP
+    ]
+
+    if not selected:
+        raise RuntimeError(
+            f"No parser contracts found for capability group '{SELECTED_PARSER_CAPABILITY_GROUP}'. "
+            "Verify that the group name is correct and that plugin metadata declares the expected capabilities."
+        )
+
+    return selected
+
+
+def test_parser_capability_groups_are_populated() -> None:
+    """Ensure known CI capability groups map to at least one parser plugin."""
+    groups = {get_parser_capability_group(metadata_path) for _, _, metadata_path in get_all_custom_parsers()}
+    missing = KNOWN_PARSER_CAPABILITY_GROUPS - groups
+    assert not missing, (
+        "The parser capability matrix contains groups with no matching plugins: "
+        f"{sorted(missing)}. "
+        "Update KNOWN_PARSER_CAPABILITY_GROUPS or plugin metadata capabilities accordingly."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Module Fixtures
 # ---------------------------------------------------------------------------
@@ -50,7 +111,7 @@ def plugin_manager_instance():
 # Parser Contract Tests
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("plugin_id, parser_path, metadata_path", get_all_custom_parsers())
+@pytest.mark.parametrize("plugin_id, parser_path, metadata_path", get_selected_custom_parsers())
 def test_parser_contract_compliance(plugin_id, parser_path, metadata_path, plugin_manager_instance):
     """
     Verifies that every custom parser in the codebase complies with

--- a/testing/backend/integration/test_parser_output_contract.py
+++ b/testing/backend/integration/test_parser_output_contract.py
@@ -57,8 +57,8 @@ def get_parser_capability_group(metadata_path: Path) -> str:
 
     if "exploit" in caps:
         return "exploit"
-    if "docker" in caps:
-        return "docker"
+    # if "docker" in caps:
+    #     return "docker"
     if "credentials" in caps:
         return "credentials"
     if "intrusive" in caps:


### PR DESCRIPTION
## Description
Split parser contract validation in CI by parser capability groups to make parser failures easier to isolate and triage.

Changes:

Added capability-group filtering to testing/backend/integration/test_parser_output_contract.py using the PARSER_CAPABILITY_GROUP environment variable.
Added a guard test to ensure every configured CI capability group has at least one matching parser plugin.
Added a parser-contracts matrix job in .github/workflows/ci.yml that runs parser contract tests independently for each capability group.
Updated backend test aggregation so parser contract failures are surfaced clearly in CI results.

## Related Issues
Closes #876 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran parser contract tests locally:
pytest testing/backend/integration/test_parser_output_contract.py -v
Verified capability-group filtering works through the PARSER_CAPABILITY_GROUP environment variable.
Confirmed the guard test validates CI capability group configuration and fails when a configured group has no matching parser plugins.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
