### PR TITLE
feat(plugins): declare network capability for http_inspector (#854)

### DIFF
--- a/plugins/http_inspector/metadata.json
+++ b/plugins/http_inspector/metadata.json
@@ -79,6 +79,9 @@
       "max_concurrent": 5
     }
   },
+  "capabilities": [
+    "network"
+  ],
   "learning": {
     "difficulty": "beginner",
     "estimated_duration": "30 seconds",
@@ -92,5 +95,5 @@
     "system_packages": []
   },
   "docker_image": "curlimages/curl",
-  "checksum": "435436b8dbde27b30f545c3f5701089db880794a8a3f3a47e08cf2e6dbffa447"
+  "checksum": "e62fb9a052a9d10b634541d9c3fc72c2c700bb684272324a66ecf75af070ab77"
 }

--- a/testing/backend/test_http_inspector_plugin.py
+++ b/testing/backend/test_http_inspector_plugin.py
@@ -1,0 +1,135 @@
+"""
+Capability inventory and contract tests for the http_inspector plugin.
+
+These tests load the real plugins/http_inspector/metadata.json, validate it
+through the project PluginMetadataValidator, and assert the declared capability
+inventory both directly and as surfaced by the real PluginManager (the path the
+UI uses for capability-based grouping).
+
+http_inspector performs safe, read-only HTTP requests, so the only capability it
+exercises is outbound ``network``. Declaring it explicitly keeps UI grouping
+predictable instead of relying on the safety-level implied fallback.
+
+Related to issue #854: Add capability inventory notes for http_inspector
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from backend.secuscan.capabilities import (
+    effective_capabilities,
+    validate_capability_list,
+    _SAFETY_LEVEL_IMPLIED,
+)
+from backend.secuscan.plugin_validator import PluginMetadataValidator
+from backend.secuscan.plugins import PluginManager
+
+PLUGIN_DIR = REPO_ROOT / "plugins" / "http_inspector"
+PLUGINS_DIR = REPO_ROOT / "plugins"
+
+
+def _load_metadata() -> dict:
+    return json.loads((PLUGIN_DIR / "metadata.json").read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Metadata contract tests
+# ---------------------------------------------------------------------------
+
+
+def test_http_inspector_metadata_file_exists():
+    """metadata.json must exist at the expected plugin path."""
+    assert (PLUGIN_DIR / "metadata.json").exists()
+
+
+def test_http_inspector_metadata_is_valid_json():
+    """metadata.json must be valid, parseable JSON."""
+    assert isinstance(_load_metadata(), dict)
+
+
+def test_http_inspector_metadata_id_matches_directory():
+    """Plugin id in metadata.json must match the directory name."""
+    assert _load_metadata()["id"] == "http_inspector"
+
+
+def test_http_inspector_passes_validator():
+    """The full PluginMetadataValidator must accept the plugin without errors."""
+    result = PluginMetadataValidator(PLUGIN_DIR).validate()
+    assert result.valid, "Plugin validation errors:\n" + "\n".join(
+        e.display() for e in result.errors
+    )
+
+
+def test_http_inspector_is_safe_level():
+    """http_inspector is a read-only HTTP tool and must stay at safety level 'safe'."""
+    assert _load_metadata()["safety"]["level"] == "safe"
+
+
+# ---------------------------------------------------------------------------
+# Capability inventory tests (issue #854)
+# ---------------------------------------------------------------------------
+
+
+def test_http_inspector_declares_capabilities_explicitly():
+    """Metadata must declare an explicit capabilities list (not rely on the fallback)."""
+    data = _load_metadata()
+    assert "capabilities" in data, "http_inspector must declare a capabilities list"
+    assert data["capabilities"] == ["network"]
+
+
+def test_http_inspector_capabilities_are_known_tokens():
+    """Declared capabilities must all be recognised capability tokens."""
+    caps = _load_metadata()["capabilities"]
+    assert validate_capability_list(caps, "http_inspector") == ["network"]
+
+
+def test_http_inspector_capabilities_match_implied_safe_set():
+    """
+    The explicit declaration must match the capability set previously implied by
+    the 'safe' safety level, proving this change documents existing behavior
+    rather than altering enforcement.
+    """
+    data = _load_metadata()
+    effective = effective_capabilities(
+        data["capabilities"], data["safety"]["level"], "http_inspector"
+    )
+    assert effective == {"network"}
+    assert effective == set(_SAFETY_LEVEL_IMPLIED["safe"])
+
+
+# ---------------------------------------------------------------------------
+# Capability surfacing via the real PluginManager (UI grouping path)
+# ---------------------------------------------------------------------------
+
+
+def test_http_inspector_loaded_by_plugin_manager(setup_test_environment):
+    """PluginManager must load http_inspector and expose its declared capabilities."""
+    manager = PluginManager(str(PLUGINS_DIR))
+    asyncio.run(manager.load_plugins())
+
+    plugin = manager.get_plugin("http_inspector")
+    assert plugin is not None
+    assert plugin.id == "http_inspector"
+    assert plugin.capabilities == ["network"]
+
+
+def test_http_inspector_capabilities_surface_in_listing(setup_test_environment):
+    """
+    list_plugins() must report capabilities for http_inspector so the UI can group
+    it predictably.
+    """
+    manager = PluginManager(str(PLUGINS_DIR))
+    asyncio.run(manager.load_plugins())
+
+    entry = next(
+        (p for p in manager.list_plugins() if p["id"] == "http_inspector"), None
+    )
+    assert entry is not None
+    assert entry["capabilities"] == ["network"]


### PR DESCRIPTION
## Description
`http_inspector` performs safe, read-only HTTP requests (`curl -i -L`), so the only
capability it exercises is outbound **network**. Previously it declared no
`capabilities` list and fell back to the safety-level implied set, which left UI
capability grouping dependent on inference rather than the plugin contract.

This PR declares the capability inventory explicitly:
- Add `"capabilities": ["network"]` to `plugins/http_inspector/metadata.json`
  (placed after the `safety` block, mirroring `api_scanner`/`network_scanner`) and
  refresh the plugin `checksum`.
- The explicit set is identical to the set previously implied for `safe` plugins, so
  capability **enforcement behavior is unchanged** — this only makes the declaration
  (and therefore UI grouping via `PluginManager.list_plugins`) predictable.
- No change needed in `backend/secuscan/capabilities.py`; explicit lists are already
  validated and enforced.
- Add `testing/backend/test_http_inspector_plugin.py` with contract + capability tests.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `pytest testing/backend/test_http_inspector_plugin.py` — 10/10 pass (metadata contract,
  explicit declaration, validator acceptance, `effective_capabilities` == implied `safe`
  set, and surfacing via `PluginManager.get_plugin` / `list_plugins`).
- `pytest testing/backend/unit/test_plugins.py` — 21 pass; sibling
  `test_http_request_logger_plugin.py` — 20 pass (no regression).
- `python scripts/validate_plugin.py --plugin http_inspector` — OK.
- `python scripts/validate_plugins.py` — 59/59 valid.
- `python scripts/validate_plugins_catalog.py --catalog PLUGINS.md --plugins-dir plugins` — in sync.
- `ruff check backend testing/backend` — clean.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

Closes #854

@utksh1 please review this pr 