### PR TITLE
fix: prevent task deletion race condition (TOCTOU) with in-memory check and optimistic lock

### DIFF
--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -559,7 +559,7 @@ class Database:
         print(f"Backfilled risk scores for {len(rows)} existing finding(s).")
 
     async def execute(self, query: str, params: tuple = ()):
-        """Execute a write query."""
+        """Execute a write query and return the cursor (so callers can inspect rowcount)."""
         cursor = await self.connection.execute(query, params)
         await self.connection.commit()
         return cursor

--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -560,12 +560,14 @@ class Database:
 
     async def execute(self, query: str, params: tuple = ()):
         """Execute a write query."""
-        await self.connection.execute(query, params)
+        cursor = await self.connection.execute(query, params)
         await self.connection.commit()
+        return cursor
 
     async def execute_no_commit(self, query: str, params: tuple = ()):
         """Execute a write query without committing (for use inside transactions)."""
-        await self.connection.execute(query, params)
+        cursor = await self.connection.execute(query, params)
+        return cursor
 
     async def begin(self):
         """Begin a transaction."""

--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -362,11 +362,16 @@ class TaskExecutor:
         self.running_tasks[task_id] = asyncio.current_task()
 
         try:
-            # Update status to running
-            await db.execute(
-                "UPDATE tasks SET status = ?, started_at = ? WHERE id = ?",
-                (TaskStatus.RUNNING.value, datetime.now().isoformat(), task_id)
+            # Update status to running — use optimistic lock to detect
+            # if the task was deleted or already running before this point.
+            result = await db.execute(
+                "UPDATE tasks SET status = ?, started_at = ? WHERE id = ? AND status = ?",
+                (TaskStatus.RUNNING.value, datetime.now().isoformat(), task_id, TaskStatus.QUEUED.value)
             )
+            if result.rowcount == 0:
+                logger.warning(f"Task {task_id} was deleted or no longer queued before execution started. Aborting.")
+                self.running_tasks.pop(task_id, None)
+                return
             await self._invalidate_cached_views()
 
             # Get task details

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -1268,6 +1268,10 @@ async def delete_task(task_id: str, owner: str = Depends(get_current_owner)):
     if status and status.get("status") == "running":
         raise HTTPException(status_code=400, detail="Cannot delete a running task. Abort it first.")
 
+    # If the task is currently executing but the DB hasn't been updated yet, fail closed.
+    if task_id in executor.running_tasks:
+        raise HTTPException(status_code=400, detail="Cannot delete a running task. Abort it first.")
+
     await delete_task_records([task_id])
     await invalidate_view_cache()
 

--- a/testing/backend/integration/test_task_cleanup.py
+++ b/testing/backend/integration/test_task_cleanup.py
@@ -225,6 +225,34 @@ async def test_delete_running_task_returns_400(app_client):
 
 
 @pytest.mark.asyncio
+async def test_delete_task_rejected_when_in_executor_running_tasks(app_client):
+    """Deleting a task whose ID is in executor.running_tasks returns 400,
+    even if the DB status is 'queued' (i.e. the optimistic UPDATE hasn't fired yet).
+
+    This exercises the in-memory safety check added alongside the race fix.
+    """
+    db = app_client._db
+    task_id = await insert_task(db, status="queued")
+
+    # Place the task ID directly into running_tasks to simulate the race window
+    # where execute_task has stored the task but the DB UPDATE hasn't run yet.
+    app_client._mock_executor.running_tasks = {task_id: "mock_task"}
+    app_client._mock_executor.get_task_status = AsyncMock(
+        return_value={"status": "queued"}
+    )
+
+    resp = await app_client.delete(f"/api/v1/task/{task_id}")
+
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    assert "running" in body["detail"].lower()
+
+    # Verify the task still exists in the DB (was NOT deleted)
+    rows = await db_fetchall(app_client._db_path, "SELECT id FROM tasks WHERE id = ?", (task_id,))
+    assert len(rows) == 1, "Task should NOT have been deleted"
+
+
+@pytest.mark.asyncio
 async def test_delete_missing_task_returns_200(app_client):
     """Deleting a task that doesn't exist returns 200 (route is idempotent).
 

--- a/testing/backend/unit/test_executor.py
+++ b/testing/backend/unit/test_executor.py
@@ -688,3 +688,76 @@ async def test_docker_network_missing_and_create_fails(setup_test_environment):
     assert "does not exist and could not be created" in (row["error_message"] or "")
     mock_limiter.release.assert_called_once_with(task_id)
     await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_execute_task_aborts_when_task_no_longer_queued(setup_test_environment):
+    """
+    When the optimistic UPDATE ... WHERE status='queued' returns rowcount 0
+    (because the task was deleted or its status changed before execution started),
+    execute_task() must abort without proceeding further.
+    """
+    await init_db(settings.database_path)
+    db = await get_db()
+
+    task_id = str(uuid.uuid4())
+    await db.execute(
+        """
+        INSERT INTO tasks (id, plugin_id, tool_name, target, inputs_json,
+                           status, consent_granted, safe_mode)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (task_id, "nmap", "nmap", "127.0.0.1", '{"target":"127.0.0.1"}',
+         TaskStatus.RUNNING.value, 1, 1)
+    )
+
+    executor = TaskExecutor()
+
+    with patch("backend.secuscan.executor.get_plugin_manager") as mock_pm, \
+         patch("backend.secuscan.executor.concurrent_limiter") as mock_limiter:
+        mock_limiter.release = AsyncMock()
+        mock_pm.return_value.get_plugin.return_value = MagicMock(name="nmap", presets={})
+
+        await executor.execute_task(task_id)
+
+    # Verify the task was NOT updated — it stays in its original (RUNNING) state
+    row = await db.fetchone("SELECT status FROM tasks WHERE id = ?", (task_id,))
+    assert row["status"] == TaskStatus.RUNNING.value
+    mock_pm.return_value.build_command.assert_not_called()
+    await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_execute_task_aborts_when_task_deleted_before_running(setup_test_environment):
+    """
+    When the task row is deleted before execute_task runs the optimistic
+    UPDATE, the rowcount will be 0 and the method must abort gracefully.
+    """
+    await init_db(settings.database_path)
+    db = await get_db()
+
+    task_id = str(uuid.uuid4())
+    await db.execute(
+        """
+        INSERT INTO tasks (id, plugin_id, tool_name, target, inputs_json,
+                           status, consent_granted, safe_mode)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (task_id, "nmap", "nmap", "127.0.0.1", '{"target":"127.0.0.1"}',
+         TaskStatus.QUEUED.value, 1, 1)
+    )
+
+    executor = TaskExecutor()
+
+    with patch("backend.secuscan.executor.get_plugin_manager") as mock_pm, \
+         patch("backend.secuscan.executor.concurrent_limiter") as mock_limiter:
+        mock_limiter.release = AsyncMock()
+        mock_pm.return_value.get_plugin.return_value = MagicMock(name="nmap", presets={})
+
+        # Delete the task before execute_task can update it
+        await db.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+
+        await executor.execute_task(task_id)
+
+    assert task_id not in executor.running_tasks
+    await db.disconnect()


### PR DESCRIPTION
## Description

The single-task delete endpoint (`DELETE /task/{task_id}`) had a TOCTOU race condition with `executor.execute_task()`. The delete endpoint only checked the database for the task's running status, but `execute_task()` populates the in-memory `running_tasks` dict **before** updating the database. This window allowed task deletion while the task was actually executing, creating zombie containers/orphaned processes.

### Changes Made

**1. Add in-memory running_tasks check to delete_task** (`backend/secuscan/routes.py`)
- Added the same `executor.running_tasks` check that `bulk_delete_tasks` already had
- If the task is executing but the DB hasn't updated yet, the delete is rejected

**2. Add optimistic DB lock to execute_task** (`backend/secuscan/executor.py`)
- Changed the status UPDATE query to include `AND status = ?` with `TaskStatus.QUEUED.value`
- If the task was deleted before execution started, the UPDATE affects 0 rows and execution aborts
- Prevents silent execution of orphaned tasks after DB deletion

Closes  #962