### PR TITLE
docs(secret_scanner): add checksum refresh guidance

### DIFF
--- a/docs/plugin-validation.md
+++ b/docs/plugin-validation.md
@@ -151,3 +151,25 @@ Existing plugins using a raw `pattern` continue to work without changes:
 ## Backwards compatibility
 
 Plugins that already define `validation.pattern` (without `validation_type`) continue to work exactly as before. No migration is required.
+
+---
+
+## Updating plugin checksums
+
+When changing plugin metadata or parser behavior, refresh the stored checksum so metadata validation stays in sync.
+
+Typical changes that require a checksum refresh include:
+
+- Updating a plugin `metadata.json` file
+- Changing parser expectations or capabilities
+- Modifying plugin fields or defaults
+
+After making changes, run:
+
+```bash
+python scripts/refresh_plugin_checksum.py --plugin <plugin_name>
+```
+
+Then verify that the `checksum` field inside the plugin metadata has been updated and commit the resulting change together with the documentation update.
+
+This keeps parser and metadata expectations aligned and prevents checksum validation failures in CI.


### PR DESCRIPTION
## Description
Added documentation describing how contributors should refresh the secret_scanner plugin checksum after metadata or parser changes.

- Added a dedicated section to docs/plugin-validation.md.
- Documented situations that require checksum refresh.
- Added the command: python scripts/refresh_plugin_checksum.py --plugin secret_scanner
- Explained verification of the updated checksum field.
- Clarified how this helps prevent CI checksum validation failures.

## Related Issues
Closes #844 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
Documentation-only change.

Verified that:
- The new guidance is added to docs/plugin-validation.md.
- No code or parser behavior was modified.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
