### PR TITLE
docs(scapy_recon): add metadata examples and safer hints

### DIFF
--- a/plugins/scapy_recon/metadata.json
+++ b/plugins/scapy_recon/metadata.json
@@ -27,7 +27,7 @@
       "type": "string",
       "required": true,
       "placeholder": "192.168.1.0/24",
-      "help": "Target IP address or CIDR range."
+      "help": "Target IPv4 address or CIDR range. Examples: 192.168.1.10 or 192.168.1.0/24. Only scan networks you own or are authorized to assess."
     },
     {
       "id": "type",
@@ -45,7 +45,7 @@
           "label": "ICMP Ping (standard)"
         }
       ],
-      "help": "Method of network discovery."
+      "help": "Choose ARP Ping for local networks and ICMP Ping for standard host discovery. Use only with proper authorization."
     }
   ],
   "presets": {
@@ -86,5 +86,5 @@
     ]
   },
   "docker_image": "secdev/scapy:latest",
-  "checksum": "688f16afba16bcf122728cd46a060717622ffeb96dad29b964593b9025b79682"
+  "checksum": "172b7870ba6be89b46ec2918c2567b9d0e5be70b719e0e0d404d81b39a7fa18d"
 }


### PR DESCRIPTION
## Description
Improves the scapy_recon plugin metadata by adding clearer examples and safer usage guidance.

###Changes made:
- Expanded the target field help text with IPv4 and CIDR examples.
- Added authorization guidance for network scanning.
- Clarified the intended use of ARP Ping and ICMP Ping.
- Refreshed the plugin checksum after metadata updates.

## Related Issues
Closes #847 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
Ran: python scripts/refresh_plugin_checksum.py --plugin scapy_recon

- Verified that the checksum was updated successfully.
- Reviewed the metadata examples and usage hints.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
