### PR TITLE
test(whois_lookup): add empty output handling coverage

### DIFF
--- a/testing/backend/unit/test_whois_lookup_parser.py
+++ b/testing/backend/unit/test_whois_lookup_parser.py
@@ -1,0 +1,25 @@
+from plugins.whois_lookup.parser import parse
+
+
+def test_empty_output_returns_default_record():
+    result = parse("")
+
+    assert "findings" in result
+    assert "rows" in result
+    assert "detail" in result
+
+    assert len(result["findings"]) == 1
+    assert result["detail"]["registrar"] == "Unknown"
+
+
+def test_rate_limited_output_returns_default_record():
+    output = "WHOIS LIMIT EXCEEDED"
+
+    result = parse(output)
+
+    assert "findings" in result
+    assert "rows" in result
+    assert "detail" in result
+
+    assert len(result["findings"]) == 1
+    assert result["detail"]["registrar"] == "Unknown"


### PR DESCRIPTION
## Description
- Added unit tests for whois_lookup parser to verify handling of empty outputs.
- Added coverage for rate-limited or malformed outputs to ensure no malformed findings are produced.
- Improved parser robustness validation without changing plugin behavior.

## Related Issues
Closes #850 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- Added tests in testing/backend/unit/test_whois_lookup_parser.py.

- Ran: pytest testing/backend/unit/test_whois_lookup_parser.py -v

- Result: 2 passed

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
