### PR TITLE
fix(reports): usePreferredExportFormat hook consistently across export entry points.

### DIFF
--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -16,6 +16,7 @@ import {
   UserShield02Icon,
 } from '@hugeicons/core-free-icons'
 import { getDashboardSummary, getReports, API_BASE } from '../api'
+import { usePreferredExportFormat } from '../hooks/usePreferredExportFormat'
 import { formatDateLong, isWithinDateRange, type DateRange } from '../utils/date'
 
 type Report = {
@@ -96,7 +97,7 @@ export default function Reports() {
   const [selectedDateRange, setSelectedDateRange] = useState<DateRange>('all')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [preferredFormat, setPreferredFormat] = useState<string | null>(null)
+  const { preferred: preferredFormat, savePreference } = usePreferredExportFormat()
   const latestReadyReport = [...reports]
     .filter((report) => report.status === 'ready')
     .sort((a, b) => new Date(b.generated_at).getTime() - new Date(a.generated_at).getTime())[0]
@@ -120,8 +121,6 @@ export default function Reports() {
 
   useEffect(() => {
     fetchReports()
-    const pref = localStorage.getItem('secuscan:preferred-export-format')
-    if (pref) setPreferredFormat(pref)
   }, [])
 
   const filteredReports = reports.filter((report) =>
@@ -156,10 +155,11 @@ export default function Reports() {
           <button
             onClick={() => {
               if (!latestReadyReport) return
-              window.open(`${API_BASE}/task/${latestReadyReport.task_id}/report/pdf`, '_blank')
+              const format = preferredFormat ?? 'pdf'
+              window.open(`${API_BASE}/task/${latestReadyReport.task_id}/report/${format}`, '_blank')
             }}
-            aria-label="Download latest ready report PDF"
-            title={latestReadyReport ? 'Download latest ready report PDF' : 'No ready report available'}
+            aria-label={`Download latest ready report ${(preferredFormat ?? 'pdf').toUpperCase()}`}
+            title={latestReadyReport ? `Download latest ready report ${(preferredFormat ?? 'pdf').toUpperCase()}` : 'No ready report available'}
             disabled={!latestReadyReport}
             className="bg-charcoal border-4 border-black p-4 text-silver-bright shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
           >
@@ -402,11 +402,7 @@ export default function Reports() {
                                   key={format}
                                   onClick={() => {
                                     if (report.status === 'generating') return
-                                    // Persist preferred export format for future sessions/tests
-                                    try {
-                                      localStorage.setItem('secuscan:preferred-export-format', format)
-                                    } catch {}
-                                    setPreferredFormat(format)
+                                    savePreference(format)
                                     window.open(`${API_BASE}/task/${report.task_id}/report/${format}`, '_blank')
                                   }}
                                   disabled={report.status === 'generating'}

--- a/frontend/testing/unit/pages/Reports.preferredFormat.test.tsx
+++ b/frontend/testing/unit/pages/Reports.preferredFormat.test.tsx
@@ -97,4 +97,29 @@ describe('Reports — preferred export format', () => {
         const htmlBtn = await screen.findByRole('button', { name: /^html$/i })
         expect(htmlBtn.className).toContain('bg-rag-amber')
     })
+
+    it('header download button uses the preferred format instead of defaulting to pdf', async () => {
+        localStorage.setItem('secuscan:preferred-export-format', 'sarif')
+        renderReports()
+
+        const headerBtn = await screen.findByRole('button', { name: /download latest ready report sarif/i })
+        await userEvent.click(headerBtn)
+
+        expect(window.open).toHaveBeenCalledWith(
+            expect.stringContaining('/report/sarif'),
+            '_blank',
+        )
+    })
+
+    it('header download button defaults to pdf when no preference is saved', async () => {
+        renderReports()
+
+        const headerBtn = await screen.findByRole('button', { name: /download latest ready report pdf/i })
+        await userEvent.click(headerBtn)
+
+        expect(window.open).toHaveBeenCalledWith(
+            expect.stringContaining('/report/pdf'),
+            '_blank',
+        )
+    })
 })


### PR DESCRIPTION
### Description
Reports.tsx previously managed the preferred export format using its own inline useState and direct localStorage calls instead of the existing usePreferredExportFormat hook. This meant the header's quick-download button always defaulted to PDF and ignored the user's saved preference, even though the per-report export buttons respected it.

### Changes:

1. Replaced the inline preferredFormat state and manual localStorage calls in Reports.tsx with the usePreferredExportFormat hook
2. Updated the header download button to use the preferred format instead of hardcoding PDF, with matching aria-label and title text
3. Centralized the save logic so all export entry points (header button and per-report buttons) go through the same savePreference function
4. No visual changes. Existing layout, styling, and behavior for per-report export buttons are unchanged.

### Related Issues
Closes #823 

### Type of Change

-  Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Extended frontend/testing/unit/pages/Reports.preferredFormat.test.tsx with 2 new focused tests:
Header download button uses the preferred format instead of defaulting to pdf
Header download button defaults to pdf when no preference is saved
All 42 tests in the Reports test suite pass locally (40 existing + 2 new) via npm test.

### Checklist

 My code follows the code style of this project.
 I have performed a self-review of my own code.
 I have commented my code, particularly in hard-to-understand areas.
 I have made corresponding changes to the documentation.
 My changes generate no new warnings