### PR TITLE
Add metadata examples for dns_enum

### DIFF
--- a/plugins/dns_enum/metadata.json
+++ b/plugins/dns_enum/metadata.json
@@ -3,7 +3,7 @@
   "name": "DNS Reconnaissance",
   "version": "1.0.0",
   "description": "Enumerate DNS records and configurations",
-  "long_description": "DNSRecon is a powerful DNS reconnaissance tool. It can perform various types of DNS security assessments, including zone transfers, reverse lookups, and brute forcing.",
+  "long_description": "DNSRecon performs DNS reconnaissance against a single registrable domain (for example example.com or scanme.nmap.org). Standard enumeration resolves the domain's A/AAAA, NS, MX and SOA records and groups repeated values into one readable entry per host. Zone Transfer (AXFR) attempts a full zone copy and reports a critical finding when a name server allows it. Brute Force discovers subdomains from a built-in name list. Run it only against domains you own or are explicitly authorized to assess.",
   "category": "recon",
   "author": {
     "name": "SecuScan Contributors",
@@ -28,7 +28,7 @@
       "type": "string",
       "required": true,
       "placeholder": "example.com",
-      "help": "Target domain for DNS enumeration."
+      "help": "Registrable domain to enumerate — no scheme or path (e.g. example.com, scanme.nmap.org, or an internal domain such as corp.example). DNSRecon resolves this domain's A/AAAA, NS, MX and SOA records; subdomains are only discovered when Enum Type is set to Brute Force."
     },
     {
       "id": "type",
@@ -50,7 +50,7 @@
           "label": "Brute Force Subdomains"
         }
       ],
-      "help": "Type of DNS enumeration to perform."
+      "help": "What DNSRecon enumerates. Standard returns the domain's A/AAAA, NS, MX and SOA records grouped per host. Zone Transfer (AXFR) attempts a full zone copy and reports a critical finding if the server allows it. Brute Force discovers subdomains from a built-in name list."
     }
   ],
   "presets": {
@@ -59,6 +59,9 @@
     },
     "zone_transfer": {
       "type": "axfr"
+    },
+    "subdomain_bruteforce": {
+      "type": "brt"
     }
   },
   "output": {
@@ -88,5 +91,5 @@
     ]
   },
   "docker_image": "darkoperator/dnsrecon:latest",
-  "checksum": "a9d9107ad715c542acc252d495337b6f7de790210e3d300971e1aba2e19260f4"
+  "checksum": "12cd4e84e7bf888e9b8d5a21d597ca1487f2ab843be78ab367e486bec9b2b761"
 }

--- a/testing/backend/test_dns_enum_plugin.py
+++ b/testing/backend/test_dns_enum_plugin.py
@@ -1,0 +1,227 @@
+"""
+Contract tests for the dns_enum (DNS Reconnaissance) plugin.
+
+These tests load the real plugins/dns_enum/metadata.json, validate it through
+the project PluginMetadataValidator, render commands through the real
+PluginManager, and exercise the real parser.py parse() function.
+
+The focus is the example/guidance contract added for issue #856
+("Add metadata examples for dns_enum"): the field help, long_description and
+presets must document common domain targets and the output expectations
+(grouped DNS records, and a critical finding when a zone transfer succeeds).
+If that guidance, the command template, or the parser drift, these tests fail.
+
+Related to issue #856.
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from backend.secuscan.plugin_validator import PluginMetadataValidator
+from backend.secuscan.plugins import PluginManager
+from plugins.dns_enum.parser import parse
+
+PLUGIN_DIR = REPO_ROOT / "plugins" / "dns_enum"
+PLUGINS_DIR = REPO_ROOT / "plugins"
+
+
+def _metadata() -> dict:
+    return json.loads((PLUGIN_DIR / "metadata.json").read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Metadata contract tests
+# ---------------------------------------------------------------------------
+
+
+def test_dns_enum_metadata_file_exists():
+    """metadata.json must exist at the expected plugin path."""
+    assert (PLUGIN_DIR / "metadata.json").exists()
+
+
+def test_dns_enum_metadata_is_valid_json():
+    """metadata.json must be valid, parseable JSON."""
+    assert isinstance(_metadata(), dict)
+
+
+def test_dns_enum_passes_validator():
+    """The full PluginMetadataValidator must accept the plugin without errors."""
+    result = PluginMetadataValidator(PLUGIN_DIR).validate()
+    assert result.valid, "Plugin validation errors:\n" + "\n".join(
+        e.display() for e in result.errors
+    )
+
+
+def test_dns_enum_metadata_id_matches_directory():
+    """Plugin id in metadata.json must match the directory name."""
+    assert _metadata()["id"] == "dns_enum"
+
+
+def test_dns_enum_engine_is_dnsrecon():
+    """Engine must be the dnsrecon CLI binary."""
+    data = _metadata()
+    assert data["engine"]["type"] == "cli"
+    assert data["engine"]["binary"] == "dnsrecon"
+
+
+def test_dns_enum_output_parser_is_custom():
+    """Parser type must be 'custom', backed by parser.py."""
+    assert _metadata()["output"]["parser"] == "custom"
+
+
+def test_dns_enum_parser_file_exists():
+    """parser.py must exist alongside metadata.json."""
+    assert (PLUGIN_DIR / "parser.py").exists()
+
+
+def test_dns_enum_has_required_target_field():
+    """Plugin must declare a required 'target' field for the domain."""
+    fields = {f["id"]: f for f in _metadata()["fields"]}
+    assert "target" in fields, "Missing required field: target"
+    assert fields["target"]["required"] is True
+
+
+# ---------------------------------------------------------------------------
+# Example / guidance contract (issue #856)
+# ---------------------------------------------------------------------------
+
+
+def test_dns_enum_target_help_documents_example_domain():
+    """The target field help must show a concrete domain example and clarify
+    that it is a bare domain (no scheme or path)."""
+    target = next(f for f in _metadata()["fields"] if f["id"] == "target")
+    help_text = target["help"].lower()
+    assert "example.com" in target["placeholder"]
+    assert "example.com" in help_text
+    # Must steer operators away from pasting a URL.
+    assert "scheme" in help_text or "no http" in help_text
+
+
+def test_dns_enum_type_help_documents_output_expectations():
+    """The enum-type help must describe what each mode produces."""
+    type_field = next(f for f in _metadata()["fields"] if f["id"] == "type")
+    help_text = type_field["help"].lower()
+    # Output expectations: record types, zone transfer, subdomain discovery.
+    assert "soa" in help_text and "mx" in help_text
+    assert "zone transfer" in help_text or "axfr" in help_text
+    assert "subdomain" in help_text
+
+
+def test_dns_enum_long_description_documents_targets_and_output():
+    """long_description must cover common targets and output expectations,
+    and preserve the authorized-use framing."""
+    long_desc = _metadata()["long_description"].lower()
+    assert "example.com" in long_desc
+    assert "record" in long_desc
+    assert "critical" in long_desc and (
+        "zone transfer" in long_desc or "axfr" in long_desc
+    )
+    assert "authorized" in long_desc
+
+
+def test_dns_enum_presets_cover_every_enum_mode():
+    """Presets must give a one-click example for each declared enum type, and
+    every preset value must be a real option value."""
+    data = _metadata()
+    type_field = next(f for f in data["fields"] if f["id"] == "type")
+    option_values = {opt["value"] for opt in type_field["options"]}
+
+    presets = data["presets"]
+    preset_types = {preset.get("type") for preset in presets.values()}
+
+    assert {"standard", "zone_transfer", "subdomain_bruteforce"} <= set(presets)
+    # Each enum option is represented by at least one preset...
+    assert option_values <= preset_types
+    # ...and no preset references an undeclared option value.
+    assert preset_types <= option_values
+
+
+# ---------------------------------------------------------------------------
+# Command rendering tests via the real PluginManager
+# ---------------------------------------------------------------------------
+
+
+def test_dns_enum_command_renders_with_default_type(setup_test_environment):
+    """With only a target, the default enum type ('std') is applied."""
+    manager = PluginManager(str(PLUGINS_DIR))
+    asyncio.run(manager.load_plugins())
+
+    command = manager.build_command("dns_enum", {"target": "example.com"})
+
+    assert command == ["dnsrecon", "-d", "example.com", "-t", "std"], (
+        f"Command template drift detected. Got: {command}"
+    )
+
+
+def test_dns_enum_command_renders_explicit_zone_transfer(setup_test_environment):
+    """An explicit AXFR selection must flow through to '-t axfr'."""
+    manager = PluginManager(str(PLUGINS_DIR))
+    asyncio.run(manager.load_plugins())
+
+    command = manager.build_command(
+        "dns_enum", {"target": "example.com", "type": "axfr"}
+    )
+
+    assert command == ["dnsrecon", "-d", "example.com", "-t", "axfr"]
+
+
+def test_dns_enum_rejects_unknown_enum_type(setup_test_environment):
+    """A type outside the declared option set must be rejected, not rendered."""
+    manager = PluginManager(str(PLUGINS_DIR))
+    asyncio.run(manager.load_plugins())
+
+    with pytest.raises(ValueError):
+        manager.build_command(
+            "dns_enum", {"target": "example.com", "type": "not-a-real-mode"}
+        )
+
+
+def test_dns_enum_loaded_by_plugin_manager(setup_test_environment):
+    """PluginManager must load dns_enum (this also verifies the checksum)."""
+    manager = PluginManager(str(PLUGINS_DIR))
+    asyncio.run(manager.load_plugins())
+
+    plugin = manager.get_plugin("dns_enum")
+    assert plugin is not None
+    assert plugin.id == "dns_enum"
+    assert plugin.name == "DNS Reconnaissance"
+
+
+# ---------------------------------------------------------------------------
+# Parser checks that back the documented output expectations
+# ---------------------------------------------------------------------------
+
+
+def test_dns_enum_standard_output_groups_records_per_host():
+    """The metadata promises records 'grouped per host' — verify the parser
+    collapses repeated values into one finding per (type, host)."""
+    output = "\n".join(
+        [
+            "[*] NS adi.ns.cloudflare.com 173.245.58.56",
+            "[*] NS adi.ns.cloudflare.com 172.64.32.56",
+            "[*] MX route1.mx.cloudflare.net 162.159.205.11",
+            "[*] A example.com 93.184.216.34",
+        ]
+    )
+    result = parse(output)
+
+    assert result["count"] == 4  # raw record values
+    assert len(result["findings"]) == 3  # grouped per (type, host)
+    ns = next(f for f in result["findings"] if f["title"].startswith("DNS NS Record"))
+    assert ns["metadata"]["record_count"] == 2
+
+
+def test_dns_enum_zone_transfer_success_raises_critical_finding():
+    """The metadata promises a critical finding when AXFR succeeds — verify it."""
+    result = parse("[*] A example.com 93.184.216.34\nZone Transfer Successful")
+
+    critical = [f for f in result["findings"] if f["severity"] == "critical"]
+    assert critical, "Expected a critical finding for a successful zone transfer"
+    assert "Zone Transfer" in critical[0]["title"]


### PR DESCRIPTION
## Description
Improve the `dns_enum` (DNS Reconnaissance) plugin metadata so it documents common
domain targets and output expectations, as requested in #856.

There is no structured `examples` field in the plugin schema, and an unknown top-level
key would be silently dropped by the metadata model (and is not rendered by the UI), so
the examples are added to the operator-visible / contract fields rather than a new
schema key — keeping the change to a single plugin with no cross-cutting refactor:

- `target.help` now shows concrete domain examples (`example.com`, `scanme.nmap.org`,
  an internal domain) and clarifies it must be a bare domain (no scheme or path), and
  that subdomains are only discovered in Brute Force mode.
- `type.help` now describes what each mode produces: Standard groups A/AAAA/NS/MX/SOA
  records per host; Zone Transfer (AXFR) reports a critical finding if the server allows
  it; Brute Force discovers subdomains.
- `long_description` is rewritten to cover common targets and output expectations
  accurately for the exposed modes (the previous text referenced "reverse lookups",
  which this plugin's options don't expose) and preserves the authorized-use framing.
- A `subdomain_bruteforce` preset is added so all three enum modes have a one-click
  example.
- The plugin `checksum` is refreshed for the metadata change.

Parser logic is unchanged.

## Related Issues
Closes #856

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation / metadata clarity (no parser behavior change)

## How Has This Been Tested?
- `pytest testing/backend/test_dns_enum_plugin.py testing/backend/unit/test_dns_enum_parser.py` — 20 passed
  (18 new contract/guidance/command/parser-expectation tests + 2 existing parser tests).
- `python scripts/validate_plugin.py --plugin dns_enum` — OK.
- `python scripts/validate_plugins.py` — 59/59 valid.
- `python scripts/validate_plugins_catalog.py --catalog PLUGINS.md --plugins-dir plugins` — in sync.
- `ruff check backend testing/backend` — clean.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

---

This PR closes issue #856.

@utksh1 — please review this PR
