### PR TITLE
feat: add idempotent task retry endpoint (#799)

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -483,6 +483,69 @@ async def start_task(
         "stream_url": f"/api/v1/task/{task_id}/stream"
     }
 
+@router.post("/task/{task_id}/retry", dependencies=[Depends(task_start_limiter)])
+async def retry_task(
+    task_id: str,
+    background_tasks: BackgroundTasks,
+    raw_request: Request,
+    owner: str = Depends(get_current_owner),
+):
+    """
+    Retry a failed or cancelled scan task.
+    """
+    db = await get_db()
+    task = await require_owned_task(db, task_id, owner, columns="id, owner_id, status, plugin_id")
+
+    if task["status"] in ["queued", "running"]:
+        raise HTTPException(status_code=409, detail="Task is already queued or running")
+    elif task["status"] not in ["failed", "cancelled"]:
+        raise HTTPException(status_code=400, detail="Only failed or cancelled tasks can be retried")
+
+    # Check plugin rate limits
+    plugin_manager = await get_plugin_manager_for_request()
+    plugin = plugin_manager.get_plugin(task["plugin_id"])
+    if not plugin:
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {task['plugin_id']}")
+
+    client_id = resolve_client_identity(raw_request)
+    can_execute, error_msg = await rate_limiter.can_execute(
+        task["plugin_id"],
+        plugin.safety.get("rate_limit", {}).get("max_per_hour", settings.max_tasks_per_hour),
+        client_id=client_id,
+    )
+
+    if not can_execute:
+        raise HTTPException(status_code=429, detail=error_msg)
+
+    # Atomic update to prevent duplicate reruns if called rapidly
+    cursor = await db.execute(
+        "UPDATE tasks SET status = 'queued', error_message = NULL, exit_code = NULL, "
+        "started_at = NULL, completed_at = NULL "
+        "WHERE id = ? AND status IN ('failed', 'cancelled')",
+        (task_id,)
+    )
+    if cursor.rowcount == 0:
+        raise HTTPException(status_code=409, detail="Task is already queued or running")
+
+    # Cleanup previous findings and reports for a fresh retry
+    await db.execute("DELETE FROM findings WHERE task_id = ?", (task_id,))
+    await db.execute("DELETE FROM reports WHERE task_id = ?", (task_id,))
+
+    # Re-acquire concurrency slot
+    can_acquire, error_msg = await concurrent_limiter.acquire(task_id)
+    if not can_acquire:
+        await executor.mark_task_failed(task_id, reason="Concurrency limit reached; task was not retried")
+        raise HTTPException(status_code=503, detail=error_msg)
+
+    background_tasks.add_task(executor.execute_task, task_id)
+    await invalidate_view_cache()
+
+    return {
+        "task_id": task_id,
+        "status": "queued",
+        "message": "Task retry initiated"
+    }
+
 @router.get("/task/{task_id}/status")
 async def get_task_status(task_id: str, owner: str = Depends(get_current_owner)):
     """Get task status"""

--- a/testing/backend/integration/test_routes.py
+++ b/testing/backend/integration/test_routes.py
@@ -243,3 +243,54 @@ class TestSafeModeCIDRBypass:
                 assert "safe mode" not in detail.lower() and "Public IP" not in detail, (
                     f"Filesystem path was incorrectly rejected by network validation: {detail!r}"
                 )
+
+def test_task_retry_idempotency(test_client):
+    """Test the /task/{task_id}/retry endpoint is idempotent and rejects non-failed tasks."""
+    # Start a task and wait for it to complete/fail
+    with patch("backend.secuscan.executor.TaskExecutor._execute_command") as mock_exec:
+        mock_exec.return_value = ("Failed", 1)  # Simulate failure
+
+        payload = {
+            "plugin_id": "http_inspector",
+            "inputs": {"url": "http://127.0.0.1:8000"},
+            "consent_granted": True,
+        }
+        start_res = test_client.post("/api/v1/task/start", json=payload)
+        assert start_res.status_code == 200
+        task_id = start_res.json()["task_id"]
+
+        time.sleep(0.5)
+
+        # Verify it is failed
+        status_res = test_client.get(f"/api/v1/task/{task_id}/status")
+        assert status_res.status_code == 200
+        assert status_res.json()["status"] == TaskStatus.FAILED.value
+
+        # Attempt to retry it multiple times concurrently/rapidly
+        mock_exec.return_value = ("Mocked successful output", 0)  # Next run succeeds
+
+        # We must mock execute_task so the TestClient doesn't run it inline
+        # before the second retry request can even be fired.
+        with patch("backend.secuscan.executor.TaskExecutor.execute_task"):
+            retry_res_1 = test_client.post(f"/api/v1/task/{task_id}/retry")
+            retry_res_2 = test_client.post(f"/api/v1/task/{task_id}/retry")
+
+            assert retry_res_1.status_code == 200
+            assert retry_res_1.json()["status"] == "queued"
+
+            # Second immediate retry should hit idempotency check
+            assert retry_res_2.status_code == 409
+
+        # Now let it actually run to completion manually
+        import asyncio
+        from backend.secuscan.executor import executor
+        asyncio.run(executor.execute_task(task_id))
+
+        # Verify it completed successfully this time
+        status_res = test_client.get(f"/api/v1/task/{task_id}/status")
+        assert status_res.status_code == 200
+        assert status_res.json()["status"] == TaskStatus.COMPLETED.value
+
+        # Attempting to retry a completed task should fail
+        retry_res_3 = test_client.post(f"/api/v1/task/{task_id}/retry")
+        assert retry_res_3.status_code == 400

--- a/testing/backend/integration/test_routes.py
+++ b/testing/backend/integration/test_routes.py
@@ -294,3 +294,59 @@ def test_task_retry_idempotency(test_client):
         # Attempting to retry a completed task should fail
         retry_res_3 = test_client.post(f"/api/v1/task/{task_id}/retry")
         assert retry_res_3.status_code == 400
+
+def test_task_retry_authorization(test_client):
+    """Test the /task/{task_id}/retry endpoint properly scopes to owner."""
+    import sqlite3
+    from backend.secuscan.config import settings
+
+    payload = {
+        "plugin_id": "http_inspector",
+        "inputs": {"url": "http://127.0.0.1:8000"},
+        "consent_granted": True,
+    }
+    start_res = test_client.post("/api/v1/task/start", json=payload)
+    assert start_res.status_code == 200
+    task_id = start_res.json()["task_id"]
+
+    # Temporarily change owner in the database to simulate another user's task
+    with sqlite3.connect(settings.database_path) as conn:
+        conn.execute("UPDATE tasks SET owner_id = 'other_owner', status = 'failed' WHERE id = ?", (task_id,))
+        conn.commit()
+
+    # Attempt to retry it with our default test_client (which is not 'other_owner')
+    retry_res = test_client.post(f"/api/v1/task/{task_id}/retry")
+    assert retry_res.status_code == 403
+    assert "access" in retry_res.json()["detail"].lower()
+
+def test_task_retry_terminal_states(test_client):
+    """Test retry behavior explicitly on all terminal vs non-terminal statuses."""
+    import sqlite3
+    from backend.secuscan.config import settings
+
+    payload = {
+        "plugin_id": "http_inspector",
+        "inputs": {"url": "http://127.0.0.1:8000"},
+        "consent_granted": True,
+    }
+    start_res = test_client.post("/api/v1/task/start", json=payload)
+    assert start_res.status_code == 200
+    task_id = start_res.json()["task_id"]
+
+    # Test mapping of status to expected HTTP response codes when hitting /retry
+    status_expectations = [
+        ("completed", 400),
+        ("failed", 200),
+        ("cancelled", 200),
+        ("queued", 409),
+        ("running", 409),
+    ]
+
+    for status, expected_code in status_expectations:
+        with sqlite3.connect(settings.database_path) as conn:
+            conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, task_id))
+            conn.commit()
+
+        with patch("backend.secuscan.executor.TaskExecutor.execute_task"):
+            res = test_client.post(f"/api/v1/task/{task_id}/retry")
+            assert res.status_code == expected_code, f"Expected {expected_code} for status '{status}', got {res.status_code}"


### PR DESCRIPTION
## Description
This PR implements a `/api/v1/task/{task_id}/retry` endpoint to safely retry failed or cancelled scan tasks. 

Key additions:
- Enforces strict BOLA protection by re-using `require_owned_task`.
- Secures idempotency natively via an atomic SQL `UPDATE` leveraging `cursor.rowcount`. Rapidly queued concurrent retry requests will cleanly hit a `409 Conflict`.
- Integrates cleanup logic to clear previous findings/reports bound to the retried `task_id` before inserting the task back into the `background_tasks` queue.
- Re-uses `task_start_limiter` and `rate_limiter.can_execute` to strictly obey per-endpoint and plugin-specific rate limits.

## Related Issues
Resolves #799

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Integration tests were added and validated locally.

- **Test Path:** `testing/backend/integration/test_routes.py::test_task_retry_idempotency`
- **Scenarios Validated:**
  - Standard retry succeeds when status is `failed` or `cancelled`.
  - Concurrent lock mechanism strictly returns `409 Conflict` if the task state is actively `queued` or `running`.
  - Rejects attempts to retry a task that is `completed` with a `400 Bad Request`.
  - Proves background execution flow correctly transitions the retried task back to `completed`.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
