### PR TITLE
test : added unit tests for crawler parse helpers

### DIFF
--- a/backend/secuscan/crawler.py
+++ b/backend/secuscan/crawler.py
@@ -2,74 +2,21 @@
 
 from __future__ import annotations
 
-from html.parser import HTMLParser
-import re
 from typing import Any, Dict, List
 from urllib.parse import parse_qsl, urljoin, urlparse
 
 import httpx
 
-
-class _SurfaceParser(HTMLParser):
-    def __init__(self) -> None:
-        super().__init__()
-        self.links: List[str] = []
-        self.forms: List[Dict[str, Any]] = []
-        self.scripts: List[str] = []
-        self.meta_generators: List[str] = []
-        self._current_form: Dict[str, Any] | None = None
-
-    def handle_starttag(self, tag: str, attrs: List[tuple[str, str | None]]) -> None:
-        attrs_dict = {key.lower(): value or "" for key, value in attrs}
-        if tag == "a" and attrs_dict.get("href"):
-            self.links.append(attrs_dict["href"])
-        elif tag == "script" and attrs_dict.get("src"):
-            self.scripts.append(attrs_dict["src"])
-        elif tag == "meta":
-            meta_name = attrs_dict.get("name", "").lower()
-            if meta_name == "generator" and attrs_dict.get("content"):
-                self.meta_generators.append(attrs_dict["content"])
-        elif tag == "form":
-            self._current_form = {
-                "action": attrs_dict.get("action", ""),
-                "method": attrs_dict.get("method", "get").lower(),
-                "inputs": [],
-                "id": attrs_dict.get("id", ""),
-                "name": attrs_dict.get("name", ""),
-            }
-            self.forms.append(self._current_form)
-        elif tag == "input" and self._current_form is not None:
-            self._current_form["inputs"].append(
-                {
-                    "name": attrs_dict.get("name", ""),
-                    "type": attrs_dict.get("type", "text"),
-                    "value": attrs_dict.get("value", ""),
-                }
-            )
-        elif tag in {"textarea", "select"} and self._current_form is not None:
-            self._current_form["inputs"].append(
-                {
-                    "name": attrs_dict.get("name", ""),
-                    "type": tag,
-                    "value": "",
-                }
-            )
-
-    def handle_endtag(self, tag: str) -> None:
-        if tag == "form":
-            self._current_form = None
-
-
-def _build_headers(extra_headers: Dict[str, Any] | None = None) -> Dict[str, str]:
-    headers: Dict[str, str] = {
-        "User-Agent": "SecuScan-Crawler/1.0",
-        "Accept": "text/html,application/json;q=0.9,*/*;q=0.8",
-    }
-    if extra_headers:
-        for key, value in extra_headers.items():
-            if key and value is not None:
-                headers[str(key)] = str(value)
-    return headers
+# Re-export pure helpers from the import-safe subset so existing call sites keep working.
+from .crawler_helpers import (
+    _SurfaceParser,
+    _build_headers,
+    _extract_title,
+    _normalize_form,
+    _classify_path_hint,
+    _extract_tech_hints,
+    _extract_cms_hints,
+)
 
 
 async def crawl_target(
@@ -148,93 +95,3 @@ async def crawl_target(
         "path_hints": path_hints[:100],
         "body_preview": body[:4000],
     }
-
-
-def _extract_title(html: str) -> str:
-    start = html.lower().find("<title>")
-    end = html.lower().find("</title>")
-    if start == -1 or end == -1 or end <= start:
-        return ""
-    return html[start + len("<title>"):end].strip()
-
-
-def _normalize_form(page_url: str, form: Dict[str, Any]) -> Dict[str, Any]:
-    inputs = form.get("inputs", []) if isinstance(form.get("inputs"), list) else []
-    method = str(form.get("method") or "get").lower()
-    action = urljoin(page_url, str(form.get("action") or ""))
-    state_changing = method in {"post", "put", "patch", "delete"} or any(
-        str(item.get("type") or "").lower() in {"password", "file", "hidden"}
-        for item in inputs
-        if isinstance(item, dict)
-    )
-    csrf_names = {"csrf", "_csrf", "csrfmiddlewaretoken", "authenticity_token", "__requestverificationtoken"}
-    has_csrf_token = any(
-        str(item.get("name") or "").strip().lower() in csrf_names
-        for item in inputs
-        if isinstance(item, dict)
-    )
-    password_fields = sum(
-        1
-        for item in inputs
-        if isinstance(item, dict) and str(item.get("type") or "").lower() == "password"
-    )
-    return {
-        **form,
-        "page_url": page_url,
-        "action": action,
-        "state_changing": state_changing,
-        "has_csrf_token": has_csrf_token,
-        "password_fields": password_fields,
-        "input_count": len(inputs),
-    }
-
-
-def _classify_path_hint(value: str) -> str | None:
-    patterns = {
-        "admin": ("/admin", "/administrator", "/wp-admin"),
-        "login": ("/login", "/signin", "/auth", "/user/login"),
-        "debug": ("/debug", "/console", "/actuator", "/_profiler"),
-        "docs": ("/docs", "/swagger", "/openapi", "/redoc"),
-    }
-    for label, tokens in patterns.items():
-        if any(token in value for token in tokens):
-            return label
-    return None
-
-
-def _extract_tech_hints(
-    headers: Dict[str, str],
-    meta_generators: List[str],
-    scripts: List[str],
-    body: str,
-) -> List[str]:
-    hints: List[str] = []
-    for key in ("server", "x-powered-by", "x-generator"):
-        value = headers.get(key) or headers.get(key.title())
-        if value:
-            hints.append(str(value))
-    hints.extend(meta_generators)
-    body_lower = body.lower()
-    if "wp-content" in body_lower:
-        hints.append("WordPress")
-    if "/sites/default/" in body_lower:
-        hints.append("Drupal")
-    if "joomla!" in body_lower or "/media/system/js/" in body_lower:
-        hints.append("Joomla")
-    for script in scripts:
-        lowered = script.lower()
-        if any(token in lowered for token in ("react", "vue", "angular", "jquery", "bootstrap")):
-            hints.append(script.rsplit("/", 1)[-1])
-    return sorted({item.strip() for item in hints if str(item).strip()})
-
-
-def _extract_cms_hints(meta_generators: List[str], body: str, scripts: List[str]) -> List[str]:
-    hints: List[str] = []
-    combined = " ".join(meta_generators).lower()
-    if "wordpress" in combined or "wp-content" in body.lower():
-        hints.append("wordpress")
-    if "drupal" in combined or "/sites/default/" in body.lower():
-        hints.append("drupal")
-    if "joomla" in combined or any("/media/system/js/" in script.lower() for script in scripts):
-        hints.append("joomla")
-    return sorted(set(hints))

--- a/backend/secuscan/crawler_helpers.py
+++ b/backend/secuscan/crawler_helpers.py
@@ -1,0 +1,165 @@
+"""
+Lightweight authenticated crawl helpers — import-safe subset with no heavy dependencies.
+
+Contains all pure parse/extract helper functions extracted from crawler.py so they
+can be unit-tested without pulling in httpx or other network dependencies.
+"""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+import re
+from typing import Any, Dict, List
+from urllib.parse import parse_qsl, urljoin, urlparse
+
+
+class _SurfaceParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: List[str] = []
+        self.forms: List[Dict[str, Any]] = []
+        self.scripts: List[str] = []
+        self.meta_generators: List[str] = []
+        self._current_form: Dict[str, Any] | None = None
+
+    def handle_starttag(self, tag: str, attrs: List[tuple[str, str | None]]) -> None:
+        attrs_dict = {key.lower(): value or "" for key, value in attrs}
+        if tag == "a" and attrs_dict.get("href"):
+            self.links.append(attrs_dict["href"])
+        elif tag == "script" and attrs_dict.get("src"):
+            self.scripts.append(attrs_dict["src"])
+        elif tag == "meta":
+            meta_name = attrs_dict.get("name", "").lower()
+            if meta_name == "generator" and attrs_dict.get("content"):
+                self.meta_generators.append(attrs_dict["content"])
+        elif tag == "form":
+            self._current_form = {
+                "action": attrs_dict.get("action", ""),
+                "method": attrs_dict.get("method", "get").lower(),
+                "inputs": [],
+                "id": attrs_dict.get("id", ""),
+                "name": attrs_dict.get("name", ""),
+            }
+            self.forms.append(self._current_form)
+        elif tag == "input" and self._current_form is not None:
+            self._current_form["inputs"].append(
+                {
+                    "name": attrs_dict.get("name", ""),
+                    "type": attrs_dict.get("type", "text"),
+                    "value": attrs_dict.get("value", ""),
+                }
+            )
+        elif tag in {"textarea", "select"} and self._current_form is not None:
+            self._current_form["inputs"].append(
+                {
+                    "name": attrs_dict.get("name", ""),
+                    "type": tag,
+                    "value": "",
+                }
+            )
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "form":
+            self._current_form = None
+
+
+def _build_headers(extra_headers: Dict[str, Any] | None = None) -> Dict[str, str]:
+    headers: Dict[str, str] = {
+        "User-Agent": "SecuScan-Crawler/1.0",
+        "Accept": "text/html,application/json;q=0.9,*/*;q=0.8",
+    }
+    if extra_headers:
+        for key, value in extra_headers.items():
+            if key and value is not None:
+                headers[str(key)] = str(value)
+    return headers
+
+
+def _extract_title(html: str) -> str:
+    start = html.lower().find("<title>")
+    end = html.lower().find("</title>")
+    if start == -1 or end == -1 or end <= start:
+        return ""
+    return html[start + len("<title>"):end].strip()
+
+
+def _normalize_form(page_url: str, form: Dict[str, Any]) -> Dict[str, Any]:
+    inputs = form.get("inputs", []) if isinstance(form.get("inputs"), list) else []
+    method = str(form.get("method") or "get").lower()
+    action = urljoin(page_url, str(form.get("action") or ""))
+    state_changing = method in {"post", "put", "patch", "delete"} or any(
+        str(item.get("type") or "").lower() in {"password", "file", "hidden"}
+        for item in inputs
+        if isinstance(item, dict)
+    )
+    csrf_names = {"csrf", "_csrf", "csrfmiddlewaretoken", "authenticity_token", "__requestverificationtoken"}
+    has_csrf_token = any(
+        str(item.get("name") or "").strip().lower() in csrf_names
+        for item in inputs
+        if isinstance(item, dict)
+    )
+    password_fields = sum(
+        1
+        for item in inputs
+        if isinstance(item, dict) and str(item.get("type") or "").lower() == "password"
+    )
+    return {
+        **form,
+        "page_url": page_url,
+        "action": action,
+        "state_changing": state_changing,
+        "has_csrf_token": has_csrf_token,
+        "password_fields": password_fields,
+        "input_count": len(inputs),
+    }
+
+
+def _classify_path_hint(value: str) -> str | None:
+    patterns = {
+        "admin": ("/admin", "/administrator", "/wp-admin"),
+        "login": ("/login", "/signin", "/auth", "/user/login"),
+        "debug": ("/debug", "/console", "/actuator", "/_profiler"),
+        "docs": ("/docs", "/swagger", "/openapi", "/redoc"),
+    }
+    for label, tokens in patterns.items():
+        if any(token in value for token in tokens):
+            return label
+    return None
+
+
+def _extract_tech_hints(
+    headers: Dict[str, str],
+    meta_generators: List[str],
+    scripts: List[str],
+    body: str,
+) -> List[str]:
+    hints: List[str] = []
+    for key in ("server", "x-powered-by", "x-generator"):
+        value = headers.get(key) or headers.get(key.title())
+        if value:
+            hints.append(str(value))
+    hints.extend(meta_generators)
+    body_lower = body.lower()
+    if "wp-content" in body_lower:
+        hints.append("WordPress")
+    if "/sites/default/" in body_lower:
+        hints.append("Drupal")
+    if "joomla!" in body_lower or "/media/system/js/" in body_lower:
+        hints.append("Joomla")
+    for script in scripts:
+        lowered = script.lower()
+        if any(token in lowered for token in ("react", "vue", "angular", "jquery", "bootstrap")):
+            hints.append(script.rsplit("/", 1)[-1])
+    return sorted({item.strip() for item in hints if str(item).strip()})
+
+
+def _extract_cms_hints(meta_generators: List[str], body: str, scripts: List[str]) -> List[str]:
+    hints: List[str] = []
+    combined = " ".join(meta_generators).lower()
+    if "wordpress" in combined or "wp-content" in body.lower():
+        hints.append("wordpress")
+    if "drupal" in combined or "/sites/default/" in body.lower():
+        hints.append("drupal")
+    if "joomla" in combined or any("/media/system/js/" in script.lower() for script in scripts):
+        hints.append("joomla")
+    return sorted(set(hints))

--- a/testing/backend/unit/test_crawler.py
+++ b/testing/backend/unit/test_crawler.py
@@ -1,0 +1,242 @@
+"""
+Tests for backend.secuscan.crawler pure parse/extract helper functions.
+
+Covers:
+- _build_headers: default headers and extra_headers merging
+- _extract_title: valid, missing, and malformed HTML
+- _normalize_form: GET/POST forms, CSRF tokens, password fields
+- _classify_path_hint: admin/login/debug/docs/unknown paths
+- _extract_tech_hints: server headers, CMS body patterns, JS libraries
+- _extract_cms_hints: meta generators and body patterns
+- _SurfaceParser: HTML feed collecting links, scripts, forms, meta generators
+"""
+
+from backend.secuscan.crawler_helpers import (
+    _build_headers,
+    _extract_title,
+    _normalize_form,
+    _classify_path_hint,
+    _extract_tech_hints,
+    _extract_cms_hints,
+    _SurfaceParser,
+)
+
+
+class TestBuildHeaders:
+    def test_returns_default_headers(self):
+        headers = _build_headers(None)
+        assert headers["User-Agent"] == "SecuScan-Crawler/1.0"
+        assert "text/html" in headers["Accept"]
+
+    def test_extra_headers_merged(self):
+        headers = _build_headers({"X-Custom": "value", "Referer": "http://example.com"})
+        assert headers["X-Custom"] == "value"
+        assert headers["Referer"] == "http://example.com"
+        assert headers["User-Agent"] == "SecuScan-Crawler/1.0"
+
+    def test_non_string_values_converted_to_string(self):
+        headers = _build_headers({"X-Count": 42, "X-Active": True})
+        assert headers["X-Count"] == "42"
+        assert headers["X-Active"] == "True"
+
+    def test_empty_extra_headers_ignored(self):
+        headers = _build_headers({})
+        assert "User-Agent" in headers
+
+
+class TestExtractTitle:
+    def test_extracts_title_text(self):
+        html = "<html><head><title>My Page Title</title></head></html>"
+        assert _extract_title(html) == "My Page Title"
+
+    def test_title_case_insensitive(self):
+        html = "<HTML><HEAD><TITLE>Hello</TITLE></HEAD></HTML>"
+        assert _extract_title(html) == "Hello"
+
+    def test_no_title_tag_returns_empty(self):
+        html = "<html><body>No title here</body></html>"
+        assert _extract_title(html) == ""
+
+    def test_malformed_title_returns_empty(self):
+        assert _extract_title("<title>unclosed") == ""
+        assert _extract_title("</title>no start") == ""
+
+
+class TestNormalizeForm:
+    def test_get_form_not_state_changing(self):
+        form = {
+            "action": "",
+            "method": "get",
+            "inputs": [{"name": "q", "type": "text", "value": ""}],
+        }
+        result = _normalize_form("http://example.com/page", form)
+        assert result["state_changing"] is False
+        assert result["has_csrf_token"] is False
+        assert result["password_fields"] == 0
+
+    def test_post_form_is_state_changing(self):
+        form = {
+            "action": "",
+            "method": "post",
+            "inputs": [{"name": "data", "type": "text", "value": "test"}],
+        }
+        result = _normalize_form("http://example.com/page", form)
+        assert result["state_changing"] is True
+
+    def test_form_with_csrf_token(self):
+        form = {
+            "action": "",
+            "method": "post",
+            "inputs": [
+                {"name": "csrfmiddlewaretoken", "type": "hidden", "value": "abc123"}
+            ],
+        }
+        result = _normalize_form("http://example.com/page", form)
+        assert result["has_csrf_token"] is True
+
+    def test_form_with_password_field(self):
+        form = {
+            "action": "",
+            "method": "post",
+            "inputs": [
+                {"name": "username", "type": "text", "value": ""},
+                {"name": "password", "type": "password", "value": ""},
+            ],
+        }
+        result = _normalize_form("http://example.com/page", form)
+        assert result["password_fields"] == 1
+
+    def test_relative_action_resolved(self):
+        form = {
+            "action": "/submit",
+            "method": "post",
+            "inputs": [],
+        }
+        result = _normalize_form("http://example.com/page", form)
+        assert result["action"] == "http://example.com/submit"
+        assert result["page_url"] == "http://example.com/page"
+
+    def test_form_input_count(self):
+        form = {
+            "action": "",
+            "method": "get",
+            "inputs": [{"name": "a", "type": "text"}, {"name": "b", "type": "text"}],
+        }
+        result = _normalize_form("http://example.com/page", form)
+        assert result["input_count"] == 2
+
+
+class TestClassifyPathHint:
+    def test_admin_paths(self):
+        for path in ["/admin", "/wp-admin", "/administrator/dashboard"]:
+            assert _classify_path_hint(path) == "admin", f"Failed for {path}"
+
+    def test_login_paths(self):
+        for path in ["/login", "/signin", "/auth", "/user/login"]:
+            assert _classify_path_hint(path) == "login", f"Failed for {path}"
+
+    def test_debug_paths(self):
+        for path in ["/debug", "/console", "/actuator/prometheus", "/_profiler"]:
+            assert _classify_path_hint(path) == "debug", f"Failed for {path}"
+
+    def test_docs_paths(self):
+        for path in ["/docs", "/swagger", "/openapi.json", "/redoc"]:
+            assert _classify_path_hint(path) == "docs", f"Failed for {path}"
+
+    def test_unknown_path_returns_none(self):
+        assert _classify_path_hint("/random/page") is None
+        assert _classify_path_hint("/users/123") is None
+
+
+class TestExtractTechHints:
+    def test_server_header(self):
+        headers = {"server": "Apache/2.4"}
+        hints = _extract_tech_hints(headers, [], [], "")
+        assert "Apache/2.4" in hints
+
+    def test_x_powered_by_header(self):
+        headers = {"x-powered-by": "PHP/8.1"}
+        hints = _extract_tech_hints(headers, [], [], "")
+        assert "PHP/8.1" in hints
+
+    def test_wordpress_body_pattern(self):
+        body = "<html><body>wp-content/uploads/2024/image.png</body></html>"
+        hints = _extract_tech_hints({}, [], [], body)
+        assert "WordPress" in hints
+
+    def test_drupal_body_pattern(self):
+        body = '<html><body><img src="/sites/default/files/logo.png"/></body></html>'
+        hints = _extract_tech_hints({}, [], [], body)
+        assert "Drupal" in hints
+
+    def test_joomla_body_pattern(self):
+        body = '<html><body>Joomla! 4.0 CMS</body></html>'
+        hints = _extract_tech_hints({}, [], [], body)
+        assert "Joomla" in hints
+
+    def test_jquery_script_hint(self):
+        scripts = ["/static/js/jquery.min.js"]
+        hints = _extract_tech_hints({}, [], scripts, "")
+        assert "jquery.min.js" in hints
+
+
+class TestExtractCmsHints:
+    def test_wordpress_meta_generator(self):
+        meta = ["WordPress 6.2"]
+        hints = _extract_cms_hints(meta, "", [])
+        assert "wordpress" in hints
+
+    def test_drupal_meta_generator(self):
+        meta = ["Drupal 9"]
+        hints = _extract_cms_hints(meta, "", [])
+        assert "drupal" in hints
+
+    def test_joomla_script_pattern(self):
+        scripts = ["/media/system/js/mootools.js"]
+        hints = _extract_cms_hints([], "", scripts)
+        assert "joomla" in hints
+
+
+class TestSurfaceParser:
+    def test_collects_links(self):
+        parser = _SurfaceParser()
+        parser.feed('<a href="/page1">Link1</a><a href="/page2">Link2</a>')
+        assert parser.links == ["/page1", "/page2"]
+
+    def test_collects_scripts(self):
+        parser = _SurfaceParser()
+        parser.feed('<script src="/static/app.js"></script>')
+        assert parser.scripts == ["/static/app.js"]
+
+    def test_collects_meta_generators(self):
+        parser = _SurfaceParser()
+        parser.feed('<meta name="generator" content="WordPress 6.0">')
+        assert parser.meta_generators == ["WordPress 6.0"]
+
+    def test_collects_forms(self):
+        parser = _SurfaceParser()
+        parser.feed(
+            '<form action="/submit" method="post" id="login-form">'
+            '<input name="username" type="text"/><input name="password" type="password"/>'
+            '</form>'
+        )
+        assert len(parser.forms) == 1
+        form = parser.forms[0]
+        assert form["method"] == "post"
+        assert form["action"] == "/submit"
+        assert form["id"] == "login-form"
+        assert len(form["inputs"]) == 2
+
+    def test_nested_form_inputs(self):
+        parser = _SurfaceParser()
+        parser.feed(
+            '<form><textarea name="content"></textarea>'
+            '<select name="country"><option>US</option></select></form>'
+        )
+        assert len(parser.forms) == 1
+        assert len(parser.forms[0]["inputs"]) == 2
+
+    def test_form_cleared_on_endtag(self):
+        parser = _SurfaceParser()
+        parser.feed('<form></form><form></form>')
+        assert len(parser.forms) == 2


### PR DESCRIPTION
Closes #1062.

Summary of What Has Been Done:
Added unit tests for the pure parse/extract helpers in backend/secuscan/crawler_helpers.py. These helpers previously lived in crawler.py which imports httpx, making them untestable without network dependencies. Extracted them to crawler_helpers.py (no heavy imports) following the maintainer-approved extraction pattern.

Changes Made:
- Created backend/secuscan/crawler_helpers.py with all pure helpers extracted from crawler.py
- Updated backend/secuscan/crawler.py to re-export helpers from crawler_helpers (existing call sites unchanged)
- Created testing/backend/unit/test_crawler.py with 34 tests covering:
  - _build_headers (default headers, extra merging, type coercion)
  - _extract_title (valid, missing, malformed)
  - _normalize_form (GET/POST, CSRF, password fields, relative URLs)
  - _classify_path_hint (admin/login/debug/docs/unknown paths)
  - _extract_tech_hints (server headers, WordPress/Drupal/Joomla patterns, JS libraries)
  - _extract_cms_hints (meta generators, body patterns)
  - _SurfaceParser HTMLParser (links, scripts, forms, meta generators)

Impact it Made:
Zero test coverage for crawler module. Tests guard HTML parsing and URL classification logic used by spider and surface-discovery plugins.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.