### PR TITLE
test : added unit tests for platform_resources helpers

### DIFF
--- a/backend/secuscan/platform_resources.py
+++ b/backend/secuscan/platform_resources.py
@@ -2,32 +2,20 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import uuid
-from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional
 
 from .database import Database
-from .execution_context import normalize_execution_context
-from .models import ExecutionContext
 
-
-def _now_iso() -> str:
-    return datetime.utcnow().isoformat()
-
-
-def _stable_asset_id(target: str, host: Any, port: Any, protocol: Any) -> str:
-    material = "||".join(
-        [
-            str(target or "").strip().lower(),
-            str(host or "").strip().lower(),
-            str(port or "").strip().lower(),
-            str(protocol or "").strip().lower(),
-        ]
-    )
-    digest = hashlib.sha1(material.encode("utf-8")).hexdigest()[:16]
-    return f"asset:{digest}"
+# Re-export pure helpers so existing call sites keep working.
+from .platform_resources_helpers import (
+    _now_iso,
+    _stable_asset_id,
+    serialize_execution_context,
+    _deserialize_resource_row,
+    deserialize_resource_rows,
+)
 
 
 async def get_target_policy(db: Database, owner_id: str, policy_id: str | None) -> Optional[Dict[str, Any]]:
@@ -169,29 +157,3 @@ async def replace_asset_services(
                 json.dumps(metadata),
             ),
         )
-
-
-def serialize_execution_context(context: ExecutionContext | Dict[str, Any] | None) -> str:
-    return json.dumps(normalize_execution_context(context or {}))
-
-
-def _deserialize_resource_row(row: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-    if row is None:
-        return None
-    item = dict(row)
-    for key in list(item.keys()):
-        if key.endswith("_json") and isinstance(item[key], str):
-            try:
-                item[key[:-5]] = json.loads(item[key])
-            except json.JSONDecodeError:
-                item[key[:-5]] = item[key]
-    return item
-
-
-def deserialize_resource_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    results: List[Dict[str, Any]] = []
-    for row in rows:
-        parsed = _deserialize_resource_row(row)
-        if parsed is not None:
-            results.append(parsed)
-    return results

--- a/backend/secuscan/platform_resources_helpers.py
+++ b/backend/secuscan/platform_resources_helpers.py
@@ -1,0 +1,59 @@
+"""
+Pure helper functions for platform resources — import-safe subset with no database dependencies.
+
+Extracted from platform_resources.py so they can be unit-tested without pulling in
+aiosqlite and the rest of the database layer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from .execution_context import normalize_execution_context
+from .models import ExecutionContext
+
+
+def _now_iso() -> str:
+    return datetime.utcnow().isoformat()
+
+
+def _stable_asset_id(target: str, host: Any, port: Any, protocol: Any) -> str:
+    material = "||".join(
+        [
+            str(target or "").strip().lower(),
+            str(host or "").strip().lower(),
+            str(port or "").strip().lower(),
+            str(protocol or "").strip().lower(),
+        ]
+    )
+    digest = hashlib.sha1(material.encode("utf-8")).hexdigest()[:16]
+    return f"asset:{digest}"
+
+
+def serialize_execution_context(context: ExecutionContext | Dict[str, Any] | None) -> str:
+    return json.dumps(normalize_execution_context(context or {}))
+
+
+def _deserialize_resource_row(row: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if row is None:
+        return None
+    item = dict(row)
+    for key in list(item.keys()):
+        if key.endswith("_json") and isinstance(item[key], str):
+            try:
+                item[key[:-5]] = json.loads(item[key])
+            except json.JSONDecodeError:
+                item[key[:-5]] = item[key]
+    return item
+
+
+def deserialize_resource_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    results: List[Dict[str, Any]] = []
+    for row in rows:
+        parsed = _deserialize_resource_row(row)
+        if parsed is not None:
+            results.append(parsed)
+    return results

--- a/testing/backend/unit/test_platform_resources.py
+++ b/testing/backend/unit/test_platform_resources.py
@@ -1,0 +1,135 @@
+"""
+Tests for backend.secuscan.platform_resources pure helper functions.
+
+Covers:
+- _stable_asset_id: deterministic SHA-based asset ID generation
+- serialize_execution_context: ExecutionContext -> JSON string
+- _deserialize_resource_row: _json suffix columns deserialized; None passthrough
+- deserialize_resource_rows: list of rows, skips None
+"""
+
+from backend.secuscan.platform_resources_helpers import (
+    _stable_asset_id,
+    serialize_execution_context,
+    _deserialize_resource_row,
+    deserialize_resource_rows,
+)
+from backend.secuscan.models import ExecutionContext, ValidationMode, EvidenceLevel
+
+
+class TestStableAssetId:
+    def test_deterministic_same_inputs(self):
+        a = _stable_asset_id("http://example.com", "93.184.216.34", 443, "https")
+        b = _stable_asset_id("http://example.com", "93.184.216.34", 443, "https")
+        assert a == b
+
+    def test_different_inputs_different_ids(self):
+        a = _stable_asset_id("http://example.com", "93.184.216.34", 443, "https")
+        b = _stable_asset_id("http://example.org", "93.184.216.34", 443, "https")
+        assert a != b
+
+    def test_port_difference_produces_different_id(self):
+        a = _stable_asset_id("example.com", "1.2.3.4", 80, "http")
+        b = _stable_asset_id("example.com", "1.2.3.4", 443, "http")
+        assert a != b
+
+    def test_empty_and_none_values_handled_gracefully(self):
+        # Should not raise, should produce a valid string
+        result = _stable_asset_id("", None, None, None)
+        assert isinstance(result, str)
+        assert result.startswith("asset:")
+
+    def test_result_format_is_asset_prefix(self):
+        result = _stable_asset_id("example.com", "1.2.3.4", 80, "http")
+        assert result.startswith("asset:")
+        # SHA-1 truncated to 16 hex chars = 16 chars after "asset:"
+        assert len(result) == len("asset:") + 16
+
+
+class TestSerializeExecutionContext:
+    def test_with_execution_context_instance(self):
+        ctx = ExecutionContext(
+            validation_mode=ValidationMode.PROOF,
+            evidence_level=EvidenceLevel.FULL,
+        )
+        result = serialize_execution_context(ctx)
+        assert isinstance(result, str)
+        import json
+        parsed = json.loads(result)
+        assert parsed["validation_mode"] == "proof"
+
+    def test_with_plain_dict(self):
+        raw = {"validation_mode": "detect_only", "evidence_level": "standard"}
+        result = serialize_execution_context(raw)
+        assert isinstance(result, str)
+        import json
+        parsed = json.loads(result)
+        assert parsed["validation_mode"] == "detect_only"
+
+    def test_with_none_returns_default_dump(self):
+        result = serialize_execution_context(None)
+        assert isinstance(result, str)
+        import json
+        parsed = json.loads(result)
+        assert "validation_mode" in parsed
+
+
+class TestDeserializeResourceRow:
+    def test_none_input_returns_none(self):
+        assert _deserialize_resource_row(None) is None
+
+    def test_json_columns_deserialized(self):
+        row = {
+            "id": "abc123",
+            "metadata_json": '{"key": "value"}',
+            "risk_factors_json": '["low", "high"]',
+        }
+        result = _deserialize_resource_row(row)
+        assert result["metadata"] == {"key": "value"}
+        assert result["risk_factors"] == ["low", "high"]
+
+    def test_invalid_json_falls_back_to_raw_string(self):
+        row = {
+            "id": "abc123",
+            "metadata_json": "not valid json {",
+        }
+        result = _deserialize_resource_row(row)
+        # Falls back to raw string value
+        assert result["metadata"] == "not valid json {"
+
+    def test_non_json_columns_preserved(self):
+        row = {
+            "id": "abc123",
+            "name": "Test Asset",
+            "metadata_json": '{"key": "value"}',
+        }
+        result = _deserialize_resource_row(row)
+        assert result["id"] == "abc123"
+        assert result["name"] == "Test Asset"
+
+
+class TestDeserializeResourceRows:
+    def test_applies_to_each_row(self):
+        rows = [
+            {"id": "1", "metadata_json": '{"a": 1}'},
+            {"id": "2", "metadata_json": '{"b": 2}'},
+        ]
+        results = deserialize_resource_rows(rows)
+        assert len(results) == 2
+        assert results[0]["metadata"] == {"a": 1}
+        assert results[1]["metadata"] == {"b": 2}
+
+    def test_skips_none_rows(self):
+        rows = [
+            {"id": "1", "metadata_json": '{"a": 1}'},
+            None,
+            {"id": "2", "metadata_json": '{"b": 2}'},
+        ]
+        results = deserialize_resource_rows(rows)
+        assert len(results) == 2
+        assert results[0]["id"] == "1"
+        assert results[1]["id"] == "2"
+
+    def test_empty_list(self):
+        results = deserialize_resource_rows([])
+        assert results == []


### PR DESCRIPTION
Closes #1063.

Summary of What Has Been Done:
Added unit tests for the pure helper functions in backend/secuscan/platform_resources_helpers.py. These helpers were extracted to a new import-safe module because platform_resources.py imports from database.py which pulls in aiosqlite, making direct testing impossible without that dependency.

Changes Made:
- Created backend/secuscan/platform_resources_helpers.py with pure helpers: _now_iso, _stable_asset_id, serialize_execution_context, _deserialize_resource_row, deserialize_resource_rows
- Updated backend/secuscan/platform_resources.py to re-export from platform_resources_helpers (existing call sites unchanged)
- Created testing/backend/unit/test_platform_resources.py with 15 tests:
  - _stable_asset_id: deterministic same inputs, different inputs, empty/None values, asset: prefix format
  - serialize_execution_context: ExecutionContext instance, plain dict, None
  - _deserialize_resource_row: None input, _json columns deserialized, invalid JSON fallback, non-JSON columns preserved
  - deserialize_resource_rows: applies to each row, skips None rows, empty list

Impact it Made:
Zero test coverage for platform_resources module. Tests guard asset ID generation and SQLite JSON deserialization logic used throughout crawl run and asset persistence paths.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.