### PR TITLE
test : added unit tests for routes JSON deserialization helpers

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -14,57 +14,14 @@ import asyncio
 from pathlib import Path
 from urllib.parse import urlencode, urlparse
 
-def parse_json_fields(rows: List[Dict], fields: List[str]) -> List[Dict]:
-    """Helper to parse stringified JSON fields from SQLite."""
-    parsed = []
-    for row in rows:
-        item = dict(row)
-        for field in fields:
-            if item.get(field) and isinstance(item[field], str):
-                try:
-                    item[field] = json.loads(item[field])
-                except json.JSONDecodeError:
-                    pass
-        parsed.append(item)
-    return parsed
 
-
-FINDING_JSON_FIELDS = [
-    "metadata_json",
-    "risk_factors_json",
-    "evidence_json",
-    "asset_refs_json",
-    "references_json",
-    "corroborating_sources_json",
-]
-
-
-def deserialize_finding_rows(rows: List[Dict]) -> List[Dict[str, Any]]:
-    findings = parse_json_fields(rows, FINDING_JSON_FIELDS)
-    for finding in findings:
-        if "metadata_json" in finding:
-            finding["metadata"] = finding.pop("metadata_json")
-        if "risk_factors_json" in finding:
-            finding["risk_factors"] = finding.pop("risk_factors_json")
-        if "evidence_json" in finding:
-            finding["evidence"] = finding.pop("evidence_json")
-        if "asset_refs_json" in finding:
-            finding["asset_refs"] = finding.pop("asset_refs_json")
-        if "references_json" in finding:
-            finding["references"] = finding.pop("references_json")
-        if "corroborating_sources_json" in finding:
-            finding["corroborating_sources"] = finding.pop("corroborating_sources_json")
-    return findings
-
-
-def deserialize_asset_service_rows(rows: List[Dict]) -> List[Dict[str, Any]]:
-    items = parse_json_fields(rows, ["metadata_json", "cert_san_json"])
-    for item in items:
-        if "metadata_json" in item:
-            item["metadata"] = item.pop("metadata_json")
-        if "cert_san_json" in item:
-            item["cert_san"] = item.pop("cert_san_json")
-    return items
+# Re-export pure helpers from import-safe module.
+from .routes_json_helpers import (
+    parse_json_fields,
+    deserialize_finding_rows,
+    deserialize_asset_service_rows,
+    FINDING_JSON_FIELDS,
+)
 
 def _parse_workflow_steps(raw_steps: Any) -> List[Dict[str, Any]]:
     if isinstance(raw_steps, list):

--- a/backend/secuscan/routes_json_helpers.py
+++ b/backend/secuscan/routes_json_helpers.py
@@ -1,0 +1,64 @@
+"""
+JSON deserialization helpers for SQLite row data — import-safe subset of routes.py.
+
+Contains pure parse/deserialize helpers extracted from routes.py so they can be
+unit-tested without pulling in FastAPI, httpx, or the rest of the web layer.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+
+FINDING_JSON_FIELDS = [
+    "metadata_json",
+    "risk_factors_json",
+    "evidence_json",
+    "asset_refs_json",
+    "references_json",
+    "corroborating_sources_json",
+]
+
+
+def parse_json_fields(rows: List[Dict], fields: List[str]) -> List[Dict]:
+    """Helper to parse stringified JSON fields from SQLite."""
+    parsed = []
+    for row in rows:
+        item = dict(row)
+        for field in fields:
+            if item.get(field) and isinstance(item[field], str):
+                try:
+                    item[field] = json.loads(item[field])
+                except json.JSONDecodeError:
+                    pass
+        parsed.append(item)
+    return parsed
+
+
+def deserialize_finding_rows(rows: List[Dict]) -> List[Dict[str, Any]]:
+    findings = parse_json_fields(rows, FINDING_JSON_FIELDS)
+    for finding in findings:
+        if "metadata_json" in finding:
+            finding["metadata"] = finding.pop("metadata_json")
+        if "risk_factors_json" in finding:
+            finding["risk_factors"] = finding.pop("risk_factors_json")
+        if "evidence_json" in finding:
+            finding["evidence"] = finding.pop("evidence_json")
+        if "asset_refs_json" in finding:
+            finding["asset_refs"] = finding.pop("asset_refs_json")
+        if "references_json" in finding:
+            finding["references"] = finding.pop("references_json")
+        if "corroborating_sources_json" in finding:
+            finding["corroborating_sources"] = finding.pop("corroborating_sources_json")
+    return findings
+
+
+def deserialize_asset_service_rows(rows: List[Dict]) -> List[Dict[str, Any]]:
+    items = parse_json_fields(rows, ["metadata_json", "cert_san_json"])
+    for item in items:
+        if "metadata_json" in item:
+            item["metadata"] = item.pop("metadata_json")
+        if "cert_san_json" in item:
+            item["cert_san"] = item.pop("cert_san_json")
+    return items

--- a/testing/backend/unit/test_routes_json_helpers.py
+++ b/testing/backend/unit/test_routes_json_helpers.py
@@ -1,0 +1,112 @@
+"""
+Tests for backend.secuscan.routes_json_helpers pure JSON deserialization helpers.
+
+Covers:
+- parse_json_fields: rows with JSON columns, non-string values, invalid JSON
+- deserialize_finding_rows: all FINDING_JSON_FIELDS, missing fields, empty list
+- deserialize_asset_service_rows: metadata_json and cert_san_json, empty list
+"""
+
+from backend.secuscan.routes_json_helpers import (
+    parse_json_fields,
+    deserialize_finding_rows,
+    deserialize_asset_service_rows,
+    FINDING_JSON_FIELDS,
+)
+
+
+class TestParseJsonFields:
+    def test_parses_string_json_columns(self):
+        rows = [
+            {"id": "1", "data_json": '{"key": "value"}'},
+            {"id": "2", "data_json": '{"other": 42}'},
+        ]
+        result = parse_json_fields(rows, ["data_json"])
+        # parse_json_fields overwrites the _json key with the parsed value
+        assert result[0]["data_json"] == {"key": "value"}
+        assert result[1]["data_json"] == {"other": 42}
+
+    def test_non_string_values_left_unchanged(self):
+        rows = [{"id": "1", "data_json": {"nested": True}}]
+        result = parse_json_fields(rows, ["data_json"])
+        assert result[0]["data_json"] == {"nested": True}
+
+    def test_invalid_json_left_as_string(self):
+        rows = [{"id": "1", "data_json": "not valid json {"}]
+        result = parse_json_fields(rows, ["data_json"])
+        assert result[0]["data_json"] == "not valid json {"
+
+    def test_missing_field_left_unchanged(self):
+        rows = [{"id": "1"}]
+        result = parse_json_fields(rows, ["data_json"])
+        assert "data_json" not in result[0]
+
+
+class TestDeserializeFindingRows:
+    def test_deserializes_all_finding_json_fields(self):
+        rows = [
+            {
+                "id": "finding-1",
+                "metadata_json": '{"cvss": 9.1}',
+                "risk_factors_json": '["CVE-2024-1234"]',
+                "evidence_json": '[{"type": "screenshot"}]',
+                "asset_refs_json": '["asset-1"]',
+                "references_json": '[{"url": "http://example.com"}]',
+                "corroborating_sources_json": '[{"source": "nmap"}]',
+            }
+        ]
+        results = deserialize_finding_rows(rows)
+        assert len(results) == 1
+        r = results[0]
+        assert r["metadata"] == {"cvss": 9.1}
+        assert r["risk_factors"] == ["CVE-2024-1234"]
+        assert r["evidence"] == [{"type": "screenshot"}]
+        assert r["asset_refs"] == ["asset-1"]
+        assert r["references"] == [{"url": "http://example.com"}]
+        assert r["corroborating_sources"] == [{"source": "nmap"}]
+        # Original _json keys renamed
+        assert "metadata_json" not in r
+
+    def test_missing_optional_fields_ignored(self):
+        rows = [{"id": "finding-1", "severity": "high"}]
+        results = deserialize_finding_rows(rows)
+        assert len(results) == 1
+        assert results[0]["severity"] == "high"
+
+    def test_empty_rows_list(self):
+        results = deserialize_finding_rows([])
+        assert results == []
+
+    def test_invalid_json_in_field_preserved_and_renamed(self):
+        rows = [{"id": "1", "metadata_json": "broken {"}]
+        results = deserialize_finding_rows(rows)
+        # parse_json_fields keeps the key on decode failure; then deserialize_finding_rows
+        # renames it to "metadata" (regardless of whether the value is valid JSON)
+        assert results[0].get("metadata") == "broken {"
+
+
+class TestDeserializeAssetServiceRows:
+    def test_deserializes_metadata_and_cert_san(self):
+        rows = [
+            {
+                "id": "svc-1",
+                "metadata_json": '{"port": 443}',
+                "cert_san_json": '["example.com", "www.example.com"]',
+            }
+        ]
+        results = deserialize_asset_service_rows(rows)
+        assert len(results) == 1
+        assert results[0]["metadata"] == {"port": 443}
+        assert results[0]["cert_san"] == ["example.com", "www.example.com"]
+        assert "metadata_json" not in results[0]
+        assert "cert_san_json" not in results[0]
+
+    def test_empty_rows_list(self):
+        results = deserialize_asset_service_rows([])
+        assert results == []
+
+    def test_missing_fields_handled(self):
+        rows = [{"id": "svc-1", "host": "1.2.3.4"}]
+        results = deserialize_asset_service_rows(rows)
+        assert len(results) == 1
+        assert results[0]["host"] == "1.2.3.4"


### PR DESCRIPTION
Closes #1065.

Summary of What Has Been Done:
Extracted parse_json_fields, FINDING_JSON_FIELDS, deserialize_finding_rows, and deserialize_asset_service_rows from routes.py to backend/secuscan/routes_json_helpers.py. routes.py now re-exports these from the new module so existing call sites keep working. Added 11 unit tests covering the helpers.

Changes Made:
- Created backend/secuscan/routes_json_helpers.py with all pure JSON helpers extracted from routes.py
- Updated backend/secuscan/routes.py to re-export from routes_json_helpers (existing call sites unchanged)
- Created testing/backend/unit/test_routes_json_helpers.py with 11 tests:
  - parse_json_fields: parses string JSON columns, non-string values unchanged, invalid JSON fallback, missing fields
  - deserialize_finding_rows: all FINDING_JSON_FIELDS deserialized and renamed, missing optional fields, empty list, invalid JSON preserved
  - deserialize_asset_service_rows: metadata_json and cert_san_json, empty list, missing fields

Impact it Made:
Zero test coverage for these helpers. Tests guard SQLite JSON deserialization logic used in all findings and asset endpoints. Extraction enables isolated testing without FastAPI/httpx dependencies.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.