### PR TITLE
test: document xss_exploiter failure-mode parser behaviour

### DIFF
--- a/testing/backend/unit/test_xss_exploiter_plugin.py
+++ b/testing/backend/unit/test_xss_exploiter_plugin.py
@@ -93,6 +93,26 @@ def test_xss_exploiter_parser_empty_output_is_deterministic(plugin_manager):
     assert parsed["count"] == 0
     assert parsed["items"] == []
 
+def test_xss_exploiter_parser_blocked_payload_is_preserved_as_observation(plugin_manager):
+    parser = _load_xss_exploiter_parser()
+
+    parsed = parser.parse("Payload blocked by WAF")
+
+    assert parsed["count"] == 1
+    assert len(parsed["findings"]) == 1
+    assert parsed["findings"][0]["severity"] == "info"
+    assert parsed["findings"][0]["description"] == "Payload blocked by WAF"
+
+def test_xss_exploiter_parser_benign_failure_is_preserved_as_observation(plugin_manager):
+    parser = _load_xss_exploiter_parser()
+
+    parsed = parser.parse("No XSS findings")
+
+    assert parsed["count"] == 1
+    assert len(parsed["findings"]) == 1
+    assert parsed["findings"][0]["severity"] == "info"
+    assert parsed["findings"][0]["description"] == "No XSS findings"
+
 
 def test_xss_exploiter_executor_normalizes_parser_fixture(plugin_manager):
     parser = _load_xss_exploiter_parser()


### PR DESCRIPTION
## Description
This PR adds parser contract coverage for the xss_exploiter plugin to document and lock in its failure-mode behavior. It does not change plugin runtime behavior, only improves test-level documentation of expected outputs.

Specifically, it clarifies how the parser handles:
- Empty output (no findings)
- Blocked payload messages
- Benign failure messages

All cases are now explicitly covered through unit tests to ensure deterministic behavior and prevent regression.

## Related Issues
Closes #858

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

## How Has This Been Tested?
The following test suite was executed:
python -m pytest testing/backend/unit/test_xss_exploiter_plugin.py -v

Results:
- 7 tests passed
- No failures
- No runtime changes to plugin behavior

Covered scenarios:
- Empty output returns deterministic empty findings
- Blocked payload messages are preserved as informational findings
- Benign failure messages are preserved as informational findings
- Existing parser + executor behavior remains unchanged

## Checklist
- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.