### PR TITLE
ci: restore Node.js 20/22 runtime matrix coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,10 @@ jobs:
       needs.detect-changes.outputs.run_frontend == 'true' &&
       (needs.formatting-hygiene.result == 'success' || needs.formatting-hygiene.result == 'skipped')
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+
     defaults:
       run:
         working-directory: frontend
@@ -262,7 +266,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node-version }}
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
       - name: Install frontend dependencies


### PR DESCRIPTION
Summary

Restore Node.js 20/22 runtime matrix coverage for frontend checks.

Changes

* Add a Node.js runtime matrix covering Node 20 and Node 22.
* Use `${{ matrix.node-version }}` in the frontend checks job.
* Keep the diff limited to `.github/workflows/ci.yml`.

Verification

* Verified `matrix.node-version` is defined and referenced correctly.
* Confirmed the workflow configuration is internally consistent.
* Diff is limited to the CI workflow update.
