### PR TITLE
feat: add named url validation preset for joomscan

### DIFF
--- a/plugins/joomscan/metadata.json
+++ b/plugins/joomscan/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83c\udff7\ufe0f",
+  "icon": "🏷️",
   "engine": {
     "type": "cli",
     "binary": "joomscan"
@@ -28,7 +28,7 @@
       "required": true,
       "placeholder": "https://joomla.secuscan.in",
       "validation": {
-        "pattern": "^https?://",
+        "validation_type": "url",
         "message": "Must be a valid HTTP(S) URL"
       }
     }
@@ -56,5 +56,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "fc1b9feab32f4f65d995b6613ba450d32d0f318cb5209e6144be3e961e38e392"
+  "checksum": "d3ffeb4aaee18cfca0ba2f9ba6958b71e5e5c29a3823a8e1855040c19de09b04"
 }

--- a/testing/backend/test_joomscan_plugin.py
+++ b/testing/backend/test_joomscan_plugin.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "joomscan"
+
+
+def test_joomscan_target_field_uses_url_validation_preset():
+    data = json.loads((PLUGIN_DIR / "metadata.json").read_text(encoding="utf-8"))
+    fields = {f["id"]: f for f in data["fields"]}
+
+    target_validation = fields["target"].get("validation", {})
+
+    assert target_validation.get("validation_type") == "url"
+    assert target_validation.get("message") == "Must be a valid HTTP(S) URL"
+    assert "pattern" not in target_validation


### PR DESCRIPTION
## Description
- Replaced the regex-based target validation in `plugins/joomscan/metadata.json` with the named URL validation preset.
- Removed the explicit URL pattern and kept the existing validation message.
- Added a dedicated contract test to ensure the Joomscan target field continues to use the named URL validation preset.

## Related Issues
Closes #841 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

```bash
pytest testing/backend/test_joomscan_plugin.py -v

============================= test session starts ==============================
platform win32 -- Python 3.12.10, pytest-9.0.3, pluggy-1.6.0
collected 1 item

testing/backend/test_joomscan_plugin.py::test_joomscan_target_field_uses_url_validation_preset PASSED [100%]

======================== 1 passed, 2 warnings in 0.07s =========================
```

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
