### PR TITLE
Improve subdomain discovery confidence mapping

### DIFF
--- a/plugins/subdomain_discovery/metadata.json
+++ b/plugins/subdomain_discovery/metadata.json
@@ -88,5 +88,5 @@
     "system_packages": []
   },
   "docker_image": "projectdiscovery/subfinder:latest",
-  "checksum": "36a62951d26ba2da37b777b21fc117f81b4125e88144688f43cc1beb0989cc0c"
+  "checksum": "11c9b9517e288518d4eefa78aff3a3efdfb9d2023dacf5ddfe95e2b3808eac72"
 }

--- a/plugins/subdomain_discovery/parser.py
+++ b/plugins/subdomain_discovery/parser.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, List
+from typing import Dict, Any
 
 def parse(output: str) -> Dict[str, Any]:
     """
@@ -13,10 +13,18 @@ def parse(output: str) -> Dict[str, Any]:
             "title": f"Subdomain Discovered: {sub}",
             "category": "Subdomain",
             "severity": "info",
-            "description": f"Discovered subdomain: {sub}",
-            "remediation": "Verify if this subdomain is intended to be public and secure.",
+            "description": (
+                f"Discovered subdomain: {sub}. "
+                "Confidence: high based on passive enumeration output."
+            ),
+            "remediation": (
+                "Verify if this subdomain is intended to be public and secure."
+            ),
             "metadata": {
-                "subdomain": sub
+                "subdomain": sub,
+                "source": "subfinder",
+                "evidence": f"Subdomain discovered from subfinder output: {sub}",
+                "confidence": "high"
             }
         })
         

--- a/testing/backend/unit/test_subdomain_finder_plugin.py
+++ b/testing/backend/unit/test_subdomain_finder_plugin.py
@@ -92,7 +92,14 @@ def test_subdomain_discovery_parser_fixture_produces_stable_findings(plugin_mana
     assert first["title"] == "Subdomain Discovered: api.secuscan.in"
     assert first["category"] == "Subdomain"
     assert first["severity"] == "info"
-    assert first["metadata"]["subdomain"] == "api.secuscan.in"
+
+    metadata = first["metadata"]
+
+    assert metadata["subdomain"] == "api.secuscan.in"
+    assert metadata["source"] == "subfinder"
+    assert metadata["confidence"] == "high"
+    assert "evidence" in metadata
+    assert "api.secuscan.in" in metadata["evidence"]
 
 
 def test_subdomain_discovery_parser_empty_output_is_deterministic(plugin_manager):


### PR DESCRIPTION
## Description
This PR improves the subdomain_discovery plugin parser by standardizing how confidence and evidence metadata are represented for discovered subdomains. The goal is to make parser output more consistent, predictable, and aligned with existing plugin contract patterns.

The changes ensure that each finding exposes a clearer confidence mapping structure, improving downstream reliability and making the plugin easier to test and extend.
Minor updates were also made to unit tests to validate the updated parser behavior and ensure backward compatibility for existing discovery outputs.

## Related Issues
Closes #859

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Updated and extended tests in testing/backend/unit/test_subdomain_finder_plugin.py
- Verified parser output structure for multiple subdomain discovery formats
- Ensured confidence/evidence fields are consistently mapped across all findings
- Ran backend unit test suite to confirm no regression in existing plugin behavior

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.