### PR TITLE
feat: wire up light/dark mode toggle end-to-end (darkMode class, them…

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3855,3 +3855,19 @@ button,
     white-space: nowrap;
   }
 }
+
+/* ============================================
+   Light Theme Overrides
+   ============================================ */
+.theme-light {
+  --bg-primary: #f8f9fa;
+  --bg-secondary: #ffffff;
+  --bg-tertiary: #f1f3f5;
+  --bg-elevated: #e9ecef;
+  --accent-silver: #6c757d;
+  --accent-silver-dim: #adb5bd;
+  --accent-silver-bright: #212529;
+  --text-primary: #212529;
+  --text-secondary: #495057;
+  --text-muted: #6c757d;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -7,6 +8,15 @@ export default {
   theme: {
     extend: {
       colors: {
+        'primary': 'var(--bg-primary)',
+        'secondary': 'var(--bg-secondary)',
+        'bg-primary': 'var(--bg-primary)',
+        'bg-secondary': 'var(--bg-secondary)',
+        'bg-tertiary': 'var(--bg-tertiary)',
+        'bg-elevated': 'var(--bg-elevated)',
+        'primary-text': 'var(--text-primary)',
+        'secondary-text': 'var(--text-secondary)',
+        'muted': 'var(--text-muted)',
         'charcoal-dark': '#0a0a0c',
         charcoal: {
           light: '#1d1d21',

--- a/frontend/testing/unit/components/ThemeToggle.test.tsx
+++ b/frontend/testing/unit/components/ThemeToggle.test.tsx
@@ -55,6 +55,34 @@ describe('ThemeToggle', () => {
     expect(button).toHaveAttribute('aria-pressed', 'true')
   })
 
+  it('applies the dark class to document root and removes theme-light', async () => {
+    localStorage.setItem(STORAGE_KEY, 'light')
+    document.documentElement.classList.remove('dark')
+    document.documentElement.classList.add('theme-light')
+    const user = userEvent.setup()
+    renderWithTheme()
+
+    const button = screen.getByRole('button')
+    await user.click(button)
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(document.documentElement.classList.contains('theme-light')).toBe(false)
+  })
+
+  it('applies the theme-light class to document root and removes dark', async () => {
+    localStorage.setItem(STORAGE_KEY, 'dark')
+    document.documentElement.classList.add('dark')
+    document.documentElement.classList.remove('theme-light')
+    const user = userEvent.setup()
+    renderWithTheme()
+
+    const button = screen.getByRole('button')
+    await user.click(button)
+
+    expect(document.documentElement.classList.contains('theme-light')).toBe(true)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
   it('aria-label reflects the target theme, not the current one', () => {
     localStorage.setItem(STORAGE_KEY, 'dark')
     renderWithTheme()


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Description</h2>
<p>Wired the light/dark mode toggle end-to-end. The toggle button, <code>ThemeContext</code>, and localStorage persistence logic were already implemented, but the visual theme switch never actually took effect because:</p>
<ol>
<li><code>tailwind.config.js</code> was missing <code>darkMode: 'class'</code> — Tailwind was ignoring the <code>dark</code> class added to the HTML element by <code>ThemeContext</code></li>
<li><code>.theme-light</code> CSS variable overrides were missing from <code>index.css</code> — switching to light mode had no visual effect</li>
<li><code>bg-secondary</code>, <code>bg-primary</code>, <code>bg-tertiary</code> color classes used throughout the app were not mapped to the CSS variable tokens in the Tailwind config</li>
</ol>
<p>After these fixes, clicking the toggle now switches the entire dashboard (sidebar, main content, header, text) between dark and light themes, the icon updates correctly (sun ↔ moon), and the selection persists across page refresh via localStorage.</p>
<p><strong>Before / After:</strong></p>

| Dark mode | Light mode |
|---|---|
| <img width="1920" height="1020" alt="dark" src="https://github.com/user-attachments/assets/e0ca8af5-cc41-42e8-9a59-c432b5cba150" /> | <img width="1920" height="1020" alt="theme-light" src="https://github.com/user-attachments/assets/b1560c0a-72f7-4c75-9ab9-3ba75f9000c6" /> |<h2>Related Issues</h2>
<p>Closes #954</p>
<h2>Type of Change</h2>
<ul>
<li>[x] Bug fix (non-breaking change which fixes an issue)</li>
<li>[ ] New feature (non-breaking change which adds functionality)</li>
<li>[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)</li>
<li>[ ] Documentation update</li>
</ul>
<h2>How Has This Been Tested?</h2>
<ol>
<li>Started backend (<code>python -m backend.secuscan.main</code>) and frontend (<code>npm run dev</code>) locally</li>
<li>Opened the dashboard and clicked the theme toggle button in the sidebar</li>
<li>Confirmed visually that the entire UI (background, text, sidebar) switches between dark and light themes</li>
<li>Confirmed the toggle icon updates from sun to moon and the tooltip text updates ("Switch to light mode" ↔ "Switch to dark mode")</li>
<li>Verified in browser DevTools console that <code>getComputedStyle(document.documentElement).getPropertyValue('--bg-primary')</code> returns the correct value for each theme</li>
<li>Refreshed the page and confirmed the selected theme persists (read from localStorage)</li>
</ol>
<h2>Checklist</h2>
<ul>
<li>[x] My code follows the code style of this project.</li>
<li>[x] I have performed a self-review of my own code.</li>
<li>[ ] I have commented my code, particularly in hard-to-understand areas.</li>
<li>[ ] I have made corresponding changes to the documentation.</li>
<li>[x] My changes generate no new warnings.</li>
</ul>
<hr>
<p>Drag and drop your two screenshots (dark mode and light mode) directly into the GitHub PR description box where you see <code>paste-image-link-here</code> — GitHub will upload them and auto-insert the correct image markdown.</p></body></html><!--EndFragment-->
</body>
</html>