### PR TITLE
feat: improve severity mapping in droopescan parser

### DIFF
--- a/plugins/droopescan/metadata.json
+++ b/plugins/droopescan/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee1\ufe0f",
+  "icon": "🛡️",
   "engine": {
     "type": "cli",
     "binary": "droopescan"
@@ -60,5 +60,5 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "d06997f1c1fc57665492e772ff146100ba387bbd30438f9493998eae94f71645"
+  "checksum": "14a813b3393bcc5a1c5ad697b8d6a283d61e61c7b1aa08481175df109d194e02"
 }

--- a/plugins/droopescan/parser.py
+++ b/plugins/droopescan/parser.py
@@ -12,6 +12,16 @@ def _make_finding(title: str, category: str, severity: str, description: str, me
         "metadata": metadata,
     }
 
+def _map_severity(key: str) -> str:
+    key = key.lower()
+
+    if any(token in key for token in ("critical", "vuln")):
+        return "high"
+
+    if any(token in key for token in ("warning", "interesting", "exposed")):
+        return "medium"
+
+    return "low"
 
 def parse(output: str) -> Dict[str, Any]:
     findings: List[Dict[str, Any]] = []
@@ -42,11 +52,15 @@ def parse(output: str) -> Dict[str, Any]:
                 if not isinstance(item, dict):
                     continue
                 description = str(item.get("description") or item.get("url") or item)
-                severity = "high" if "vuln" in key.lower() else "low"
+                severity = _map_severity(key)
                 findings.append(
                     _make_finding(
                         title=f"DroopeScan {key}",
-                        category="CMS Vulnerability" if severity == "high" else "CMS Discovery",
+                        category=(
+                            "CMS Vulnerability"
+                            if severity in {"high", "medium"}
+                            else "CMS Discovery"
+                        ),
                         severity=severity,
                         description=description,
                         metadata=item,

--- a/testing/backend/test_droopescan_parser.py
+++ b/testing/backend/test_droopescan_parser.py
@@ -1,0 +1,26 @@
+from plugins.droopescan.parser import parse
+
+
+def test_droopescan_severity_mapping():
+    output = """
+    {
+      "vulnerabilities": [
+        {"description": "Critical issue"}
+      ],
+      "interesting_urls": [
+        {"description": "Exposed admin endpoint"}
+      ],
+      "themes": [
+        {"description": "Theme detected"}
+      ]
+    }
+    """
+
+    result = parse(output)
+    findings = result["findings"]
+
+    severities = {f["title"]: f["severity"] for f in findings}
+
+    assert severities["DroopeScan vulnerabilities"] == "high"
+    assert severities["DroopeScan interesting_urls"] == "medium"
+    assert severities["DroopeScan themes"] == "low"


### PR DESCRIPTION
## Description
- Improved severity mapping in the DroopeScan parser to align findings more consistently with SecuScan severity levels.
- Added a dedicated `_map_severity()` helper to classify findings into `high`, `medium`, and `low` severities.
- Updated category assignment so medium-severity findings are treated as vulnerabilities.
- Added focused parser tests to verify severity mapping behavior.
- Refreshed the DroopeScan plugin checksum after modifying the parser.

## Related Issues
Closes #845 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
pytest testing/backend/test_droopescan_parser.py -v

Result:
1 passed

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
