### PR TITLE
feat: surface vault key fingerprint in secure diagnostics output

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -2327,3 +2327,40 @@ async def export_audit_log(format: str = "json"):
         media_type=mime_type,
         headers={"Content-Disposition": f"attachment; filename=network-audit.{format}"}
     )
+
+
+@router.get("/admin/vault/diagnostics", dependencies=[Depends(verify_admin_access), Depends(admin_limiter)])
+async def get_vault_diagnostics():
+    """Report non-secret diagnostics for the credential vault key.
+    Surfaces a one-way fingerprint of the active vault key so operators can confirm key-rotation state without the key material ever leaving the server.
+    Applies across deployments or before/after a rotation.
+    The endpoint never fails on configuration state: when no key is configured it reports ``configured: false`` with a null fingerprint.
+    So it can double as a health probe for vault configuration.
+    The route is admin-gated: while the fingerprint is non-secret, the key source and configuration status are operational details that belong behind the same boundary as the rest of the ``/admin`` surface.
+    """
+    if settings.vault_key:
+        key_source = "vault_key"
+    elif settings.plugin_signature_key:
+        key_source = "plugin_signature_key"
+    else:
+        key_source = None
+
+    try:
+        crypto = VaultCrypto(settings.resolved_vault_key)
+    except RuntimeError:
+        # No SECUSCAN_VAULT_KEY / plugin signature key configured.
+        return {
+            "configured": False,
+            "key_source": None,
+            "algorithm": "AES-256-GCM",
+            "key_fingerprint": None,
+            "fingerprint_algorithm": "sha256-trunc64",
+        }
+
+    return {
+        "configured": True,
+        "key_source": key_source,
+        "algorithm": "AES-256-GCM",
+        "key_fingerprint": crypto.key_fingerprint,
+        "fingerprint_algorithm": "sha256-trunc64",
+    }

--- a/backend/secuscan/vault.py
+++ b/backend/secuscan/vault.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import os
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -13,13 +14,19 @@ class VaultCrypto:
 
     Each call to encrypt() generates a fresh random 12-byte nonce so no two
     ciphertexts ever share a nonce under the same key.  The GCM auth tag
-    (16 bytes, appended by AESGCM) provides both confidentiality and integrity —
+    (16 bytes, appended by AESGCM) provides both confidentiality and integrity -
     any tampering causes decrypt() to raise ValueError.
 
     Wire format (base64url): nonce(12) || ciphertext || auth_tag(16)
     """
 
     _NONCE_LEN = 12
+
+    # Domain-separation prefix so the fingerprint can never collide with any other use of the key material as a hash input.
+    # So the digest is a dedicated identifier rather than a reusable oracle.
+    _FINGERPRINT_DOMAIN = b"secuscan/vault-key-fingerprint/v1"
+    # 8 bytes (64 bits) is plenty to distinguish keys for rotation checks while keeping the value short and obviously non-recoverable.
+    _FINGERPRINT_BYTES = 8
 
     def __init__(self, key: bytes):
         """
@@ -36,6 +43,9 @@ class VaultCrypto:
                 f"Vault key must decode to exactly 32 bytes (AES-256); got {len(raw)}"
             )
         self._aesgcm = AESGCM(raw)
+        # Compute the fingerprint at construction and retain only the resulting string, never the raw key bytes.
+        # So the instance keeps no extra copy of the key material beyond what AESGCM already holds internally.
+        self._key_fingerprint = self._compute_fingerprint(raw)
 
     def encrypt(self, plaintext: str) -> str:
         nonce = os.urandom(self._NONCE_LEN)
@@ -58,3 +68,23 @@ class VaultCrypto:
             raise ValueError("Vault payload integrity verification failed") from exc
 
         return raw.decode("utf-8")
+
+    @classmethod
+    def _compute_fingerprint(cls, raw_key: bytes) -> str:
+        """Derive the colon-separated hex fingerprint for raw 32-byte key material."""
+        digest = hashlib.sha256(cls._FINGERPRINT_DOMAIN + raw_key).digest()
+        truncated = digest[: cls._FINGERPRINT_BYTES]
+        return ":".join(f"{byte:02x}" for byte in truncated)
+
+    @property
+    def key_fingerprint(self) -> str:
+        """A non-secret, stable identifier for the active vault key.
+
+        Computed as a domain-separated SHA-256 over the raw key material, truncated to 64 bits and rendered as colon-separated hex pairs.
+        Eg: ``"1a:2b:3c:4d:5e:6f:70:81"``.
+
+        The fingerprint is one-way - the key can't be recovered from it. But it changes whenever the underlying key is rotated.
+        Operators can compare fingerprints across deployments or before/after a rotation to confirm the key state without ever handling the key itself:
+        which is why it is safe to surface in diagnostics output.
+        """
+        return self._key_fingerprint

--- a/testing/backend/integration/test_vault_diagnostics_route.py
+++ b/testing/backend/integration/test_vault_diagnostics_route.py
@@ -1,0 +1,91 @@
+"""
+Integration tests for GET /api/v1/admin/vault/diagnostics (issue #809).
+
+Verifies the secure diagnostics contract:
+- the route is admin-gated (401 without a valid admin key),
+- it surfaces a non-secret, stable key fingerprint,
+- the fingerprint matches the configured key and never leaks key material,
+- it reports configured/false instead of erroring when no key is set.
+"""
+
+import base64
+
+from backend.secuscan.config import settings
+from backend.secuscan.vault import VaultCrypto
+
+
+ADMIN_KEY = "valid-admin-key-long"  # >= 16 chars to pass the entropy check
+ADMIN_HEADERS = {"X-API-Key": ADMIN_KEY}
+
+ENDPOINT = "/api/v1/admin/vault/diagnostics"
+
+
+def test_diagnostics_requires_admin_key(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "admin_api_key", ADMIN_KEY)
+    # No admin key supplied (the test client's default X-Api-Key is the
+    # deployment key, not the admin key) -> 401.
+    res = test_client.get(ENDPOINT)
+    assert res.status_code == 401
+
+
+def test_diagnostics_rejects_wrong_admin_key(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "admin_api_key", ADMIN_KEY)
+    res = test_client.get(ENDPOINT, headers={"X-API-Key": "wrong-key"})
+    assert res.status_code == 401
+
+
+def test_diagnostics_returns_fingerprint(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "admin_api_key", ADMIN_KEY)
+    res = test_client.get(ENDPOINT, headers=ADMIN_HEADERS)
+    assert res.status_code == 200, res.text
+    data = res.json()
+
+    assert data["configured"] is True
+    assert data["algorithm"] == "AES-256-GCM"
+    assert data["key_source"] == "vault_key"  # conftest sets settings.vault_key
+    assert data["fingerprint_algorithm"] == "sha256-trunc64"
+
+    fingerprint = data["key_fingerprint"]
+    assert fingerprint
+    # Fingerprint matches the one derived from the active key.
+    expected = VaultCrypto(settings.resolved_vault_key).key_fingerprint
+    assert fingerprint == expected
+
+
+def test_diagnostics_does_not_leak_key_material(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "admin_api_key", ADMIN_KEY)
+    res = test_client.get(ENDPOINT, headers=ADMIN_HEADERS)
+    body = res.text
+    raw_key = base64.urlsafe_b64decode(settings.resolved_vault_key)
+    # Neither the configured seed, the encoded key, nor the raw key bytes
+    # should appear anywhere in the response.
+    assert settings.vault_key not in body
+    assert settings.resolved_vault_key.decode("ascii") not in body
+    assert raw_key.hex() not in body
+
+
+def test_diagnostics_reports_plugin_signature_key_fallback(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "admin_api_key", ADMIN_KEY)
+    monkeypatch.setattr(settings, "vault_key", None)
+    monkeypatch.setattr(settings, "plugin_signature_key", "fallback-signing-key")
+
+    res = test_client.get(ENDPOINT, headers=ADMIN_HEADERS)
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["configured"] is True
+    assert data["key_source"] == "plugin_signature_key"
+    assert data["key_fingerprint"]
+
+
+def test_diagnostics_reports_unconfigured_without_erroring(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "admin_api_key", ADMIN_KEY)
+    monkeypatch.setattr(settings, "vault_key", None)
+    monkeypatch.setattr(settings, "plugin_signature_key", None)
+
+    res = test_client.get(ENDPOINT, headers=ADMIN_HEADERS)
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["configured"] is False
+    assert data["key_source"] is None
+    assert data["key_fingerprint"] is None
+    assert data["algorithm"] == "AES-256-GCM"

--- a/testing/backend/integration/test_vault_diagnostics_route.py
+++ b/testing/backend/integration/test_vault_diagnostics_route.py
@@ -2,9 +2,9 @@
 Integration tests for GET /api/v1/admin/vault/diagnostics (issue #809).
 
 Verifies the secure diagnostics contract:
-- the route is admin-gated (401 without a valid admin key),
-- it surfaces a non-secret, stable key fingerprint,
-- the fingerprint matches the configured key and never leaks key material,
+- the route is admin-gated (401 without a valid admin key)
+- it surfaces a non-secret, stable key fingerprint
+- the fingerprint matches the configured key and never leaks key material
 - it reports configured/false instead of erroring when no key is set.
 """
 

--- a/testing/backend/unit/test_vault_fingerprint.py
+++ b/testing/backend/unit/test_vault_fingerprint.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for the vault key fingerprint (issue #809).
+
+The fingerprint must let operators confirm key-rotation state without ever
+exposing key material, so it has to be:
+
+- deterministic / stable for a given key,
+- different for different keys (changes on rotation),
+- one-way: it must not contain or trivially reveal the key,
+- a fixed, well-formed colon-separated hex identifier.
+"""
+
+import base64
+import hashlib
+
+from backend.secuscan.config import settings
+from backend.secuscan.vault import VaultCrypto
+
+
+def _make_key(seed: str) -> bytes:
+    """Mirror settings.resolved_vault_key: base64url(sha256(seed))."""
+    raw = hashlib.sha256(seed.encode()).digest()
+    return base64.urlsafe_b64encode(raw)
+
+
+class TestKeyFingerprintProperties:
+    def test_fingerprint_is_deterministic(self):
+        a = VaultCrypto(_make_key("rotation-test")).key_fingerprint
+        b = VaultCrypto(_make_key("rotation-test")).key_fingerprint
+        assert a == b
+
+    def test_fingerprint_changes_when_key_rotates(self):
+        before = VaultCrypto(_make_key("key-v1")).key_fingerprint
+        after = VaultCrypto(_make_key("key-v2")).key_fingerprint
+        assert before != after
+
+    def test_fingerprint_format_is_colon_hex(self):
+        fp = VaultCrypto(_make_key("format")).key_fingerprint
+        parts = fp.split(":")
+        # 8 bytes -> 8 colon-separated pairs, each two lowercase hex digits.
+        assert len(parts) == VaultCrypto._FINGERPRINT_BYTES
+        assert all(len(p) == 2 for p in parts)
+        # Round-trips back to bytes => only valid hex characters present.
+        assert bytes.fromhex(fp.replace(":", ""))
+
+    def test_fingerprint_length_matches_truncation(self):
+        fp = VaultCrypto(_make_key("len")).key_fingerprint
+        raw = bytes.fromhex(fp.replace(":", ""))
+        assert len(raw) == VaultCrypto._FINGERPRINT_BYTES
+
+    def test_fingerprint_does_not_reveal_key_material(self):
+        key = _make_key("secret-material")
+        crypto = VaultCrypto(key)
+        fp = crypto.key_fingerprint
+        raw_key = base64.urlsafe_b64decode(key)
+        # Neither the encoded nor the raw key should appear in the fingerprint.
+        assert key.decode("ascii") not in fp
+        assert raw_key.hex() not in fp.replace(":", "")
+
+    def test_fingerprint_uses_domain_separated_sha256(self):
+        """Fingerprint equals the documented construction, not a bare hash."""
+        key = _make_key("domain-sep")
+        raw_key = base64.urlsafe_b64decode(key)
+        expected_digest = hashlib.sha256(
+            VaultCrypto._FINGERPRINT_DOMAIN + raw_key
+        ).digest()[: VaultCrypto._FINGERPRINT_BYTES]
+        expected = ":".join(f"{b:02x}" for b in expected_digest)
+        assert VaultCrypto(key).key_fingerprint == expected
+
+    def test_bare_sha256_would_differ_from_fingerprint(self):
+        """Domain separation actually changes the output vs. a plain hash."""
+        key = _make_key("no-domain")
+        raw_key = base64.urlsafe_b64decode(key)
+        bare = hashlib.sha256(raw_key).digest()[: VaultCrypto._FINGERPRINT_BYTES]
+        bare_fp = ":".join(f"{b:02x}" for b in bare)
+        assert VaultCrypto(key).key_fingerprint != bare_fp
+
+
+class TestResolvedKeyFingerprint:
+    def test_fingerprint_available_for_resolved_key(self):
+        crypto = VaultCrypto(settings.resolved_vault_key)
+        assert crypto.key_fingerprint
+        assert ":" in crypto.key_fingerprint

--- a/testing/backend/unit/test_vault_fingerprint.py
+++ b/testing/backend/unit/test_vault_fingerprint.py
@@ -1,12 +1,11 @@
 """
 Unit tests for the vault key fingerprint (issue #809).
 
-The fingerprint must let operators confirm key-rotation state without ever
-exposing key material, so it has to be:
+The fingerprint must let operators confirm key-rotation state without ever exposing key material, so it has to be:
 
-- deterministic / stable for a given key,
-- different for different keys (changes on rotation),
-- one-way: it must not contain or trivially reveal the key,
+- deterministic / stable for a given key
+- different for different keys (changes on rotation)
+- one-way: it must not contain or trivially reveal the key
 - a fixed, well-formed colon-separated hex identifier.
 """
 


### PR DESCRIPTION
# feat: surface vault key fingerprint in secure diagnostics output

Closes #809

## Summary

Operators need a way to confirm which vault key is active - and whether a key rotation actually took effect - without ever handling the key itself. 
This PR adds a **one-way, non-secret fingerprint** of the active vault key and exposes it through a new admin-gated diagnostics endpoint, `GET /api/v1/admin/vault/diagnostics`.
The fingerprint is deterministic for a given key and changes whenever the key is rotated, so comparing fingerprints across deployments (or before/after a rotation) is enough to confirm key state. The key material is never returned.

## Changes

**`backend/secuscan/vault.py`**
- Added a `key_fingerprint` property to `VaultCrypto`: which is derived as a **domain-separated SHA-256** over the raw 32-byte key material (`b"secuscan/vault-key-fingerprint/v1" + raw_key`), truncated to 64 bits and rendered as colon-separated hex pairs, e.g. `1a:2b:3c:4d:5e:6f:70:81`.
- The fingerprint is computed once at construction; only the resulting string is retained, so the instance keeps no extra copy of the raw key beyond what `AESGCM` already holds.

**`backend/secuscan/routes.py`**
- Added `GET /api/v1/admin/vault/diagnostics`, gated by the existing `verify_admin_access` + `admin_limiter` dependencies (placed alongside the other `/admin/*` endpoints).

### API contract

`GET /api/v1/admin/vault/diagnostics` (admin key required for this)

When a key is configured:
```json
{
  "configured": true,
  "key_source": "vault_key",
  "algorithm": "AES-256-GCM",
  "key_fingerprint": "1a:2b:3c:4d:5e:6f:70:81",
  "fingerprint_algorithm": "sha256-trunc64"
}
```

- `key_source` is `"vault_key"` when `SECUSCAN_VAULT_KEY` is set, or `"plugin_signature_key"` when the key falls back to the plugin signature key: an operationally relevant signal for rotation.

When **NO** key is configured, the endpoint reports state rather than failing, so it doubles as a configuration health probe:
```json
{
  "configured": false,
  "key_source": null,
  "algorithm": "AES-256-GCM",
  "key_fingerprint": null,
  "fingerprint_algorithm": "sha256-trunc64"
}
```

Auth errors follow the existing `/admin` contract: a missing/invalid admin key returns `401`; an unconfigured/very weak admin key returns `500` (enforced by `verify_admin_access`).

## Design decisions

- **Admin-gated**: no pre-existing diagnostics endpoint; the only operator-grade, authenticated surface is `/admin/*`. Although the fingerprint is non-secret, the key source and configuration status are operational details that belong behind the same boundary, thus "secure diagnostics output," not the unauthenticated `/settings` payload.
- **One-way**: fingerprint is a truncated SHA-256, so the key can't be recovered from it. Domain separation guarantees the digest can never collide with any other use of the key as a hash input and isn't a reusable oracle.
- **Stable and rotation-sensitive**: deterministic for a given key (operators can compare across hosts) but different for any other key (rotation is visible).
- **No new key footprint**: computed at construction; the raw bytes are not stored as a separate attribute.

## Testing

New tests:
- `testing/backend/unit/test_vault_fingerprint.py`: determinism, rotation sensitivity, colon-hex format/length, one-way (key material absent from output), domain-separated construction (and that it differs from a bare SHA-256).
- `testing/backend/integration/test_vault_diagnostics_route.py`: admin gating (401 without/with wrong key), fingerprint matches the active key, no key material leaks into the response, `plugin_signature_key` fallback reporting, and the unconfigured `configured: false` path.

### Regular test cases

```bash
PS C:\Users\madhu\Documents\SecuScan> pytest testing/backend/unit/test_vault_fingerprint.py testing/backend/integration/test_vault_diagnostics_route.py
================================================= test session starts =================================================
platform win32 -- Python 3.11.7, pytest-9.0.3, pluggy-1.6.0
rootdir: C:\Users\madhu\Documents\SecuScan
configfile: pyproject.toml
plugins: anyio-4.13.0, deepeval-4.0.5, Faker-40.19.1, langsmith-0.8.8, asyncio-1.4.0, cov-7.1.0, mock-3.15.1, repeat-0.9.4, rerunfailures-16.3, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 14 items

testing\backend\unit\test_vault_fingerprint.py ........                                                          [ 57%]
testing\backend\integration\test_vault_diagnostics_route.py ......                                               [100%]Running teardown with pytest sessionfinish...


================================================== warnings summary ===================================================
..\..\AppData\Roaming\Python\Python311\site-packages\fastapi\testclient.py:1
  C:\Users\madhu\AppData\Roaming\Python\Python311\site-packages\fastapi\testclient.py:1: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    from starlette.testclient import TestClient as TestClient  # noqa

backend\secuscan\config.py:15
  C:\Users\madhu\Documents\SecuScan\backend\secuscan\config.py:15: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class Settings(BaseSettings):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 14 passed, 2 warnings in 5.79s ============================================
```

### Regression tests: existing vault PLUS admin suites

```bash
PS C:\Users\madhu\Documents\SecuScan> pytest testing/backend/unit/test_vault.py testing/backend/unit/test_vault_security.py testing/backend/unit/test_admin_network_policy.py
================================================= test session starts =================================================
platform win32 -- Python 3.11.7, pytest-9.0.3, pluggy-1.6.0
rootdir: C:\Users\madhu\Documents\SecuScan
configfile: pyproject.toml
plugins: anyio-4.13.0, deepeval-4.0.5, Faker-40.19.1, langsmith-0.8.8, asyncio-1.4.0, cov-7.1.0, mock-3.15.1, repeat-0.9.4, rerunfailures-16.3, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 26 items

testing\backend\unit\test_vault.py .                                                                             [  3%]
testing\backend\unit\test_vault_security.py ...............                                                      [ 61%]
testing\backend\unit\test_admin_network_policy.py ..........                                                     [100%]Running teardown with pytest sessionfinish...


================================================== warnings summary ===================================================
..\..\AppData\Roaming\Python\Python311\site-packages\fastapi\testclient.py:1
  C:\Users\madhu\AppData\Roaming\Python\Python311\site-packages\fastapi\testclient.py:1: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    from starlette.testclient import TestClient as TestClient  # noqa

backend\secuscan\config.py:15
  C:\Users\madhu\Documents\SecuScan\backend\secuscan\config.py:15: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class Settings(BaseSettings):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 26 passed, 2 warnings in 7.92s ============================================
```

Result: all new tests pass; existing vault and admin suites remain green. `ruff check` is clean on all touched files.

## Acceptance criteria

- [x] The target backend behavior is implemented with a clear contract — `key_fingerprint` property + documented `GET /admin/vault/diagnostics` response shape.
- [x] Regressions are covered by focused unit and integration tests.
- [x] Error handling stays consistent with existing API patterns — reuses `verify_admin_access`/`admin_limiter`; unconfigured-key state is reported, not raised.

## Scope

Changes limited to `vault.py` and `routes.py` plus tests. No UI changes, schema migrations or unrelated refactors.