### PR TITLE
feat(task-details): add collapsible panes for error output and final command #818

### DIFF
--- a/frontend/src/pages/TaskDetails.tsx
+++ b/frontend/src/pages/TaskDetails.tsx
@@ -241,6 +241,42 @@ const itemVariants = {
     visible: { opacity: 1, y: 0 }
 }
 
+function CollapsiblePane({
+    content,
+    maxCollapsedLength = 300,
+    label = 'content',
+    prefix = '',
+}: {
+    content?: string
+    maxCollapsedLength?: number
+    label?: string
+    prefix?: string
+}) {
+    const [expanded, setExpanded] = useState(false)
+    const text = content || ''
+    const isLong = text.length > maxCollapsedLength
+    const display = !isLong || expanded ? text : text.slice(0, maxCollapsedLength) + '…'
+
+    return (
+        <div className="space-y-2">
+            <div className="border border-white/6 bg-black/30 p-4 font-mono text-[11px] text-rag-blue/80 break-all leading-6 whitespace-pre-wrap">
+                {prefix && <span className="text-silver/20 mr-2">{prefix}</span>}
+                {display}
+            </div>
+            {isLong && (
+                <button
+                    type="button"
+                    onClick={() => setExpanded((prev) => !prev)}
+                    aria-expanded={expanded}
+                    className="text-[9px] uppercase tracking-[0.15em] text-rag-blue/70 hover:text-rag-blue font-black transition-colors"
+                >
+                    {expanded ? `[ COLLAPSE ${label.toUpperCase()} ]` : `[ EXPAND ${label.toUpperCase()} ]`}
+                </button>
+            )}
+        </div>
+    )
+}
+
 function DetailIcon({
     icon,
     size = 18,
@@ -911,9 +947,7 @@ export default function TaskDetails() {
                             <DetailIcon icon={AlertCircleIcon} />
                             <h3 className="text-xs font-black uppercase tracking-[0.3em] italic">Critical_Execution_Fault</h3>
                         </div>
-                        <p className="text-sm font-mono text-silver/80 leading-relaxed max-w-4xl">
-                            {task.error_message}
-                        </p>
+                        <CollapsiblePane content={task.error_message} maxCollapsedLength={400} label="error output" />
                         <div className="pt-2">
                             <span className="text-[9px] font-black text-silver/30 uppercase tracking-[0.2em] italic">Diagnostic_Code::EXEC_FAIL_{task.exit_code || 'ERR'}</span>
                         </div>
@@ -1297,10 +1331,7 @@ export default function TaskDetails() {
                                             <h3 className="text-xs font-black text-silver-bright uppercase tracking-[0.36em] italic">Final Command</h3>
                                             <div className="h-px flex-1 bg-white/8" />
                                         </div>
-                                        <div className="border border-white/6 bg-black/30 p-4 font-mono text-[11px] text-rag-blue/80 break-all leading-6">
-                                            <span className="text-silver/20 mr-2">$</span>
-                                            {result.command_used}
-                                        </div>
+                                        <CollapsiblePane content={result.command_used} maxCollapsedLength={200} label="command" prefix="$ " />
                                     </motion.div>
                                 )}
                                 <motion.div variants={itemVariants} className="border border-white/8 bg-charcoal p-6">
@@ -1446,10 +1477,7 @@ export default function TaskDetails() {
                                 <h3 className="text-xs font-black text-silver-bright uppercase tracking-[0.36em] italic">Operational Command</h3>
                                 <div className="h-px flex-1 bg-white/8" />
                             </div>
-                            <div className="border border-white/6 bg-black/30 p-4 font-mono text-[10px] text-rag-blue/70 break-all italic leading-6">
-                                <span className="text-silver/20 mr-2">$</span>
-                                {result.command_used}
-                            </div>
+                            <CollapsiblePane content={result.command_used} maxCollapsedLength={150} label="command" prefix="$ " />
                         </section>
                     )}
                 </aside>

--- a/frontend/testing/unit/pages/TaskDetails.collapsible.test.tsx
+++ b/frontend/testing/unit/pages/TaskDetails.collapsible.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import TaskDetails from '../../../src/pages/TaskDetails'
+import { getTaskStatus, getTaskResult, getPluginSchema } from '../../../src/api'
+import { useTaskSubscription } from '../../../src/hooks/useTaskSubscription'
+
+vi.mock('../../../src/api', () => ({
+  getTaskStatus: vi.fn(),
+  getTaskResult: vi.fn(),
+  getPluginSchema: vi.fn(),
+  startTask: vi.fn(),
+  API_BASE: 'http://127.0.0.1:8000',
+}))
+
+vi.mock('../../../src/hooks/useTaskSubscription', () => ({
+  useTaskSubscription: vi.fn(),
+}))
+
+vi.mock('../../../src/components/ToastContext', () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}))
+
+const baseTask = {
+  task_id: 'task-1',
+  plugin_id: 'nmap',
+  tool: 'nmap',
+  target: 'example.com',
+  status: 'failed',
+  created_at: '2026-05-14T10:00:00Z',
+  started_at: '2026-05-14T10:00:00Z',
+  completed_at: '2026-05-14T10:05:00Z',
+  exit_code: 1,
+  error_message: 'X'.repeat(600),
+}
+
+function renderTaskDetails() {
+  return render(
+    <MemoryRouter initialEntries={['/task/task-1']}>
+      <Routes>
+        <Route path="/task/:taskId" element={<TaskDetails />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  vi.mocked(getTaskStatus).mockResolvedValue(baseTask)
+  vi.mocked(getTaskResult).mockResolvedValue(null)
+  vi.mocked(getPluginSchema).mockResolvedValue({ fields: [], presets: {} } as any)
+  vi.mocked(useTaskSubscription).mockImplementation(() => ({} as any))
+})
+
+describe('TaskDetails — collapsible error output', () => {
+  it('collapses long error_message and shows an expand control', async () => {
+    renderTaskDetails()
+
+    const expandBtn = await screen.findByRole('button', { name: /expand error output/i })
+    expect(expandBtn).toBeInTheDocument()
+    expect(expandBtn).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('expands the error output when the expand button is clicked', async () => {
+    const user = (await import('@testing-library/user-event')).default.setup()
+    renderTaskDetails()
+
+    const expandBtn = await screen.findByRole('button', { name: /expand error output/i })
+    await user.click(expandBtn)
+
+    expect(screen.getByRole('button', { name: /collapse error output/i })).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('does not show an expand control for short error_message', async () => {
+    vi.mocked(getTaskStatus).mockResolvedValue({ ...baseTask, error_message: 'short error' })
+    renderTaskDetails()
+
+    await screen.findByText('short error')
+    expect(screen.queryByRole('button', { name: /expand error output/i })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Description

Added a reusable `CollapsiblePane` component in `TaskDetails.tsx` and applied it to sections that previously rendered long content fully expanded:

* `error_message` / `stderr` block displayed for failed tasks
* `Final Command` block shown in both the Parameters tab and the sidebar

Long content is now collapsed by default and can be expanded or collapsed with a toggle, improving readability and reducing visual clutter when reviewing large scan results.

The existing Raw Output tab was left unchanged because it already provides search, line wrapping, and a scrollable container for large output.

## Related Issues

Closes #818

## Type of Change

* [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Added `frontend/testing/unit/pages/TaskDetails.collapsible.test.tsx` with 3 focused tests:

* Long `error_message` renders in a collapsed state with an expand control
* Expanding content updates the control and `aria-expanded` state correctly
* Short `error_message` renders without an expand/collapse control

### Test Command

```bash
npm test
```

### Result

* All 3 new tests passed
* Full frontend test suite passed locally (360 tests)

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] My changes generate no new warnings.
