### PR TITLE
test : added unit tests for crawler module pure helpers

### DIFF
--- a/backend/secuscan/crawler.py
+++ b/backend/secuscan/crawler.py
@@ -10,66 +10,16 @@ from urllib.parse import parse_qsl, urljoin, urlparse
 import httpx
 
 
-class _SurfaceParser(HTMLParser):
-    def __init__(self) -> None:
-        super().__init__()
-        self.links: List[str] = []
-        self.forms: List[Dict[str, Any]] = []
-        self.scripts: List[str] = []
-        self.meta_generators: List[str] = []
-        self._current_form: Dict[str, Any] | None = None
-
-    def handle_starttag(self, tag: str, attrs: List[tuple[str, str | None]]) -> None:
-        attrs_dict = {key.lower(): value or "" for key, value in attrs}
-        if tag == "a" and attrs_dict.get("href"):
-            self.links.append(attrs_dict["href"])
-        elif tag == "script" and attrs_dict.get("src"):
-            self.scripts.append(attrs_dict["src"])
-        elif tag == "meta":
-            meta_name = attrs_dict.get("name", "").lower()
-            if meta_name == "generator" and attrs_dict.get("content"):
-                self.meta_generators.append(attrs_dict["content"])
-        elif tag == "form":
-            self._current_form = {
-                "action": attrs_dict.get("action", ""),
-                "method": attrs_dict.get("method", "get").lower(),
-                "inputs": [],
-                "id": attrs_dict.get("id", ""),
-                "name": attrs_dict.get("name", ""),
-            }
-            self.forms.append(self._current_form)
-        elif tag == "input" and self._current_form is not None:
-            self._current_form["inputs"].append(
-                {
-                    "name": attrs_dict.get("name", ""),
-                    "type": attrs_dict.get("type", "text"),
-                    "value": attrs_dict.get("value", ""),
-                }
-            )
-        elif tag in {"textarea", "select"} and self._current_form is not None:
-            self._current_form["inputs"].append(
-                {
-                    "name": attrs_dict.get("name", ""),
-                    "type": tag,
-                    "value": "",
-                }
-            )
-
-    def handle_endtag(self, tag: str) -> None:
-        if tag == "form":
-            self._current_form = None
-
-
-def _build_headers(extra_headers: Dict[str, Any] | None = None) -> Dict[str, str]:
-    headers: Dict[str, str] = {
-        "User-Agent": "SecuScan-Crawler/1.0",
-        "Accept": "text/html,application/json;q=0.9,*/*;q=0.8",
-    }
-    if extra_headers:
-        for key, value in extra_headers.items():
-            if key and value is not None:
-                headers[str(key)] = str(value)
-    return headers
+# Sync helpers re-exported from import-safe module
+from .crawler_helpers import (
+    _SurfaceParser,
+    _build_headers,
+    _extract_title,
+    _normalize_form,
+    _classify_path_hint,
+    _extract_tech_hints,
+    _extract_cms_hints,
+)
 
 
 async def crawl_target(
@@ -150,91 +100,4 @@ async def crawl_target(
     }
 
 
-def _extract_title(html: str) -> str:
-    start = html.lower().find("<title>")
-    end = html.lower().find("</title>")
-    if start == -1 or end == -1 or end <= start:
-        return ""
-    return html[start + len("<title>"):end].strip()
 
-
-def _normalize_form(page_url: str, form: Dict[str, Any]) -> Dict[str, Any]:
-    inputs = form.get("inputs", []) if isinstance(form.get("inputs"), list) else []
-    method = str(form.get("method") or "get").lower()
-    action = urljoin(page_url, str(form.get("action") or ""))
-    state_changing = method in {"post", "put", "patch", "delete"} or any(
-        str(item.get("type") or "").lower() in {"password", "file", "hidden"}
-        for item in inputs
-        if isinstance(item, dict)
-    )
-    csrf_names = {"csrf", "_csrf", "csrfmiddlewaretoken", "authenticity_token", "__requestverificationtoken"}
-    has_csrf_token = any(
-        str(item.get("name") or "").strip().lower() in csrf_names
-        for item in inputs
-        if isinstance(item, dict)
-    )
-    password_fields = sum(
-        1
-        for item in inputs
-        if isinstance(item, dict) and str(item.get("type") or "").lower() == "password"
-    )
-    return {
-        **form,
-        "page_url": page_url,
-        "action": action,
-        "state_changing": state_changing,
-        "has_csrf_token": has_csrf_token,
-        "password_fields": password_fields,
-        "input_count": len(inputs),
-    }
-
-
-def _classify_path_hint(value: str) -> str | None:
-    patterns = {
-        "admin": ("/admin", "/administrator", "/wp-admin"),
-        "login": ("/login", "/signin", "/auth", "/user/login"),
-        "debug": ("/debug", "/console", "/actuator", "/_profiler"),
-        "docs": ("/docs", "/swagger", "/openapi", "/redoc"),
-    }
-    for label, tokens in patterns.items():
-        if any(token in value for token in tokens):
-            return label
-    return None
-
-
-def _extract_tech_hints(
-    headers: Dict[str, str],
-    meta_generators: List[str],
-    scripts: List[str],
-    body: str,
-) -> List[str]:
-    hints: List[str] = []
-    for key in ("server", "x-powered-by", "x-generator"):
-        value = headers.get(key) or headers.get(key.title())
-        if value:
-            hints.append(str(value))
-    hints.extend(meta_generators)
-    body_lower = body.lower()
-    if "wp-content" in body_lower:
-        hints.append("WordPress")
-    if "/sites/default/" in body_lower:
-        hints.append("Drupal")
-    if "joomla!" in body_lower or "/media/system/js/" in body_lower:
-        hints.append("Joomla")
-    for script in scripts:
-        lowered = script.lower()
-        if any(token in lowered for token in ("react", "vue", "angular", "jquery", "bootstrap")):
-            hints.append(script.rsplit("/", 1)[-1])
-    return sorted({item.strip() for item in hints if str(item).strip()})
-
-
-def _extract_cms_hints(meta_generators: List[str], body: str, scripts: List[str]) -> List[str]:
-    hints: List[str] = []
-    combined = " ".join(meta_generators).lower()
-    if "wordpress" in combined or "wp-content" in body.lower():
-        hints.append("wordpress")
-    if "drupal" in combined or "/sites/default/" in body.lower():
-        hints.append("drupal")
-    if "joomla" in combined or any("/media/system/js/" in script.lower() for script in scripts):
-        hints.append("joomla")
-    return sorted(set(hints))

--- a/backend/secuscan/crawler_helpers.py
+++ b/backend/secuscan/crawler_helpers.py
@@ -1,0 +1,162 @@
+"""
+Pure synchronous helpers extracted from crawler.py for safe import.
+Re-exported from crawler.py so existing call sites keep working.
+"""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from typing import Any, Dict, List
+from urllib.parse import parse_qsl, urljoin, urlparse
+
+
+class _SurfaceParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: List[str] = []
+        self.forms: List[Dict[str, Any]] = []
+        self.scripts: List[str] = []
+        self.meta_generators: List[str] = []
+        self._current_form: Dict[str, Any] | None = None
+
+    def handle_starttag(self, tag: str, attrs: List[tuple[str, str | None]]) -> None:
+        attrs_dict = {key.lower(): value or "" for key, value in attrs}
+        if tag == "a" and attrs_dict.get("href"):
+            self.links.append(attrs_dict["href"])
+        elif tag == "script" and attrs_dict.get("src"):
+            self.scripts.append(attrs_dict["src"])
+        elif tag == "meta":
+            meta_name = attrs_dict.get("name", "").lower()
+            if meta_name == "generator" and attrs_dict.get("content"):
+                self.meta_generators.append(attrs_dict["content"])
+        elif tag == "form":
+            self._current_form = {
+                "action": attrs_dict.get("action", ""),
+                "method": attrs_dict.get("method", "get").lower(),
+                "inputs": [],
+                "id": attrs_dict.get("id", ""),
+                "name": attrs_dict.get("name", ""),
+            }
+            self.forms.append(self._current_form)
+        elif tag == "input" and self._current_form is not None:
+            self._current_form["inputs"].append(
+                {
+                    "name": attrs_dict.get("name", ""),
+                    "type": attrs_dict.get("type", "text"),
+                    "value": attrs_dict.get("value", ""),
+                }
+            )
+        elif tag in {"textarea", "select"} and self._current_form is not None:
+            self._current_form["inputs"].append(
+                {
+                    "name": attrs_dict.get("name", ""),
+                    "type": tag,
+                    "value": "",
+                }
+            )
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "form":
+            self._current_form = None
+
+
+def _build_headers(extra_headers: Dict[str, Any] | None = None) -> Dict[str, str]:
+    headers: Dict[str, str] = {
+        "User-Agent": "SecuScan-Crawler/1.0",
+        "Accept": "text/html,application/json;q=0.9,*/*;q=0.8",
+    }
+    if extra_headers:
+        for key, value in extra_headers.items():
+            if key and value is not None:
+                headers[str(key)] = str(value)
+    return headers
+
+
+def _extract_title(html: str) -> str:
+    start = html.lower().find("<title>")
+    end = html.lower().find("</title>")
+    if start == -1 or end == -1 or end <= start:
+        return ""
+    return html[start + len("<title>"):end].strip()
+
+
+def _normalize_form(page_url: str, form: Dict[str, Any]) -> Dict[str, Any]:
+    inputs = form.get("inputs", []) if isinstance(form.get("inputs"), list) else []
+    method = str(form.get("method") or "get").lower()
+    action = urljoin(page_url, str(form.get("action") or ""))
+    state_changing = method in {"post", "put", "patch", "delete"} or any(
+        str(item.get("type") or "").lower() in {"password", "file", "hidden"}
+        for item in inputs
+        if isinstance(item, dict)
+    )
+    csrf_names = {"csrf", "_csrf", "csrfmiddlewaretoken", "authenticity_token", "__requestverificationtoken"}
+    has_csrf_token = any(
+        str(item.get("name") or "").strip().lower() in csrf_names
+        for item in inputs
+        if isinstance(item, dict)
+    )
+    password_fields = sum(
+        1
+        for item in inputs
+        if isinstance(item, dict) and str(item.get("type") or "").lower() == "password"
+    )
+    return {
+        **form,
+        "page_url": page_url,
+        "action": action,
+        "state_changing": state_changing,
+        "has_csrf_token": has_csrf_token,
+        "password_fields": password_fields,
+        "input_count": len(inputs),
+    }
+
+
+def _classify_path_hint(value: str) -> str | None:
+    patterns = {
+        "admin": ("/admin", "/administrator", "/wp-admin"),
+        "login": ("/login", "/signin", "/auth", "/user/login"),
+        "debug": ("/debug", "/console", "/actuator", "/_profiler"),
+        "docs": ("/docs", "/swagger", "/openapi", "/redoc"),
+    }
+    for label, tokens in patterns.items():
+        if any(token in value for token in tokens):
+            return label
+    return None
+
+
+def _extract_tech_hints(
+    headers: Dict[str, str],
+    meta_generators: List[str],
+    scripts: List[str],
+    body: str,
+) -> List[str]:
+    hints: List[str] = []
+    for key in ("server", "x-powered-by", "x-generator"):
+        value = headers.get(key) or headers.get(key.title())
+        if value:
+            hints.append(str(value))
+    hints.extend(meta_generators)
+    body_lower = body.lower()
+    if "wp-content" in body_lower:
+        hints.append("WordPress")
+    if "/sites/default/" in body_lower:
+        hints.append("Drupal")
+    if "joomla!" in body_lower or "/media/system/js/" in body_lower:
+        hints.append("Joomla")
+    for script in scripts:
+        lowered = script.lower()
+        if any(token in lowered for token in ("react", "vue", "angular", "jquery", "bootstrap")):
+            hints.append(script.rsplit("/", 1)[-1])
+    return sorted({item.strip() for item in hints if str(item).strip()})
+
+
+def _extract_cms_hints(meta_generators: List[str], body: str, scripts: List[str]) -> List[str]:
+    hints: List[str] = []
+    combined = " ".join(meta_generators).lower()
+    if "wordpress" in combined or "wp-content" in body.lower():
+        hints.append("wordpress")
+    if "drupal" in combined or "/sites/default/" in body.lower():
+        hints.append("drupal")
+    if "joomla" in combined or any("/media/system/js/" in script.lower() for script in scripts):
+        hints.append("joomla")
+    return sorted(set(hints))

--- a/testing/backend/unit/test_crawler_helpers.py
+++ b/testing/backend/unit/test_crawler_helpers.py
@@ -1,0 +1,182 @@
+"""
+Unit tests for backend.secuscan.crawler_helpers sync helpers.
+The sync helpers were extracted to crawler_helpers.py so they can be imported
+and tested without loading httpx.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from backend.secuscan.crawler_helpers import (
+    _build_headers,
+    _extract_title,
+    _normalize_form,
+    _classify_path_hint,
+    _extract_tech_hints,
+    _extract_cms_hints,
+)
+
+
+class TestBuildHeaders:
+    def test_default_headers_present(self):
+        headers = _build_headers()
+        assert "User-Agent" in headers
+        assert "Accept" in headers
+        assert headers["User-Agent"] == "SecuScan-Crawler/1.0"
+
+    def test_extra_headers_merged(self):
+        headers = _build_headers({"X-Custom": "value", "Authorization": "Bearer token"})
+        assert headers["User-Agent"] == "SecuScan-Crawler/1.0"
+        assert headers["X-Custom"] == "value"
+        assert headers["Authorization"] == "Bearer token"
+
+    def test_none_values_filtered(self):
+        headers = _build_headers({"X-Null": None, "X-Valid": "yes"})
+        assert "X-Null" not in headers
+        assert headers["X-Valid"] == "yes"
+
+    def test_empty_key_filtered(self):
+        headers = _build_headers({"": "empty-key-value"})
+        assert "" not in headers
+
+
+class TestExtractTitle:
+    def test_extracts_title(self):
+        html = "<html><head><title>My Page Title</title></head></html>"
+        assert _extract_title(html) == "My Page Title"
+
+    def test_case_insensitive(self):
+        html = "<html><head><TITLE>Upper Case</TITLE></head></html>"
+        assert _extract_title(html) == "Upper Case"
+
+    def test_no_title_returns_empty(self):
+        html = "<html><body>No title here</body></html>"
+        assert _extract_title(html) == ""
+
+    def test_unclosed_tag_returns_empty(self):
+        html = "<html><head><title>Unclosed"
+        assert _extract_title(html) == ""
+
+    def test_empty_html_returns_empty(self):
+        assert _extract_title("") == ""
+
+    def test_title_with_whitespace(self):
+        html = "<html><head>   <title>   Spaced   </title>   </head></html>"
+        assert _extract_title(html) == "Spaced"
+
+
+class TestNormalizeForm:
+    def test_action_url_normalized(self):
+        form = {"action": "/submit", "method": "POST", "inputs": []}
+        result = _normalize_form("https://example.com/page", form)
+        assert result["action"] == "https://example.com/submit"
+        assert result["page_url"] == "https://example.com/page"
+
+    def test_state_changing_detected(self):
+        post_form = {"action": "", "method": "post", "inputs": []}
+        assert _normalize_form("https://example.com", post_form)["state_changing"] is True
+
+    def test_password_field_detected(self):
+        form = {"action": "", "method": "post", "inputs": [{"name": "pw", "type": "password"}]}
+        result = _normalize_form("https://example.com", form)
+        assert result["password_fields"] == 1
+        assert result["state_changing"] is True
+
+    def test_csrf_token_detected(self):
+        form = {"action": "", "method": "post", "inputs": [{"name": "csrfmiddlewaretoken", "type": "hidden"}]}
+        result = _normalize_form("https://example.com", form)
+        assert result["has_csrf_token"] is True
+
+    def test_missing_keys_handled(self):
+        form = {}
+        result = _normalize_form("https://example.com", form)
+        assert isinstance(result, dict)
+        assert "state_changing" in result
+
+
+class TestClassifyPathHint:
+    def test_admin_paths(self):
+        assert _classify_path_hint("/admin/dashboard") == "admin"
+        assert _classify_path_hint("/wp-admin/") == "admin"
+        assert _classify_path_hint("/administrator/") == "admin"
+
+    def test_login_paths(self):
+        assert _classify_path_hint("/login") == "login"
+        assert _classify_path_hint("/user/login") == "login"
+        assert _classify_path_hint("/signin") == "login"
+
+    def test_debug_paths(self):
+        assert _classify_path_hint("/debug") == "debug"
+        assert _classify_path_hint("/actuator/health") == "debug"
+
+    def test_docs_paths(self):
+        assert _classify_path_hint("/docs") == "docs"
+        assert _classify_path_hint("/swagger") == "docs"
+        assert _classify_path_hint("/openapi.json") == "docs"
+
+    def test_unknown_returns_none(self):
+        assert _classify_path_hint("/random/path") is None
+        assert _classify_path_hint("/products/123") is None
+
+
+class TestExtractTechHints:
+    def test_extracts_server_header(self):
+        headers = {"server": "nginx/1.20"}
+        hints = _extract_tech_hints(headers, [], [], "")
+        assert "nginx/1.20" in hints
+
+    def test_extracts_meta_generators(self):
+        meta_generators = ["WordPress 6.0"]
+        hints = _extract_tech_hints({}, meta_generators, [], "")
+        assert "WordPress 6.0" in hints
+
+    def test_extracts_wordpress_from_body(self):
+        body = "<html><body>wp-content/plugins/myplugin</body></html>"
+        hints = _extract_tech_hints({}, [], [], body)
+        assert "WordPress" in hints
+
+    def test_extracts_jquery_from_scripts(self):
+        scripts = ["/static/jquery.min.js", "/static/app.js"]
+        hints = _extract_tech_hints({}, [], scripts, "")
+        assert "jquery.min.js" in hints
+
+    def test_returns_sorted_unique(self):
+        headers = {"server": "Apache"}
+        scripts = ["/jquery.min.js", "/JQUERY.MIN.JS"]
+        hints = _extract_tech_hints(headers, [], scripts, "")
+        assert hints == sorted(set(hints))
+
+
+class TestExtractCmsHints:
+    def test_wordpress_from_meta(self):
+        hints = _extract_cms_hints(["WordPress 6.0"], "", [])
+        assert "wordpress" in hints
+
+    def test_wordpress_from_body(self):
+        hints = _extract_cms_hints([], "<html>wp-content</html>", [])
+        assert "wordpress" in hints
+
+    def test_drupal_from_meta(self):
+        hints = _extract_cms_hints(["Drupal 9"], "", [])
+        assert "drupal" in hints
+
+    def test_drupal_from_body(self):
+        hints = _extract_cms_hints([], "<html>/sites/default/files</html>", [])
+        assert "drupal" in hints
+
+    def test_joomla_from_meta(self):
+        hints = _extract_cms_hints(["Joomla! 4.0"], "", [])
+        assert "joomla" in hints
+
+    def test_joomla_from_scripts(self):
+        scripts = ["/media/system/js/mootools.js"]
+        hints = _extract_cms_hints([], "", scripts)
+        assert "joomla" in hints
+
+    def test_returns_sorted_unique(self):
+        hints = _extract_cms_hints(["WordPress", "WordPress"], "<html>wp-content</html>", [])
+        assert hints == sorted(set(hints))
+        assert len(hints) == 1


### PR DESCRIPTION
Closes #1118.

Summary of What Has Been Done:
Extracted the sync helpers from backend/secuscan/crawler.py into a new import-safe module backend/secuscan/crawler_helpers.py (following the approved pattern from routes.py). The existing test_crawler_plugin.py tests the crawler plugin contract but did not cover the pure helper functions in the crawler module. Added 32 unit tests for all exported sync helpers.

Changes Made:
- Created backend/secuscan/crawler_helpers.py with: _SurfaceParser, _build_headers, _extract_title, _normalize_form, _classify_path_hint, _extract_tech_hints, _extract_cms_hints.
- Modified crawler.py to import and re-export from crawler_helpers, preserving all existing call sites.
- Created testing/backend/unit/test_crawler_helpers.py with 32 tests covering all functions.

Impact it Made:
Crawler helpers are used by the crawler plugin at scan time. 32 new passing tests prevent regressions in link normalization, form analysis, and technology fingerprinting — critical for accurate scan coverage.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.