### PR TITLE
docs: add vulnerability triage decision table to dependency audit guide

### DIFF
--- a/docs/dependency_audit_operator_guide.md
+++ b/docs/dependency_audit_operator_guide.md
@@ -89,3 +89,17 @@ To generate a CycloneDX 1.4 compatible SBOM containing all frontend and backend 
 ```bash
 python scripts/generate_sbom.py --output sbom.json --include-dev
 ```
+
+---
+
+## 3. Vulnerability Triage Decision Table
+
+When an audit surfaces a finding, use the following table to classify it into one of three categories and determine the appropriate operator response. Classification is driven by severity, exploitability, and whether the affected package ships to production.
+
+| Category | Criteria | Operator Action | Example |
+| :--- | :--- | :--- | :--- |
+| **Informational** | `low` severity findings with no exploit path, or findings confined to dev-only dependencies. | Note and monitor; no immediate action required. | A `low` CVE in a build-time dev dependency that is not shipped to production. |
+| **Urgent** | `high` or `critical` findings with a known fix available, or a plausible exploit path in production dependencies. | Schedule a patch within the current sprint and file a tracking ticket. | A `high` CVE in a runtime HTTP library with a patched version released. |
+| **Blocking** | `critical` findings with active exploitation, no available fix, or affecting authentication/secrets handling. | Stop deployment; apply mitigation or a temporary exception with security-team approval immediately. | A `critical` RCE in a core runtime dependency with no patch. |
+
+Blocking findings that require a temporary allowance to unblock deployment must be documented using the exception format described in [Section 1](#1-exception-configuration-format).


### PR DESCRIPTION
Add a Section 3 triage decision table distinguishing informational, urgent, and blocking dependency findings, with operator actions and examples. Cross-links to the exception format in Section 1.

## Description
Adds a triage decision table to the dependency audit operator guide so 
operators can quickly classify findings as informational, urgent, or 
blocking, with clear actions and examples for each.

## Related Issues
Closes #867

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- Verified the new Section 3 follows the existing file's numbered-section
  and table-formatting conventions
- Confirmed the cross-link anchor `#1-exception-configuration-format`
  resolves to Section 1
- Spot-checked that no existing content was altered (lines 1–91 unchanged)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
