### PR TITLE
feat : add copy finding ID action

### DIFF
--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -966,16 +966,6 @@ export default function Findings() {
     <span className="text-xs font-mono text-silver/60">
       ID: {selectedFinding.id}
     </span>
-
-    <button
-      type="button"
-      onClick={() => copyFindingId(selectedFinding.id)}
-      className="border border-rag-blue/25 bg-rag-blue/10 px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-rag-blue"
-    >
-      {copiedFindingId === selectedFinding.id
-        ? 'Copied'
-        : 'Copy ID'}
-    </button>
   </div>
 </div>
 
@@ -1169,13 +1159,11 @@ export default function Findings() {
                         {copiedFindingId === selectedFinding.id ? 'Copied' : 'Copy Brief'}
                       </button>
                       <button
-                      type="button"
-                      onClick={() => copyFindingId(selectedFinding.id)}
-                      className="border border-rag-green/25 bg-rag-green/10 px-4 py-3 text-[10px] font-black uppercase tracking-[0.18em] text-rag-green"
->
-                      {copiedFindingId === selectedFinding.id
-                      ? 'ID Copied'
-                       : 'Copy ID'}
+                        type="button"
+                        onClick={() => copyFindingId(selectedFinding.id)}
+                        className="border border-rag-green/25 bg-rag-green/10 px-4 py-3 text-[10px] font-black uppercase tracking-[0.18em] text-rag-green"
+                      >
+                        {copiedFindingId === selectedFinding.id ? 'Copied' : 'Copy ID'}
                       </button>
                     </div>
                   </div>

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -468,7 +468,21 @@ export default function Findings() {
       setCopiedFindingId(null)
     }
   }
+  async function copyFindingId(findingId: string) {
+  try {
+    await navigator.clipboard.writeText(findingId)
 
+    setCopiedFindingId(findingId)
+
+    window.setTimeout(() => {
+      setCopiedFindingId((current) =>
+        current === findingId ? null : current
+      )
+    }, 1600)
+  } catch {
+    setCopiedFindingId(null)
+  }
+}
   // ─── Keyboard navigation ────────────────────────────────────────────────────
   const listRef = useRef<HTMLDivElement>(null)
 
@@ -940,9 +954,30 @@ export default function Findings() {
                     </div>
 
                     <div>
-                      <p className="mb-2 text-[10px] font-black uppercase tracking-[0.2em] text-silver/35">Selected Finding</p>
-                      <h2 className="text-3xl font-black uppercase italic tracking-tight text-silver-bright">{selectedFinding.title}</h2>
-                    </div>
+  <p className="mb-2 text-[10px] font-black uppercase tracking-[0.2em] text-silver/35">
+    Selected Finding
+  </p>
+
+  <h2 className="text-3xl font-black uppercase italic tracking-tight text-silver-bright">
+    {selectedFinding.title}
+  </h2>
+
+  <div className="mt-3 flex items-center gap-2">
+    <span className="text-xs font-mono text-silver/60">
+      ID: {selectedFinding.id}
+    </span>
+
+    <button
+      type="button"
+      onClick={() => copyFindingId(selectedFinding.id)}
+      className="border border-rag-blue/25 bg-rag-blue/10 px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-rag-blue"
+    >
+      {copiedFindingId === selectedFinding.id
+        ? 'Copied'
+        : 'Copy ID'}
+    </button>
+  </div>
+</div>
 
                     <div className="grid gap-3 sm:grid-cols-2">
                       <div className="border border-silver-bright/8 bg-charcoal-dark p-3">
@@ -1132,6 +1167,15 @@ export default function Findings() {
                         className="border border-rag-blue/25 bg-rag-blue/10 px-4 py-3 text-[10px] font-black uppercase tracking-[0.18em] text-rag-blue"
                       >
                         {copiedFindingId === selectedFinding.id ? 'Copied' : 'Copy Brief'}
+                      </button>
+                      <button
+                      type="button"
+                      onClick={() => copyFindingId(selectedFinding.id)}
+                      className="border border-rag-green/25 bg-rag-green/10 px-4 py-3 text-[10px] font-black uppercase tracking-[0.18em] text-rag-green"
+>
+                      {copiedFindingId === selectedFinding.id
+                      ? 'ID Copied'
+                       : 'Copy ID'}
                       </button>
                     </div>
                   </div>

--- a/frontend/testing/unit/pages/Findings.test.tsx
+++ b/frontend/testing/unit/pages/Findings.test.tsx
@@ -231,6 +231,42 @@ describe('Findings — virtualized list', () => {
     })
   })
 
+  it('copies finding id and shows success feedback', async () => {
+    const findings = [makeFinding({ id: 'f1', title: 'ID Copy Test' })]
+    vi.mocked(getFindings).mockResolvedValue({ findings })
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    })
+
+    render(<Findings />)
+    await waitFor(() => expect(screen.queryByText('Synchronizing findings feed...')).not.toBeInTheDocument())
+
+    const copyButton = screen.getByRole('button', { name: /Copy ID/i })
+    await userEvent.click(copyButton)
+
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('f1'))
+    expect(copyButton).toHaveTextContent('Copied')
+  })
+
+  it('keeps copy state idle when finding id copy fails', async () => {
+    const findings = [makeFinding({ id: 'f2', title: 'ID Copy Failure Test' })]
+    vi.mocked(getFindings).mockResolvedValue({ findings })
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error('clipboard unavailable')) },
+    })
+
+    render(<Findings />)
+    await waitFor(() => expect(screen.queryByText('Synchronizing findings feed...')).not.toBeInTheDocument())
+
+    const copyButton = screen.getByRole('button', { name: /Copy ID/i })
+    await userEvent.click(copyButton)
+
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('f2'))
+    expect(copyButton).toHaveTextContent('Copy ID')
+  })
+
   it('persists review state to localStorage', async () => {
     const findings = [makeFinding({ id: 'f1', title: 'Persist Test', severity: 'high' })]
     vi.mocked(getFindings).mockResolvedValue({ findings })


### PR DESCRIPTION
Description

Added a new "Copy Finding ID" action to vulnerability/finding cards. Users can now copy a finding identifier directly to their clipboard with a single click instead of manually selecting and copying the ID.

Changes Made

- Added a "Copy Finding ID" button in the finding details view.
- Implemented Clipboard API support for copying finding IDs.
- Added success feedback after a successful copy action.
- Supported both desktop and mobile browsers.

Related Issues

Closes #1039

Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

How Has This Been Tested?

1. Started the frontend application locally.
2. Opened the Findings page.
3. Selected multiple findings with different IDs.
4. Clicked the "Copy Finding ID" button.
5. Pasted the copied value into a text editor.
6. Verified that the pasted value matched the displayed finding ID.
7. Verified success feedback appears after copying.
8. Tested functionality in desktop and mobile browser views.

Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.