### PR TITLE
 fix : refresh scan status badges automatically

### DIFF
--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -89,7 +89,9 @@ export default function Scans() {
 
   function startPolling() {
     stopPolling();
-    intervalRef.current = setInterval(loadTasks, 5000);
+    intervalRef.current = setInterval(() => {
+  loadTasks();
+}, 3000);
   }
 
   function stopPolling() {
@@ -148,7 +150,8 @@ export default function Scans() {
       const data = await res.json();
       if (requestSeq !== requestSeqRef.current) return;
 
-      setTasks(data.tasks || []);
+      console.log("Tasks refreshed:", data.tasks);
+setTasks([...(data.tasks || [])]);
       if (data.pagination?.total_items !== undefined) {
         setTotal(data.pagination.total_items);
       }

--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -90,8 +90,8 @@ export default function Scans() {
   function startPolling() {
     stopPolling();
     intervalRef.current = setInterval(() => {
-  loadTasks();
-}, 5000);
+      loadTasks();
+    }, 5000);
   }
 
   function stopPolling() {
@@ -150,8 +150,7 @@ export default function Scans() {
       const data = await res.json();
       if (requestSeq !== requestSeqRef.current) return;
 
-      console.log("Tasks refreshed:", data.tasks);
-setTasks([...(data.tasks || [])]);
+      setTasks([...(data.tasks || [])]);
       if (data.pagination?.total_items !== undefined) {
         setTotal(data.pagination.total_items);
       }

--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -91,7 +91,7 @@ export default function Scans() {
     stopPolling();
     intervalRef.current = setInterval(() => {
   loadTasks();
-}, 3000);
+}, 5000);
   }
 
   function stopPolling() {

--- a/frontend/testing/unit/pages/Scans.polling.test.tsx
+++ b/frontend/testing/unit/pages/Scans.polling.test.tsx
@@ -135,6 +135,51 @@ describe('Scans — visibility-aware polling', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 
+  it('updates scan status badges automatically during polling', async () => {
+    const runningResponse = {
+      tasks: [{
+        task_id: 'task-123',
+        plugin_id: 'nmap',
+        tool: 'Automatic Status Scan',
+        target: 'auto.example.com',
+        status: 'running',
+        created_at: '2026-05-29T10:00:00Z',
+        started_at: '2026-05-29T10:01:00Z',
+      }],
+      pagination: { total_items: 1 },
+    };
+
+    const completedResponse = {
+      tasks: [{
+        task_id: 'task-123',
+        plugin_id: 'nmap',
+        tool: 'Automatic Status Scan',
+        target: 'auto.example.com',
+        status: 'completed',
+        created_at: '2026-05-29T10:00:00Z',
+        started_at: '2026-05-29T10:01:00Z',
+        completed_at: '2026-05-29T10:05:00Z',
+      }],
+      pagination: { total_items: 1 },
+    };
+
+    fetchSpy.mockReset();
+    fetchSpy
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(runningResponse) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(completedResponse) } as Response);
+
+    renderScans();
+    await flush();
+
+    expect(screen.getByText('running')).toBeInTheDocument();
+
+    await tickTime(5_000);
+    await flush();
+
+    expect(screen.getByText('completed')).toBeInTheDocument();
+    expect(screen.queryByText('running')).not.toBeInTheDocument();
+  });
+
   it('stops polling entirely when the tab is hidden', async () => {
     renderScans();
     await flush();


### PR DESCRIPTION
Description

This PR improves task list updates in the Scans page by creating a new array reference when updating the task state.

Changes Made

- Replaced:
  setTasks(data.tasks || []);
- With:
  setTasks([...(data.tasks || [])]);

This ensures React receives a new array reference on every polling cycle and reliably re-renders the task list when task statuses change.

Related Issues

Closes #1041

Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

How Has This Been Tested?

1. Started the frontend using "npm run dev".
2. Started a scan task.
3. Monitored task status updates on the Scans page.
4. Verified that task status changes are reflected correctly during polling.
5. Confirmed no build or runtime errors were introduced.

Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.