### PR TITLE
feat: expose notification retry backoff configuration in admin diagnostics

### DIFF
--- a/backend/secuscan/models.py
+++ b/backend/secuscan/models.py
@@ -348,6 +348,14 @@ class NotificationHistoryResponse(BaseModel):
     sent_at: datetime
 
 
+class NotificationDiagnosticsResponse(BaseModel):
+    """Diagnostic configuration details for notification delivery."""
+    webhook_timeout_seconds: float
+    webhook_connect_timeout_seconds: float
+    max_retries: int
+    backoff_factor_seconds: float
+
+
 class BulkDeleteRequest(RootModel[Annotated[List[str], Field(max_length=MAX_BULK_DELETE)]]):
     """Accepts a JSON array of task IDs directly. Max 500 per request."""
     pass

--- a/backend/secuscan/notification_service.py
+++ b/backend/secuscan/notification_service.py
@@ -47,6 +47,15 @@ _WEBHOOK_TIMEOUT_SECONDS = 10.0
 _WEBHOOK_CONNECT_TIMEOUT_SECONDS = 5.0
 _USER_AGENT = "SecuScan-Notifications/1.0"
 
+def get_delivery_configuration() -> Dict[str, Any]:
+    """Return the currently active configuration for notification delivery."""
+    return {
+        "webhook_timeout_seconds": _WEBHOOK_TIMEOUT_SECONDS,
+        "webhook_connect_timeout_seconds": _WEBHOOK_CONNECT_TIMEOUT_SECONDS,
+        "max_retries": 0,
+        "backoff_factor_seconds": 0.0,
+    }
+
 SOCKET_OPTION = Tuple[int, int, int | bytes]
 
 

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -101,10 +101,12 @@ from .models import (
     NotificationRuleCreate, NotificationRuleUpdate,
     NotificationChannelType, TaskStatus,
     ExecutionContext, WorkflowStep, ValidationMode, EvidenceLevel,
+    NotificationDiagnosticsResponse,
 )
 from .config import settings
 from .database import get_db
 from .plugins import get_plugin_manager, init_plugins
+from . import notification_service
 from .executor import executor
 from .redaction import redact_inputs
 from .ratelimit import (
@@ -2247,6 +2249,15 @@ def verify_admin_access(
             detail="Invalid or missing Admin API Key"
         )
     return candidate
+
+@router.get(
+    "/admin/diagnostics/notifications",
+    response_model=NotificationDiagnosticsResponse,
+    dependencies=[Depends(verify_admin_access), Depends(admin_limiter)]
+)
+async def get_notification_diagnostics():
+    """Get active notification delivery configuration and retry policy"""
+    return notification_service.get_delivery_configuration()
 
 @router.get("/admin/network-policy", dependencies=[Depends(verify_admin_access), Depends(admin_limiter)])
 async def get_network_policy():

--- a/testing/backend/integration/test_notification_routes.py
+++ b/testing/backend/integration/test_notification_routes.py
@@ -153,3 +153,27 @@ def test_notification_history_list_contract(test_client):
     assert filtered_data["history"][0]["rule_id"] == rule_id
     assert filtered_data["history"][0]["finding_id"]
     assert filtered_data["history"][0]["status"] == "success"
+
+
+def test_admin_diagnostics_notifications(test_client, monkeypatch):
+    from backend.secuscan.config import settings
+
+    monkeypatch.setattr(settings, "admin_api_key", "secret-test-key-long")
+
+    # Unauthorized without key
+    unauth_resp = test_client.get("/api/v1/admin/diagnostics/notifications")
+    assert unauth_resp.status_code == 401
+
+    # Success with key
+    auth_resp = test_client.get(
+        "/api/v1/admin/diagnostics/notifications",
+        headers={"X-API-Key": "secret-test-key-long"},
+    )
+    assert auth_resp.status_code == 200
+    data = auth_resp.json()
+    assert "webhook_timeout_seconds" in data
+    assert "webhook_connect_timeout_seconds" in data
+    assert "max_retries" in data
+    assert "backoff_factor_seconds" in data
+    assert type(data["max_retries"]) is int
+    assert type(data["webhook_timeout_seconds"]) is float


### PR DESCRIPTION
## Description
This PR provides operators with a structured way to inspect the active notification retry policy and delivery backoff settings by exposing a new admin diagnostics endpoint. 

Changes included:
- Added `NotificationDiagnosticsResponse` schema to represent the configuration contract.
- Implemented `get_delivery_configuration()` helper in `notification_service.py`.
- Exposed `GET /api/v1/admin/diagnostics/notifications` route protected by existing admin verification and rate limiting.
- Added integration tests to ensure the endpoint contract is maintained and authentication works as expected.

## Related Issues
Fixes #801

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
I wrote a new integration test (`test_admin_diagnostics_notifications`) and verified the behavior by running `pytest testing/backend/integration/test_notification_routes.py`. 

The test verifies:
- Unauthenticated access returns HTTP 401.
- Authenticated access using a mocked `admin_api_key` returns HTTP 200.
- The returned JSON payload strictly adheres to the `NotificationDiagnosticsResponse` contract, containing the correct keys and data types.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
