### PR TITLE
Add plugin enumeration latency diagnostics to health endpoint

### DIFF
--- a/backend/secuscan/main.py
+++ b/backend/secuscan/main.py
@@ -25,10 +25,10 @@ from .config import settings
 from .auth import init_api_key
 from .cache import init_cache, cache as global_cache
 from .database import init_db, db as global_db
-from .plugins import init_plugins
 from .routes import router
 from .saved_views import saved_views_router
 from .workflows import scheduler
+from .plugins import init_plugins, get_plugin_check_latency_ms
 
 logging.basicConfig(
     level=getattr(logging, settings.log_level),
@@ -219,7 +219,8 @@ async def health_check():
             "platform": platform.system(),
             "python_version": sys.version.split()[0],
             "docker_available": shutil.which("docker") is not None,
-        }
+        },
+        "plugin_check_latency_ms": get_plugin_check_latency_ms(),
     }
 
 # Root endpoint

--- a/backend/secuscan/plugins.py
+++ b/backend/secuscan/plugins.py
@@ -2,6 +2,7 @@
 Plugin loader and management system
 """
 
+import time
 import json
 import os
 import re
@@ -694,3 +695,15 @@ def get_plugin_manager() -> PluginManager:
     if plugin_manager is None:
         raise RuntimeError("Plugin manager not initialized")
     return plugin_manager
+
+def get_plugin_check_latency_ms() -> float:
+    """Measure plugin enumeration latency in milliseconds."""
+    manager = get_plugin_manager()
+
+    start = time.perf_counter()
+    manager.list_plugins()
+
+    return round(
+        (time.perf_counter() - start) * 1000,
+        2,
+    )

--- a/testing/backend/integration/test_routes.py
+++ b/testing/backend/integration/test_routes.py
@@ -10,6 +10,12 @@ def test_health_check(test_client):
     data = response.json()
     assert data["status"] == "operational"
     assert "version" in data
+    assert "plugin_check_latency_ms" in data
+    assert isinstance(
+        data["plugin_check_latency_ms"],
+        (int, float),
+    )
+    assert data["plugin_check_latency_ms"] >= 0
 
 def test_list_plugins(test_client):
     """Test plugins list endpoint."""


### PR DESCRIPTION
## Description
- Added plugin enumeration latency diagnostics to the /api/v1/health endpoint.
- Introduced get_plugin_check_latency_ms() in backend/secuscan/plugins.py to measure plugin listing latency.
- Updated the health check response to expose plugin_check_latency_ms.
- Added integration test coverage to verify the new metric is present and returns a non-negative numeric value.

## Related Issues
Closes #803 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran the health endpoint integration test:

pytest testing/backend/integration/test_routes.py -k health_check -v

Result:

testing/backend/integration/test_routes.py::test_health_check PASSED

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
