### PR TITLE
fix(settings): prevent management tools button text overflow (#952)

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -870,20 +870,19 @@ export default function Settings() {
                         <div className="space-y-4">
                             <button
                                 onClick={handleExport}
-                                className="w-full py-4 bg-charcoal-dark border-4 border-black text-[10px] font-black text-silver/40 uppercase tracking-[0.3em] hover:bg-black hover:text-white transition-all italic"
+                                className="w-full py-4 bg-charcoal-dark border-4 border-black text-[10px] font-black text-silver/40 uppercase tracking-[0.08em] whitespace-nowrap overflow-hidden hover:bg-black hover:text-white transition-all italic"
                             >
                                 TELEMETRY_EXPORT
                             </button>
                             <button
                                 onClick={handleReset}
-                                className="w-full py-4 bg-rag-amber border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all italic"
+                                className="w-full py-4 bg-rag-amber border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.08em] whitespace-nowrap overflow-hidden hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all italic"
                             >
                                 ENGINE_RESET
                             </button>
                             <button
                                 onClick={handleNuclearPurge}
-                                className="w-full py-4 bg-rag-red border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.3em] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-1 transition-all italic"
-                            >
+                                className="w-full py-4 bg-rag-red border-4 border-black text-[10px] font-black text-black uppercase tracking-[0.08em] whitespace-nowrap overflow-hidden hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-1 transition-all italic"                            >
                                 NUCLEAR_PURGE
                             </button>
                         </div>

--- a/frontend/testing/unit/pages/SettingsExport.test.tsx
+++ b/frontend/testing/unit/pages/SettingsExport.test.tsx
@@ -137,3 +137,44 @@ describe('Settings export flow', () => {
     vi.restoreAllMocks()
   })
 })
+
+describe('Management Tools button overflow fix', () => {
+  beforeEach(() => {
+    localStorage.removeItem('secuscan-config')
+    vi.mocked(listNotificationRules).mockResolvedValue([])
+  })
+
+  it('renders all three management tool buttons', () => {
+    renderSettings()
+    expect(screen.getByRole('button', { name: /TELEMETRY_EXPORT/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /ENGINE_RESET/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /NUCLEAR_PURGE/i })).toBeInTheDocument()
+  })
+
+  it('TELEMETRY_EXPORT button does not use overflow-breaking letter-spacing class', () => {
+    renderSettings()
+    const btn = screen.getByRole('button', { name: /TELEMETRY_EXPORT/i })
+    expect(btn.className).not.toContain('tracking-[0.3em]')
+    expect(btn.className).toContain('tracking-[0.08em]')
+    expect(btn.className).toContain('whitespace-nowrap')
+    expect(btn.className).toContain('overflow-hidden')
+  })
+
+  it('ENGINE_RESET button does not use overflow-breaking letter-spacing class', () => {
+    renderSettings()
+    const btn = screen.getByRole('button', { name: /ENGINE_RESET/i })
+    expect(btn.className).not.toContain('tracking-[0.3em]')
+    expect(btn.className).toContain('tracking-[0.08em]')
+    expect(btn.className).toContain('whitespace-nowrap')
+    expect(btn.className).toContain('overflow-hidden')
+  })
+
+  it('NUCLEAR_PURGE button does not use overflow-breaking letter-spacing class', () => {
+    renderSettings()
+    const btn = screen.getByRole('button', { name: /NUCLEAR_PURGE/i })
+    expect(btn.className).not.toContain('tracking-[0.3em]')
+    expect(btn.className).toContain('tracking-[0.08em]')
+    expect(btn.className).toContain('whitespace-nowrap')
+    expect(btn.className).toContain('overflow-hidden')
+  })
+})


### PR DESCRIPTION
## Description

Fixes #952

Buttons `TELEMETRY_EXPORT`, `ENGINE_RESET`, and `NUCLEAR_PURGE` in the `Management_Tools` sidebar card were using `tracking-[0.3em]`, which adds 0.3em of letter-spacing per character. On labels 13–16 chars long this accumulates to ~5em of extra width, causing the text to visually overflow past the button's colored background boundary.

**Fix:**
- `tracking-[0.3em]` → `tracking-[0.08em]` on all three buttons (retains the spaced-out aesthetic without breaking containment)
- Added `whitespace-nowrap` to prevent awkward line-wrapping at narrow sidebar widths
- Added `overflow-hidden` as a hard clipping safety net

## Screenshots

### Before
Text in all three buttons extended past the colored background boundary, most visible on `TELEMETRY_EXPORT` (longest label at 16 chars).

### After
<img width="1920" height="1020" alt="Screenshot 2026-06-21 150036" src="https://github.com/user-attachments/assets/56fd4a1c-be2e-44cd-9757-8b1bb1ad6054" />

## Related Issues

Fixes #952

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Unit tests** — added 4 tests to `frontend/testing/unit/pages/SettingsExport.test.tsx`:
- All three buttons render in the DOM
- `TELEMETRY_EXPORT` button has `tracking-[0.08em]`, `whitespace-nowrap`, `overflow-hidden` and does NOT have `tracking-[0.3em]`
- `ENGINE_RESET` button — same assertions
- `NUCLEAR_PURGE` button — same assertions

All 8 tests pass (4 pre-existing + 4 new).

**Visual** — verified locally at `http://localhost:5173/settings`. All three button labels are fully contained within their respective background colors.

> Note: `frontend-checks` may flag a pre-existing `vite`/`esbuild` CVE — this is a known upstream issue, not introduced by this change.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.