### PR TITLE
fix(#1136): replace localStorage with in-memory + HttpOnly session cookie

### DIFF
--- a/backend/secuscan/auth.py
+++ b/backend/secuscan/auth.py
@@ -5,19 +5,99 @@ A random key is generated at startup and written to <data_dir>/.api_key.
 Clients must supply it via:
   - Authorization: Bearer <key>
   - X-Api-Key: <key>
+
+Session management:
+  - POST /api/v1/auth/session — validate API key and set HttpOnly session cookie
+  - GET  /api/v1/auth/session/check — verify active session cookie
+  - POST /api/v1/auth/session/logout — clear session cookie
 """
 
 import os
 import secrets
+import time
 from pathlib import Path
+from datetime import datetime, timedelta
 
-from fastapi import Depends, HTTPException, Security, status, Request
+from fastapi import Depends, HTTPException, Security, status, Request, Response
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
+from fastapi import APIRouter
 
 _bearer_scheme = HTTPBearer(auto_error=False)
 _api_key_header = APIKeyHeader(name="X-Api-Key", auto_error=False)
 
 _api_key: str | None = None
+
+SESSION_TTL_SECONDS = 3600  # 1 hour
+_active_sessions: dict[str, dict] = {}
+
+auth_router = APIRouter(prefix="/api/v1/auth")
+
+
+@auth_router.post("/session")
+async def create_session(request: Request, response: Response):
+    """Validate the API key and set an HttpOnly session cookie.
+
+    The client sends the API key via the X-Api-Key header (or Authorization
+    Bearer).  On success the server sets an HttpOnly / Secure / SameSite=Strict
+    cookie so the key itself never needs to touch localStorage.
+    """
+    if _api_key is None:
+        raise HTTPException(status_code=503, detail="Authentication service not initialised")
+
+    candidate = request.headers.get("X-Api-Key")
+    if not candidate:
+        bearer = request.headers.get("Authorization", "")
+        if bearer.lower().startswith("bearer "):
+            candidate = bearer[7:]
+
+    if not candidate or not secrets.compare_digest(candidate, _api_key):
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    session_token = secrets.token_urlsafe(32)
+    _active_sessions[session_token] = {"created_at": time.time()}
+
+    response.set_cookie(
+        key="secuscan_session",
+        value=session_token,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        max_age=SESSION_TTL_SECONDS,
+    )
+    return {"status": "authenticated"}
+
+
+@auth_router.get("/session/check")
+async def check_session(request: Request):
+    """Return whether the request carries a valid session cookie."""
+    session_token = request.cookies.get("secuscan_session")
+    if session_token and session_token in _active_sessions:
+        session = _active_sessions[session_token]
+        if time.time() - session["created_at"] < SESSION_TTL_SECONDS:
+            return {"authenticated": True}
+        del _active_sessions[session_token]
+    return {"authenticated": False}
+
+
+@auth_router.post("/session/logout")
+async def logout_session(request: Request, response: Response):
+    """Destroy the session cookie."""
+    session_token = request.cookies.get("secuscan_session")
+    if session_token and session_token in _active_sessions:
+        del _active_sessions[session_token]
+    response.delete_cookie("secuscan_session")
+    return {"status": "logged_out"}
+
+
+def is_authenticated_by_session(request: Request) -> bool:
+    """Check if the request has a valid session cookie (used by require_api_key fallback)."""
+    session_token = request.cookies.get("secuscan_session")
+    if session_token and session_token in _active_sessions:
+        session = _active_sessions[session_token]
+        if time.time() - session["created_at"] < SESSION_TTL_SECONDS:
+            return True
+        del _active_sessions[session_token]
+    return False
 
 
 def init_api_key(data_dir: str) -> str:
@@ -47,16 +127,20 @@ async def require_api_key(
     x_api_key: str | None = Security(_api_key_header),
 ) -> str:
     """
-    FastAPI dependency — rejects requests that do not carry the correct API key.
+    FastAPI dependency — rejects requests that do not carry the correct API key
+    or a valid session cookie.
 
     Accepts the key in either:
     - ``Authorization: Bearer <key>``
     - ``X-Api-Key: <key>``
+    - Valid ``secuscan_session`` HttpOnly cookie (set via POST /auth/session)
     """
     if request is not None and request.url.path.startswith("/api/v1/admin"):
-        # Admin endpoints have their own separate verify_admin_access dependency.
-        # We bypass require_api_key verification to avoid blocking valid admin key requests.
         return ""
+
+    # Allow requests authenticated via session cookie
+    if request is not None and is_authenticated_by_session(request):
+        return "session-authenticated"
 
     if _api_key is None:
         raise HTTPException(

--- a/backend/secuscan/auth.py
+++ b/backend/secuscan/auth.py
@@ -42,7 +42,9 @@ async def create_session(request: Request, response: Response):
     cookie so the key itself never needs to touch localStorage.
     """
     if _api_key is None:
-        raise HTTPException(status_code=503, detail="Authentication service not initialised")
+        raise HTTPException(
+            status_code=503, detail="Authentication service not initialised"
+        )
 
     candidate = request.headers.get("X-Api-Key")
     if not candidate:

--- a/backend/secuscan/main.py
+++ b/backend/secuscan/main.py
@@ -22,7 +22,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from .request_context import get_request_id
 
 from .config import settings
-from .auth import init_api_key
+from .auth import init_api_key, auth_router
 from .cache import init_cache, cache as global_cache
 from .database import init_db, db as global_db
 from .plugins import init_plugins
@@ -200,6 +200,7 @@ async def custom_unhandled_exception_handler(request: Request, exc: Exception):
     return response
 
 # Include API routes
+app.include_router(auth_router)  # No require_api_key dependency — auth endpoints must be public
 app.include_router(router)
 app.include_router(saved_views_router)
 

--- a/backend/secuscan/main.py
+++ b/backend/secuscan/main.py
@@ -36,8 +36,8 @@ logging.basicConfig(
         logging.StreamHandler(sys.stdout),
         logging.FileHandler(settings.log_file)
         if Path(settings.log_file).parent.exists()
-        else logging.NullHandler()
-    ]
+        else logging.NullHandler(),
+    ],
 )
 
 from .logging_utils import RequestIDFilter, JSONFormatter
@@ -48,27 +48,30 @@ for handler in logging.getLogger().handlers:
 
 logger = logging.getLogger(__name__)
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan manager"""
     # Startup
     logger.info("🚀 Starting SecuScan backend...")
-    
+
     # Ensure directories exist
     settings.ensure_directories()
     logger.info("✓ Directories initialized")
 
     # Initialize API key authentication
     api_key = init_api_key(settings.data_dir)
-    logger.info("✓ API key authentication ready (key file: %s/.api_key)", settings.data_dir)
-    
+    logger.info(
+        "✓ API key authentication ready (key file: %s/.api_key)", settings.data_dir
+    )
+
     # Initialize database
     await init_db(settings.database_path)
     logger.info("✓ SQLite connected")
 
     await init_cache()
     logger.info("✓ In-memory cache initialized")
-    
+
     # Load plugins
     await init_plugins(settings.plugins_dir)
     logger.info("✓ Plugins loaded")
@@ -76,50 +79,78 @@ async def lifespan(app: FastAPI):
     # If docker is enabled, verify and auto-create the restricted docker network
     if settings.docker_enabled:
         if shutil.which("docker"):
-            logger.info(f"Docker is enabled. Verifying network '{settings.docker_network}'...")
+            logger.info(
+                f"Docker is enabled. Verifying network '{settings.docker_network}'..."
+            )
             try:
                 import subprocess
+
                 res = subprocess.run(
                     ["docker", "network", "inspect", settings.docker_network],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )
                 if res.returncode != 0:
-                    logger.info(f"Docker network '{settings.docker_network}' not found. Creating isolated bridge network (ICC disabled)...")
+                    logger.info(
+                        f"Docker network '{settings.docker_network}' not found. Creating isolated bridge network (ICC disabled)..."
+                    )
                     creation_res = subprocess.run(
                         [
-                            "docker", "network", "create",
-                            "--driver", "bridge",
-                            "--opt", "com.docker.network.bridge.enable_icc=false",
-                            settings.docker_network
+                            "docker",
+                            "network",
+                            "create",
+                            "--driver",
+                            "bridge",
+                            "--opt",
+                            "com.docker.network.bridge.enable_icc=false",
+                            settings.docker_network,
                         ],
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
                     )
                     if creation_res.returncode != 0:
-                        logger.warning("Failed to create isolated bridge network with ICC disabled. Falling back to standard bridge...")
+                        logger.warning(
+                            "Failed to create isolated bridge network with ICC disabled. Falling back to standard bridge..."
+                        )
                         subprocess.run(
-                            ["docker", "network", "create", "--driver", "bridge", settings.docker_network],
+                            [
+                                "docker",
+                                "network",
+                                "create",
+                                "--driver",
+                                "bridge",
+                                settings.docker_network,
+                            ],
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.DEVNULL,
                         )
-                        logger.info(f"✓ Docker network '{settings.docker_network}' created (fallback)")
+                        logger.info(
+                            f"✓ Docker network '{settings.docker_network}' created (fallback)"
+                        )
                     else:
-                        logger.info(f"✓ Docker network '{settings.docker_network}' created with ICC disabled")
+                        logger.info(
+                            f"✓ Docker network '{settings.docker_network}' created with ICC disabled"
+                        )
                 else:
-                    logger.info(f"✓ Docker network '{settings.docker_network}' verified")
+                    logger.info(
+                        f"✓ Docker network '{settings.docker_network}' verified"
+                    )
             except Exception as e:
-                logger.warning(f"Failed to check/create Docker network '{settings.docker_network}': {e}")
+                logger.warning(
+                    f"Failed to check/create Docker network '{settings.docker_network}': {e}"
+                )
         else:
-            logger.warning("Docker sandboxing is enabled but 'docker' executable is not in PATH.")
+            logger.warning(
+                "Docker sandboxing is enabled but 'docker' executable is not in PATH."
+            )
 
     await scheduler.start()
     logger.info("✓ Workflow scheduler started")
-    
+
     logger.info("✓ Ready to serve on %s:%d", settings.bind_address, settings.bind_port)
-    
+
     yield
-    
+
     # Shutdown
     logger.info("🛑 Shutting down SecuScan backend...")
     if global_db:
@@ -129,6 +160,7 @@ async def lifespan(app: FastAPI):
     await scheduler.stop()
     logger.info("✓ Shutdown complete")
 
+
 # Create FastAPI application
 app = FastAPI(
     title="SecuScan API",
@@ -137,23 +169,30 @@ app = FastAPI(
     docs_url="/docs",
     redoc_url="/redoc",
     openapi_url="/openapi.json",
-    lifespan=lifespan
+    lifespan=lifespan,
 )
+
 
 @app.get("/api/docs", include_in_schema=False)
 async def redirect_api_docs():
     from fastapi.responses import RedirectResponse
+
     return RedirectResponse(url="/docs")
+
 
 @app.get("/api/redoc", include_in_schema=False)
 async def redirect_api_redoc():
     from fastapi.responses import RedirectResponse
+
     return RedirectResponse(url="/redoc")
+
 
 @app.get("/api/openapi.json", include_in_schema=False)
 async def redirect_api_openapi():
     from fastapi.responses import RedirectResponse
+
     return RedirectResponse(url="/openapi.json")
+
 
 # CORS middleware
 cors_allow_all = "*" in settings.cors_allowed_origins
@@ -172,18 +211,26 @@ app.add_middleware(
 )
 app.add_middleware(RequestIDMiddleware)
 
+
 @app.exception_handler(StarletteHTTPException)
 async def custom_http_exception_handler(request: Request, exc: StarletteHTTPException):
     response = await http_exception_handler(request, exc)
-    response.headers["X-Request-ID"] = getattr(request.state, "request_id", get_request_id())
+    response.headers["X-Request-ID"] = getattr(
+        request.state, "request_id", get_request_id()
+    )
     return response
 
 
 @app.exception_handler(RequestValidationError)
-async def custom_validation_exception_handler(request: Request, exc: RequestValidationError):
+async def custom_validation_exception_handler(
+    request: Request, exc: RequestValidationError
+):
     response = await request_validation_exception_handler(request, exc)
-    response.headers["X-Request-ID"] = getattr(request.state, "request_id", get_request_id())
+    response.headers["X-Request-ID"] = getattr(
+        request.state, "request_id", get_request_id()
+    )
     return response
+
 
 @app.exception_handler(Exception)
 async def custom_unhandled_exception_handler(request: Request, exc: Exception):
@@ -191,16 +238,22 @@ async def custom_unhandled_exception_handler(request: Request, exc: Exception):
 
     if settings.debug:
         import traceback
+
         html = f"<html><body><h1>500 Internal Server Error</h1><pre>{traceback.format_exc()}</pre></body></html>"
         response = HTMLResponse(html, status_code=500)
     else:
         response = PlainTextResponse("Internal Server Error", status_code=500)
 
-    response.headers["X-Request-ID"] = getattr(request.state, "request_id", get_request_id())
+    response.headers["X-Request-ID"] = getattr(
+        request.state, "request_id", get_request_id()
+    )
     return response
 
+
 # Include API routes
-app.include_router(auth_router)  # No require_api_key dependency — auth endpoints must be public
+app.include_router(
+    auth_router
+)  # No require_api_key dependency — auth endpoints must be public
 app.include_router(router)
 app.include_router(saved_views_router)
 
@@ -211,7 +264,7 @@ async def health_check():
     """Health check endpoint"""
     import platform
     import sys
-    
+
     logger.info("Health check endpoint accessed")
     return {
         "status": "operational",
@@ -220,8 +273,9 @@ async def health_check():
             "platform": platform.system(),
             "python_version": sys.version.split()[0],
             "docker_available": shutil.which("docker") is not None,
-        }
+        },
     }
+
 
 # Root endpoint
 @app.get("/")
@@ -232,13 +286,14 @@ async def root():
         "version": "0.1.0-alpha",
         "status": "under development",
         "api_docs": f"{settings.base_url}/api/docs" if settings.debug else None,
-        "legal_notice": "For authorized testing only. Unauthorized scanning may be illegal."
+        "legal_notice": "For authorized testing only. Unauthorized scanning may be illegal.",
     }
+
 
 def main():
     """Main entry point"""
     import uvicorn
-    
+
     logger.info("""
     ╔═══════════════════════════════════════════════════════╗
     ║                                                       ║
@@ -249,14 +304,15 @@ def main():
     ║                                                       ║
     ╚═══════════════════════════════════════════════════════╝
     """)
-    
+
     uvicorn.run(
         "backend.secuscan.main:app",
         host=settings.bind_address,
         port=settings.bind_port,
         reload=settings.debug,
-        log_level=settings.log_level.lower()
+        log_level=settings.log_level.lower(),
     )
+
 
 if __name__ == "__main__":
     main()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ import { ThemeProvider } from './components/ThemeContext'
 import { ToastProvider } from './components/ToastContext'
 import { I18nProvider } from './components/I18nContext'
 import { routes } from './routes'
-import { AUTH_REQUIRED_EVENT, getStoredApiKey } from './api'
+import { AUTH_REQUIRED_EVENT, getStoredApiKey, checkAuthSession } from './api'
 
 export function AppRoutes() {
   return (
@@ -40,8 +40,15 @@ export function AppRoutes() {
 }
 
 export default function App() {
-  // True when setup is needed: no key stored, or any request got a 401.
-  const [needsKey, setNeedsKey] = useState(() => !getStoredApiKey())
+  const [needsKey, setNeedsKey] = useState(true)
+  const [checkingSession, setCheckingSession] = useState(true)
+
+  useEffect(() => {
+    checkAuthSession().then((authenticated) => {
+      setNeedsKey(!authenticated)
+      setCheckingSession(false)
+    })
+  }, [])
 
   useEffect(() => {
     function onAuthRequired() {
@@ -50,6 +57,10 @@ export default function App() {
     window.addEventListener(AUTH_REQUIRED_EVENT, onAuthRequired)
     return () => window.removeEventListener(AUTH_REQUIRED_EVENT, onAuthRequired)
   }, [])
+
+  if (checkingSession) {
+    return null
+  }
 
   return (
     <ThemeProvider>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -288,26 +288,63 @@ export interface TaskStartResponse {
   stream_url: string
 }
 
-const API_KEY_STORAGE_KEY = 'secuscan_api_key'
+let _apiKey: string | null = null
 
 export function getStoredApiKey(): string | null {
-  try {
-    return localStorage.getItem(API_KEY_STORAGE_KEY) || null
-  } catch {
-    return null
-  }
+  return _apiKey
 }
 
 export function setStoredApiKey(key: string): void {
-  try {
-    localStorage.setItem(API_KEY_STORAGE_KEY, key)
-  } catch {
-    // ignore storage errors
+  _apiKey = key
+}
+
+export function clearStoredApiKey(): void {
+  _apiKey = null
+}
+
+export async function authenticateWithApiKey(apiKey: string): Promise<void> {
+  const response = await fetch(`${API_BASE}/auth/session`, {
+    method: 'POST',
+    headers: { 'X-Api-Key': apiKey },
+    credentials: 'include',
+  })
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}))
+    throw new Error(body?.detail || 'Authentication failed')
   }
+  _apiKey = apiKey
+}
+
+export async function checkAuthSession(): Promise<boolean> {
+  try {
+    const response = await fetch(`${API_BASE}/auth/session/check`, {
+      credentials: 'include',
+    })
+    const data = await response.json()
+    if (data.authenticated) {
+      _apiKey = 'session-authenticated'
+      return true
+    }
+  } catch {
+    // ignore
+  }
+  return false
+}
+
+export async function logoutSession(): Promise<void> {
+  try {
+    await fetch(`${API_BASE}/auth/session/logout`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+  } catch {
+    // ignore
+  }
+  _apiKey = null
 }
 
 function getApiKey(): string | null {
-  return getStoredApiKey()
+  return _apiKey
 }
 
 /** Fired on the window when any API request receives HTTP 401. */

--- a/frontend/src/components/ApiKeySetupModal.tsx
+++ b/frontend/src/components/ApiKeySetupModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { setStoredApiKey } from '../api'
+import { authenticateWithApiKey } from '../api'
 
 interface Props {
   onSaved: () => void
@@ -10,24 +10,29 @@ interface Props {
  *
  * Shown when the app receives HTTP 401 or detects no stored API key.
  * The operator reads the key from `backend/data/.api_key`, pastes it here,
- * and clicks Save. The key is written only to localStorage (secuscan_api_key);
- * it is never sent to any server other than as the X-Api-Key request header.
+ * and clicks Save. The key is sent to the backend which validates it and
+ * sets an HttpOnly session cookie; the raw key is never persisted in the
+ * browser.
  */
 export default function ApiKeySetupModal({ onSaved }: Props) {
   const [key, setKey] = useState('')
   const [visible, setVisible] = useState(false)
   const [error, setError] = useState('')
 
-  function handleSave() {
+  async function handleSave() {
     const trimmed = key.trim()
     if (!trimmed) {
       setError('Please enter the API key.')
       return
     }
-    setStoredApiKey(trimmed)
-    setKey('')
-    setError('')
-    onSaved()
+    try {
+      await authenticateWithApiKey(trimmed)
+      setKey('')
+      setError('')
+      onSaved()
+    } catch (err: any) {
+      setError(err?.message || 'Authentication failed. Check the API key.')
+    }
   }
 
   return (
@@ -116,8 +121,8 @@ export default function ApiKeySetupModal({ onSaved }: Props) {
           Save and connect
         </button>
         <p style={{ marginTop: '1rem', color: '#64748b', fontSize: 12 }}>
-          The key is stored only in your browser's localStorage and sent exclusively
-          as the <code>X-Api-Key</code> request header — it is never stored server-side.
+          The key is sent to the backend which validates it and sets an HttpOnly
+          session cookie. The raw key is never persisted in the browser.
         </p>
       </div>
     </div>

--- a/frontend/src/components/ApiKeySetupScreen.tsx
+++ b/frontend/src/components/ApiKeySetupScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { setStoredApiKey } from '../api'
+import { authenticateWithApiKey } from '../api'
 
 interface Props {
   onSaved: () => void
@@ -13,24 +13,27 @@ interface Props {
  * component mounts and no protected API call fires before the key is saved.
  *
  * The operator reads the key from the server key file and pastes it here.
- * The key is stored only in localStorage under `secuscan_api_key` and sent
- * exclusively as the `X-Api-Key` request header — never logged or stored
- * server-side.
+ * The key is sent to the backend which validates it and sets an HttpOnly
+ * session cookie; the raw key is never persisted in the browser.
  */
 export default function ApiKeySetupScreen({ onSaved }: Props) {
   const [key, setKey] = useState('')
   const [error, setError] = useState('')
 
-  function handleSave() {
+  async function handleSave() {
     const trimmed = key.trim()
     if (!trimmed) {
       setError('Please enter the API key.')
       return
     }
-    setStoredApiKey(trimmed)
-    setKey('')
-    setError('')
-    onSaved()
+    try {
+      await authenticateWithApiKey(trimmed)
+      setKey('')
+      setError('')
+      onSaved()
+    } catch (err: any) {
+      setError(err?.message || 'Authentication failed. Check the API key.')
+    }
   }
 
   return (
@@ -127,10 +130,9 @@ export default function ApiKeySetupScreen({ onSaved }: Props) {
           Save and connect
         </button>
         <p style={{ marginTop: '1.25rem', color: '#475569', fontSize: 12, lineHeight: 1.5 }}>
-          The key is stored only in your browser's <code>localStorage</code> under{' '}
-          <code>secuscan_api_key</code> and sent as the{' '}
-          <code>X-Api-Key</code> header on every API request. It is never transmitted
-          to any third party or stored on the server beyond the key file.
+          The key is sent to the backend which validates it and sets an HttpOnly
+          session cookie. The raw key is never persisted in the browser and is held
+          only in memory for the duration of the page session.
         </p>
       </div>
     </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -3,12 +3,14 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { useTheme } from '../components/ThemeContext'
 import { useToast } from '../components/ToastContext'
 import {
+  authenticateWithApiKey,
+  clearStoredApiKey,
   createNotificationRule,
   deleteNotificationRule,
   getStoredApiKey,
   listNotificationHistory,
   listNotificationRules,
-  setStoredApiKey,
+  logoutSession,
   updateNotificationRule,
   type NotificationChannelType,
   type NotificationHistoryRow,
@@ -205,20 +207,25 @@ export default function Settings() {
         }
     }
 
-    const handleSaveApiKey = () => {
+    const handleSaveApiKey = async () => {
         const trimmed = apiKey.trim()
         if (!trimmed) {
             addToast("API key cannot be empty", "error")
             return
         }
-        setStoredApiKey(trimmed)
-        addToast("API key saved — all future requests will use this key", "success")
+        try {
+            await authenticateWithApiKey(trimmed)
+            addToast("API key saved — all future requests will use this key", "success")
+        } catch (err: any) {
+            addToast(err?.message || "Authentication failed", "error")
+        }
     }
 
-    const handleClearApiKey = () => {
+    const handleClearApiKey = async () => {
         if (window.confirm("Clear the stored API key? The UI will return 401 errors until a valid key is configured.")) {
             setApiKey('')
-            setStoredApiKey('')
+            clearStoredApiKey()
+            await logoutSession()
             addToast("API key cleared", "info")
         }
     }
@@ -398,7 +405,7 @@ export default function Settings() {
                             <div className="space-y-2">
                                 <label className="text-[10px] font-black text-silver-bright uppercase tracking-widest block italic">Backend_API_Key</label>
                                 <p className="text-[10px] text-silver/40 uppercase font-bold italic mb-4 leading-relaxed">
-                                    Read from <span className="text-rag-blue font-mono">backend/data/.api_key</span> after starting the backend. Stored locally in browser — never sent to any remote server.
+                                    Read from <span className="text-rag-blue font-mono">backend/data/.api_key</span> after starting the backend. Sent to the backend which sets an HttpOnly session cookie — never persisted in browser storage.
                                 </p>
                             </div>
                             <div className="flex gap-4 items-stretch">

--- a/frontend/testing/unit/App.auth.gate.test.tsx
+++ b/frontend/testing/unit/App.auth.gate.test.tsx
@@ -1,16 +1,16 @@
 /**
- * App-level first-run auth gate tests (PR #278).
+ * App-level first-run auth gate tests.
  *
  * The core reviewer requirement: once auth is enabled, the app must NOT let
  * any protected API call fire before the operator has provided the key.
  *
  * Covers:
- * - No key stored → setup screen is rendered; no fetch() is called.
+ * - No session → setup screen is rendered; no data fetch is called.
  * - Saving a valid key → route tree replaces the setup screen.
  * - Saving an empty key → validation error; still on setup screen.
- * - Key already stored → app shell renders immediately; no setup screen.
+ * - Key (session) already established → app shell renders immediately.
  * - AUTH_REQUIRED_EVENT fired → setup screen re-appears; app shell hidden.
- * - New key saved after 401 → app shell returns; localStorage updated.
+ * - New key saved after 401 → app shell returns; key stored in memory.
  */
 
 import React from 'react'
@@ -60,44 +60,78 @@ vi.mock('../../src/pages/Workflows', () => ({
   default: () => React.createElement('div', { 'data-testid': 'page-workflows' }),
 }))
 
+vi.mock('../../src/api', async (importOriginal: () => Promise<Record<string, unknown>>) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    checkAuthSession: vi.fn(),
+    authenticateWithApiKey: vi.fn(),
+  }
+})
+
 import App from '../../src/App'
-import { AUTH_REQUIRED_EVENT, setStoredApiKey } from '../../src/api'
+import { AUTH_REQUIRED_EVENT, setStoredApiKey, clearStoredApiKey } from '../../src/api'
 
 // ---------------------------------------------------------------------------
 // Setup / teardown
 // ---------------------------------------------------------------------------
 
-beforeEach(() => {
+let mockCheckAuthSession: import('vitest').Mock<(...args: any[]) => any>
+let mockAuthenticateWithApiKey: import('vitest').Mock<(...args: any[]) => any>
+
+beforeEach(async () => {
+  clearStoredApiKey()
   localStorage.clear()
   vi.unstubAllGlobals()
+  const api = await import('../../src/api')
+  mockCheckAuthSession = api.checkAuthSession as import('vitest').Mock
+  mockAuthenticateWithApiKey = api.authenticateWithApiKey as import('vitest').Mock
+  mockCheckAuthSession.mockReset()
+  mockAuthenticateWithApiKey.mockReset()
 })
 
 afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
+  clearStoredApiKey()
   localStorage.clear()
 })
 
 // ---------------------------------------------------------------------------
-// First-run: no key stored
+// First-run: no session
 // ---------------------------------------------------------------------------
 
-describe('first-run gate (no key stored)', () => {
-  it('renders the setup screen instead of the app routes', () => {
+describe('first-run gate (no session)', () => {
+  beforeEach(() => {
+    mockCheckAuthSession.mockResolvedValue(false)
+    mockAuthenticateWithApiKey.mockResolvedValue(undefined)
+  })
+
+  it('renders the setup screen instead of the app routes', async () => {
     const { container } = render(React.createElement(App))
-    expect(screen.getByRole('main', { name: /api key setup/i })).toBeTruthy()
+    await waitFor(() =>
+      expect(screen.getByRole('main', { name: /api key setup/i })).toBeTruthy()
+    )
     expect(container.querySelector('[data-testid="app-shell"]')).toBeNull()
   })
 
-  it('does not call fetch() while the setup screen is showing', () => {
+  it('does not call fetch() while the setup screen is showing', async () => {
     const fetchSpy = vi.fn()
     vi.stubGlobal('fetch', fetchSpy)
     render(React.createElement(App))
+    // After the session check, the setup screen should be shown. No data-fetch
+    // call (beyond the checkAuthSession fetch) should fire.
+    await waitFor(() =>
+      expect(screen.getByRole('main', { name: /api key setup/i })).toBeTruthy()
+    )
+    // The checkAuthSession mock does not call real fetch, so fetchSpy is 0.
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
   it('shows the app shell after the operator saves a valid key', async () => {
     render(React.createElement(App))
+    await waitFor(() => screen.getByLabelText(/Backend API Key/i))
+
     fireEvent.change(screen.getByLabelText(/Backend API Key/i), {
       target: { value: 'my-operator-key' },
     })
@@ -109,20 +143,25 @@ describe('first-run gate (no key stored)', () => {
     expect(screen.getByTestId('app-shell')).toBeTruthy()
   })
 
-  it('persists the key to localStorage after save', async () => {
+  it('does not write the key to localStorage after save', async () => {
     render(React.createElement(App))
+    await waitFor(() => screen.getByLabelText(/Backend API Key/i))
+
     fireEvent.change(screen.getByLabelText(/Backend API Key/i), {
       target: { value: 'stored-key-abc' },
     })
     fireEvent.click(screen.getByText(/Save and connect/i))
 
     await waitFor(() =>
-      expect(localStorage.getItem('secuscan_api_key')).toBe('stored-key-abc')
+      expect(screen.queryByRole('main', { name: /api key setup/i })).toBeNull()
     )
+    expect(localStorage.getItem('secuscan_api_key')).toBeNull()
   })
 
-  it('shows a validation error and stays on setup screen for empty key', () => {
+  it('shows a validation error and stays on setup screen for empty key', async () => {
     render(React.createElement(App))
+    await waitFor(() => screen.getByLabelText(/Backend API Key/i))
+
     fireEvent.click(screen.getByText(/Save and connect/i))
     expect(screen.getByRole('alert')).toBeTruthy()
     expect(screen.getByRole('main', { name: /api key setup/i })).toBeTruthy()
@@ -130,6 +169,8 @@ describe('first-run gate (no key stored)', () => {
 
   it('saves key on Enter keypress in the input', async () => {
     render(React.createElement(App))
+    await waitFor(() => screen.getByLabelText(/Backend API Key/i))
+
     const input = screen.getByLabelText(/Backend API Key/i)
     fireEvent.change(input, { target: { value: 'enter-key-test' } })
     fireEvent.keyDown(input, { key: 'Enter' })
@@ -137,25 +178,30 @@ describe('first-run gate (no key stored)', () => {
     await waitFor(() =>
       expect(screen.queryByRole('main', { name: /api key setup/i })).toBeNull()
     )
-    expect(localStorage.getItem('secuscan_api_key')).toBe('enter-key-test')
+    expect(mockAuthenticateWithApiKey).toHaveBeenCalledWith('enter-key-test')
   })
 })
 
 // ---------------------------------------------------------------------------
-// Key already stored: app renders normally
+// Session already established: app renders normally
 // ---------------------------------------------------------------------------
 
-describe('key already stored', () => {
-  it('renders the app shell without the setup screen', () => {
-    setStoredApiKey('pre-seeded-key')
-    render(React.createElement(App))
-    expect(screen.queryByRole('main', { name: /api key setup/i })).toBeNull()
-    expect(screen.getByTestId('app-shell')).toBeTruthy()
+describe('session already established', () => {
+  beforeEach(() => {
+    mockCheckAuthSession.mockResolvedValue(true)
   })
 
-  it('does not render the setup screen when a whitespace-trimmed key exists', () => {
-    localStorage.setItem('secuscan_api_key', 'some-valid-key')
+  it('renders the app shell without the setup screen', async () => {
     render(React.createElement(App))
+    await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy())
+    expect(screen.queryByRole('main', { name: /api key setup/i })).toBeNull()
+  })
+
+  it('does not render the setup screen when a whitespace-trimmed key exists', async () => {
+    setStoredApiKey('some-valid-key')
+    mockCheckAuthSession.mockResolvedValue(true)
+    render(React.createElement(App))
+    await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy())
     expect(screen.queryByRole('main', { name: /api key setup/i })).toBeNull()
   })
 })
@@ -165,10 +211,14 @@ describe('key already stored', () => {
 // ---------------------------------------------------------------------------
 
 describe('401 re-triggers setup screen', () => {
+  beforeEach(() => {
+    mockCheckAuthSession.mockResolvedValue(true)
+    mockAuthenticateWithApiKey.mockResolvedValue(undefined)
+  })
+
   it('shows the setup screen when AUTH_REQUIRED_EVENT fires', async () => {
-    setStoredApiKey('valid-key')
     render(React.createElement(App))
-    expect(screen.getByTestId('app-shell')).toBeTruthy()
+    await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy())
 
     act(() => { window.dispatchEvent(new CustomEvent(AUTH_REQUIRED_EVENT)) })
 
@@ -179,8 +229,9 @@ describe('401 re-triggers setup screen', () => {
   })
 
   it('hides the setup screen after a new key is saved post-401', async () => {
-    setStoredApiKey('valid-key')
     render(React.createElement(App))
+    await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy())
+
     act(() => { window.dispatchEvent(new CustomEvent(AUTH_REQUIRED_EVENT)) })
     await waitFor(() => screen.getByRole('main', { name: /api key setup/i }))
 
@@ -193,12 +244,12 @@ describe('401 re-triggers setup screen', () => {
       expect(screen.queryByRole('main', { name: /api key setup/i })).toBeNull()
     )
     expect(screen.getByTestId('app-shell')).toBeTruthy()
-    expect(localStorage.getItem('secuscan_api_key')).toBe('new-key-after-401')
+    expect(mockAuthenticateWithApiKey).toHaveBeenCalledWith('new-key-after-401')
   })
 
   it('does not call fetch() after 401 until the new key is saved', async () => {
-    setStoredApiKey('old-key')
     render(React.createElement(App))
+    await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy())
 
     const fetchSpy = vi.fn()
     vi.stubGlobal('fetch', fetchSpy)

--- a/frontend/testing/unit/api.auth.test.ts
+++ b/frontend/testing/unit/api.auth.test.ts
@@ -16,6 +16,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   AUTH_REQUIRED_EVENT,
+  clearStoredApiKey,
   getStoredApiKey,
   setStoredApiKey,
   listPlugins,
@@ -39,6 +40,7 @@ function mockResponse(status: number, body: unknown = {}) {
 
 describe('getStoredApiKey / setStoredApiKey', () => {
   beforeEach(() => {
+    clearStoredApiKey()
     localStorage.clear()
   })
 
@@ -57,11 +59,9 @@ describe('getStoredApiKey / setStoredApiKey', () => {
     expect(getStoredApiKey()).toBe('new-key')
   })
 
-  it('stores the key only under secuscan_api_key', () => {
+  it('does not write the key to localStorage', () => {
     setStoredApiKey('abc123')
-    expect(localStorage.getItem('secuscan_api_key')).toBe('abc123')
-    // No other localStorage entry should be written by setStoredApiKey.
-    expect(localStorage.length).toBe(1)
+    expect(localStorage.getItem('secuscan_api_key')).toBeNull()
   })
 })
 
@@ -72,6 +72,7 @@ describe('getStoredApiKey / setStoredApiKey', () => {
 describe('request() X-Api-Key header', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    clearStoredApiKey()
     localStorage.clear()
   })
 


### PR DESCRIPTION
## Problem
The API key was stored in `localStorage` under `secuscan_api_key`, making it
accessible to any XSS attack — a single `localStorage.getItem("secuscan_api_key")`
exfiltrates the credential.

## Solution
- Moved the API key from `localStorage` to an in-memory module-level variable
  (`_apiKey` in `api.ts`)
- Added new backend endpoints under `/api/v1/auth/`:
  - `POST /session` — validates the key and sets an HttpOnly, Secure, SameSite=Strict
    session cookie
  - `GET /session/check` — verifies an existing session on page load
  - `POST /session/logout` — clears the session cookie
- Updated `require_api_key` dependency to also accept the session cookie as valid auth
- Frontend now calls `authenticateWithApiKey()` which POSTs the key to the backend;
  the raw key is held in memory for the tab's lifetime only
- `App.tsx` calls `checkAuthSession()` on mount to restore session across page refreshes
- All UI text references to localStorage removed

## Files changed
`backend/secuscan/auth.py`, `backend/secuscan/main.py`,
`frontend/src/api.ts`, `frontend/src/App.tsx`,
`frontend/src/components/ApiKeySetupScreen.tsx`,
`frontend/src/components/ApiKeySetupModal.tsx`,
`frontend/src/pages/Settings.tsx`

Closes #1136