### PR TITLE
test: add packet-loss-only coverage for icmp_ping parser

### DIFF
--- a/testing/backend/unit/test_executor.py
+++ b/testing/backend/unit/test_executor.py
@@ -133,6 +133,26 @@ Request timeout for icmp_seq 0
     assert result["metrics"]["filtered"] is True
 
 
+def test_icmp_ping_parser_handles_packet_loss_only_output(setup_test_environment):
+    manager = _ensure_plugins_loaded()
+    plugin = manager.get_plugin("icmp_ping")
+    assert plugin is not None
+
+    executor = TaskExecutor()
+    output = """PING 8.8.8.8 (8.8.8.8): 56 data bytes
+
+--- 8.8.8.8 ping statistics ---
+4 packets transmitted, 4 packets received, 0.0% packet loss
+"""
+
+    result = executor._parse_results(plugin, output)
+
+    assert result["count"] == 1
+    assert result["findings"][0]["title"] == "Host Reachable: 8.8.8.8"
+    assert result["metrics"]["packet_loss_percent"] == 0.0
+    assert result["metrics"]["reachable"] is True
+
+
 def test_classify_command_result_allows_nonfatal_ping_exit_with_statistics(setup_test_environment):
     manager = _ensure_plugins_loaded()
     plugin = manager.get_plugin("icmp_ping")


### PR DESCRIPTION
## Description
- Added coverage for `icmp_ping` packet-loss-only output.
- Added a parser fixture scenario where ping statistics are present without latency summary lines.
- Verified that the parser still reports host reachability and preserves packet loss metrics.
- Kept parser behavior unchanged and added focused regression coverage.

## Related Issues
Closes #839 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran the icmp_ping parser tests:

```bash
pytest testing/backend/unit/test_executor.py -k icmp_ping

Result:
2 passed, 22 deselected
```

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
