### PR TITLE
fix(security): enforce vault owner isolation with owner/name uniqueness

### DIFF
--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -274,8 +274,8 @@ class Database:
                 updated_at TIMESTAMP NOT NULL DEFAULT (datetime('now')),
                 UNIQUE(owner_id, name)
                 );
-                
-                
+
+
 
 CREATE INDEX IF NOT EXISTS idx_credential_vault_owner
 ON credential_vault(owner_id);
@@ -513,7 +513,7 @@ ON credential_vault(owner_id);
             "SELECT sql FROM sqlite_master "
             "WHERE type='table' AND name='credential_vault'"
             )
-        
+
         if "owner_id" not in existing_vault_cols:
             try:
                 await self.execute(
@@ -523,7 +523,7 @@ ON credential_vault(owner_id);
                 print("Added missing column 'owner_id' to credential_vault table.")
             except Exception as e:
                 print(f"Failed to add 'owner_id' to credential_vault: {e}")
-        
+
         if vault_schema:
             ddl = vault_schema["sql"]
             has_composite = "UNIQUE(owner_id, name)" in ddl
@@ -538,7 +538,7 @@ ON credential_vault(owner_id);
                         updated_at TIMESTAMP NOT NULL DEFAULT (datetime('now')),
                         UNIQUE(owner_id, name)
                         );
-                        
+
 
             INSERT INTO credential_vault_new
             (
@@ -643,7 +643,7 @@ ON credential_vault(owner_id);
             CREATE INDEX IF NOT EXISTS idx_notification_rules_owner ON notification_rules(owner_id);
             """
             )
-        
+
 
     async def _run_migrations(self):
         migrations_dir = Path(__file__).parent / "migrations"

--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -271,8 +271,11 @@ class Database:
                 name TEXT NOT NULL,
                 encrypted_value TEXT NOT NULL,
                 created_at TIMESTAMP NOT NULL DEFAULT (datetime('now')),
-                updated_at TIMESTAMP NOT NULL DEFAULT (datetime('now'))
-            );
+                updated_at TIMESTAMP NOT NULL DEFAULT (datetime('now')),
+                UNIQUE(owner_id, name)
+                );
+                
+                
 
 CREATE INDEX IF NOT EXISTS idx_credential_vault_owner
 ON credential_vault(owner_id);
@@ -506,6 +509,11 @@ ON credential_vault(owner_id);
             "PRAGMA table_info(credential_vault)"
             )
         existing_vault_cols = {col["name"] for col in vault_columns}
+        vault_schema = await self.fetchone(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type='table' AND name='credential_vault'"
+            )
+        
         if "owner_id" not in existing_vault_cols:
             try:
                 await self.execute(
@@ -513,9 +521,48 @@ ON credential_vault(owner_id);
                     "ADD COLUMN owner_id TEXT NOT NULL DEFAULT 'default'"
                     )
                 print("Added missing column 'owner_id' to credential_vault table.")
-
             except Exception as e:
                 print(f"Failed to add 'owner_id' to credential_vault: {e}")
+        
+        if vault_schema:
+            ddl = vault_schema["sql"]
+            has_composite = "UNIQUE(owner_id, name)" in ddl
+            if not has_composite:
+                await self.connection.executescript(
+                    """CREATE TABLE credential_vault_new (
+                        id TEXT PRIMARY KEY,
+                        owner_id TEXT NOT NULL DEFAULT 'default',
+                        name TEXT NOT NULL,
+                        encrypted_value TEXT NOT NULL,
+                        created_at TIMESTAMP NOT NULL DEFAULT (datetime('now')),
+                        updated_at TIMESTAMP NOT NULL DEFAULT (datetime('now')),
+                        UNIQUE(owner_id, name)
+                        );
+                        
+
+            INSERT INTO credential_vault_new
+            (
+                id,
+                owner_id,
+                name,
+                encrypted_value,
+                created_at,
+                updated_at
+            )
+            SELECT
+                id,
+                COALESCE(owner_id, 'default'),
+                name,
+                encrypted_value,
+                created_at,
+                updated_at
+            FROM credential_vault;
+
+            DROP TABLE credential_vault;
+            ALTER TABLE credential_vault_new
+            RENAME TO credential_vault;
+        """)
+                await self.connection.commit()
 
         # Workflows table migration: ensure owner_id and composite unique exist
         workflows_columns = await self.fetchall("PRAGMA table_info(workflows)")
@@ -587,20 +634,16 @@ ON credential_vault(owner_id);
 
         # Owner indexes must run after ALTER TABLE backfills owner_id on legacy DBs.
         await self.connection.executescript(
-        """
-        CREATE INDEX IF NOT EXISTS idx_tasks_owner ON tasks(owner_id);
-        CREATE INDEX IF NOT EXISTS idx_findings_owner ON findings(owner_id);
-        CREATE INDEX IF NOT EXISTS idx_reports_owner ON reports(owner_id);
-        CREATE INDEX IF NOT EXISTS idx_credential_vault_owner ON credential_vault(owner_id);
-        """
             """
             CREATE INDEX IF NOT EXISTS idx_tasks_owner ON tasks(owner_id);
             CREATE INDEX IF NOT EXISTS idx_findings_owner ON findings(owner_id);
             CREATE INDEX IF NOT EXISTS idx_reports_owner ON reports(owner_id);
+            CREATE INDEX IF NOT EXISTS idx_credential_vault_owner ON credential_vault(owner_id);
             CREATE INDEX IF NOT EXISTS idx_workflows_owner ON workflows(owner_id);
             CREATE INDEX IF NOT EXISTS idx_notification_rules_owner ON notification_rules(owner_id);
             """
-        )
+            )
+        
 
     async def _run_migrations(self):
         migrations_dir = Path(__file__).parent / "migrations"

--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -267,11 +267,15 @@ class Database:
 
             CREATE TABLE IF NOT EXISTS credential_vault (
                 id TEXT PRIMARY KEY,
-                name TEXT NOT NULL UNIQUE,
+                owner_id TEXT NOT NULL DEFAULT 'default',
+                name TEXT NOT NULL,
                 encrypted_value TEXT NOT NULL,
                 created_at TIMESTAMP NOT NULL DEFAULT (datetime('now')),
                 updated_at TIMESTAMP NOT NULL DEFAULT (datetime('now'))
             );
+
+CREATE INDEX IF NOT EXISTS idx_credential_vault_owner
+ON credential_vault(owner_id);
 
             CREATE TABLE IF NOT EXISTS workflows (
                 id TEXT PRIMARY KEY,
@@ -392,7 +396,7 @@ class Database:
         # Migration logic: ensure latest columns exist in 'tasks' table
         tasks_columns = await self.fetchall("PRAGMA table_info(tasks)")
         existing_cols = {col["name"] for col in tasks_columns}
-        
+
         needed_cols = {
             # Per-user ownership for BOLA prevention (issue #401). NOT NULL with a
             # constant default backfills every existing row to the shared default
@@ -497,6 +501,22 @@ class Database:
             except Exception as e:
                 print(f"Failed to add 'owner_id' to reports: {e}")
 
+        # Vault table migration: ensure owner_id exists
+        vault_columns = await self.fetchall(
+            "PRAGMA table_info(credential_vault)"
+            )
+        existing_vault_cols = {col["name"] for col in vault_columns}
+        if "owner_id" not in existing_vault_cols:
+            try:
+                await self.execute(
+                    "ALTER TABLE credential_vault "
+                    "ADD COLUMN owner_id TEXT NOT NULL DEFAULT 'default'"
+                    )
+                print("Added missing column 'owner_id' to credential_vault table.")
+
+            except Exception as e:
+                print(f"Failed to add 'owner_id' to credential_vault: {e}")
+
         # Workflows table migration: ensure owner_id and composite unique exist
         workflows_columns = await self.fetchall("PRAGMA table_info(workflows)")
         existing_wf_cols = {col["name"] for col in workflows_columns}
@@ -567,6 +587,12 @@ class Database:
 
         # Owner indexes must run after ALTER TABLE backfills owner_id on legacy DBs.
         await self.connection.executescript(
+        """
+        CREATE INDEX IF NOT EXISTS idx_tasks_owner ON tasks(owner_id);
+        CREATE INDEX IF NOT EXISTS idx_findings_owner ON findings(owner_id);
+        CREATE INDEX IF NOT EXISTS idx_reports_owner ON reports(owner_id);
+        CREATE INDEX IF NOT EXISTS idx_credential_vault_owner ON credential_vault(owner_id);
+        """
             """
             CREATE INDEX IF NOT EXISTS idx_tasks_owner ON tasks(owner_id);
             CREATE INDEX IF NOT EXISTS idx_findings_owner ON findings(owner_id);

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -1393,16 +1393,28 @@ async def get_settings():
 
 
 @router.get("/vault", dependencies=[Depends(vault_limiter)])
-async def list_vault_secrets():
+async def list_vault_secrets(
+    owner: str = Depends(get_current_owner),
+):
     db = await get_db()
     rows = await db.fetchall(
-        "SELECT id, name, created_at, updated_at FROM credential_vault ORDER BY name ASC"
+        """
+        SELECT id, name, created_at, updated_at
+        FROM credential_vault
+        WHERE owner_id = ?
+        ORDER BY name ASC
+        """,
+        (owner,),
     )
     return {"items": rows, "total": len(rows)}
 
 
 @router.put("/vault/{name}", dependencies=[Depends(vault_limiter)])
-async def upsert_vault_secret(name: str, payload: Dict[str, str]):
+async def upsert_vault_secret(
+    name: str,
+    payload: Dict[str, str],
+    owner: str = Depends(get_current_owner),
+):
     value = str(payload.get("value", ""))
     if not value:
         raise HTTPException(status_code=400, detail="Secret value is required")
@@ -1412,36 +1424,81 @@ async def upsert_vault_secret(name: str, payload: Dict[str, str]):
     encrypted = crypto.encrypt(value)
     secret_id = str(uuid.uuid4())
 
-    existing = await db.fetchone("SELECT id FROM credential_vault WHERE name = ?", (name,))
+    existing = await db.fetchone(
+        """
+        SELECT id
+        FROM credential_vault
+        WHERE owner_id = ? AND name = ?
+        """,
+        (owner, name),
+    )
+
     if existing:
         await db.execute(
-            "UPDATE credential_vault SET encrypted_value = ?, updated_at = datetime('now') WHERE name = ?",
-            (encrypted, name),
+            """
+            UPDATE credential_vault
+            SET encrypted_value = ?, updated_at = datetime('now')
+            WHERE owner_id = ? AND name = ?
+            """,
+            (encrypted, owner, name),
         )
     else:
         await db.execute(
-            "INSERT INTO credential_vault (id, name, encrypted_value) VALUES (?, ?, ?)",
-            (secret_id, name, encrypted),
+            """
+            INSERT INTO credential_vault
+            (id, owner_id, name, encrypted_value)
+            VALUES (?, ?, ?, ?)
+            """,
+            (secret_id, owner, name, encrypted),
         )
+
     return {"name": name, "stored": True}
 
-
 @router.get("/vault/{name}", dependencies=[Depends(vault_limiter)])
-async def get_vault_secret(name: str):
+async def get_vault_secret(
+    name: str,
+    owner: str = Depends(get_current_owner),
+):
     db = await get_db()
-    row = await db.fetchone("SELECT encrypted_value FROM credential_vault WHERE name = ?", (name,))
+
+    row = await db.fetchone(
+        """
+        SELECT encrypted_value
+        FROM credential_vault
+        WHERE owner_id = ? AND name = ?
+        """,
+        (owner, name),
+    )
+
     if not row:
         raise HTTPException(status_code=404, detail="Secret not found")
-    crypto = VaultCrypto(settings.resolved_vault_key)
-    return {"name": name, "value": crypto.decrypt(row["encrypted_value"])}
 
+    crypto = VaultCrypto(settings.resolved_vault_key)
+
+    return {
+        "name": name,
+        "value": crypto.decrypt(row["encrypted_value"]),
+    }
 
 @router.delete("/vault/{name}", dependencies=[Depends(vault_limiter)])
-async def delete_vault_secret(name: str):
+async def delete_vault_secret(
+    name: str,
+    owner: str = Depends(get_current_owner),
+):
     db = await get_db()
-    await db.execute("DELETE FROM credential_vault WHERE name = ?", (name,))
-    return {"name": name, "deleted": True}
 
+    await db.execute(
+        """
+        DELETE FROM credential_vault
+        WHERE owner_id = ? AND name = ?
+        """,
+        (owner, name),
+    )
+
+    return {
+        "name": name,
+        "deleted": True,
+    }
 
 @router.get("/target-policies")
 async def list_target_policies(owner: str = Depends(get_current_owner)):

--- a/testing/backend/unit/test_vault_owner_isolation.py
+++ b/testing/backend/unit/test_vault_owner_isolation.py
@@ -1,0 +1,129 @@
+"""
+Vault owner-isolation tests.
+
+Verifies that credential vault operations are scoped by owner_id and
+that one owner cannot read, list, overwrite, or delete another owner's
+secrets.
+"""
+
+import asyncio
+import pytest
+
+from backend.secuscan.config import settings
+from backend.secuscan.ratelimit import (
+    reset_all_endpoint_limiters,
+    vault_limiter,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolate_vault_tests(monkeypatch):
+    monkeypatch.setattr(settings, "rate_limit_vault_limit", 100)
+    monkeypatch.setattr(settings, "rate_limit_vault_window", 60)
+
+    vault_limiter.limit = 100
+    vault_limiter.window_seconds = 60
+
+    asyncio.run(reset_all_endpoint_limiters())
+
+
+class TestVaultOwnerIsolation:
+    OWNER_A = {"X-User-Id": "alice"}
+    OWNER_B = {"X-User-Id": "bob"}
+
+    def test_owner_cannot_read_other_owner_secret(self, test_client):
+        name = "owner-isolation-read"
+
+        r = test_client.put(
+            f"/api/v1/vault/{name}",
+            json={"value": "alice-secret"},
+            headers=self.OWNER_A,
+        )
+        assert r.status_code == 200
+
+        r = test_client.get(
+            f"/api/v1/vault/{name}",
+            headers=self.OWNER_B,
+        )
+
+        assert r.status_code == 404
+
+    def test_owner_list_only_returns_owned_secrets(self, test_client):
+        test_client.put(
+            "/api/v1/vault/alice-secret",
+            json={"value": "a"},
+            headers=self.OWNER_A,
+        )
+
+        test_client.put(
+            "/api/v1/vault/bob-secret",
+            json={"value": "b"},
+            headers=self.OWNER_B,
+        )
+
+        r = test_client.get(
+            "/api/v1/vault",
+            headers=self.OWNER_B,
+        )
+
+        assert r.status_code == 200
+        print(r.json())
+
+        names = {item["name"] for item in r.json()["items"]}
+
+        assert "bob-secret" in names
+        assert "alice-secret" not in names
+
+    def test_owner_cannot_overwrite_other_owner_secret(self, test_client):
+        name = "shared-name"
+
+        test_client.put(
+            f"/api/v1/vault/{name}",
+            json={"value": "alice-value"},
+            headers=self.OWNER_A,
+        )
+
+        test_client.put(
+            f"/api/v1/vault/{name}",
+            json={"value": "bob-value"},
+            headers=self.OWNER_B,
+        )
+
+        alice = test_client.get(
+            f"/api/v1/vault/{name}",
+            headers=self.OWNER_A,
+        )
+
+        bob = test_client.get(
+            f"/api/v1/vault/{name}",
+            headers=self.OWNER_B,
+        )
+
+        assert alice.status_code == 200
+        assert bob.status_code == 200
+
+        assert alice.json()["value"] == "alice-value"
+        assert bob.json()["value"] == "bob-value"
+
+    def test_owner_cannot_delete_other_owner_secret(self, test_client):
+        name = "owner-isolation-delete"
+
+        test_client.put(
+            f"/api/v1/vault/{name}",
+            json={"value": "alice-secret"},
+            headers=self.OWNER_A,
+        )
+
+        delete_r = test_client.delete(
+           f"/api/v1/vault/{name}",
+           headers=self.OWNER_B,
+      )
+        assert delete_r.status_code in (200, 404)
+
+        r = test_client.get(
+            f"/api/v1/vault/{name}",
+            headers=self.OWNER_A,
+        )
+
+        assert r.status_code == 200
+        assert r.json()["value"] == "alice-secret"

--- a/testing/backend/unit/test_vault_owner_isolation.py
+++ b/testing/backend/unit/test_vault_owner_isolation.py
@@ -127,10 +127,10 @@ class TestVaultOwnerIsolation:
 
         assert r.status_code == 200
         assert r.json()["value"] == "alice-secret"
-        
+
     def test_upsert_updates_existing_secret_for_same_owner(self, test_client):
             name = "duplicate-secret"
-            
+
             test_client.put(
                 f"/api/v1/vault/{name}",
                 json={"value": "first"},
@@ -147,19 +147,19 @@ class TestVaultOwnerIsolation:
                 f"/api/v1/vault/{name}",
                 headers=self.OWNER_A,
                 )
-            
+
             assert secret.status_code == 200
             assert secret.json()["value"] == "second"
-            
+
             listing = test_client.get(
                 "/api/v1/vault",
                  headers=self.OWNER_A,
                  )
-            
+
             matches = [
                 item
                 for item in listing.json()["items"]
                 if item["name"] == name
                 ]
-            
+
             assert len(matches) == 1

--- a/testing/backend/unit/test_vault_owner_isolation.py
+++ b/testing/backend/unit/test_vault_owner_isolation.py
@@ -127,3 +127,39 @@ class TestVaultOwnerIsolation:
 
         assert r.status_code == 200
         assert r.json()["value"] == "alice-secret"
+        
+    def test_upsert_updates_existing_secret_for_same_owner(self, test_client):
+            name = "duplicate-secret"
+            
+            test_client.put(
+                f"/api/v1/vault/{name}",
+                json={"value": "first"},
+                headers=self.OWNER_A,
+                )
+
+            test_client.put(
+                f"/api/v1/vault/{name}",
+                json={"value": "second"},
+                headers=self.OWNER_A,
+                )
+
+            secret = test_client.get(
+                f"/api/v1/vault/{name}",
+                headers=self.OWNER_A,
+                )
+            
+            assert secret.status_code == 200
+            assert secret.json()["value"] == "second"
+            
+            listing = test_client.get(
+                "/api/v1/vault",
+                 headers=self.OWNER_A,
+                 )
+            
+            matches = [
+                item
+                for item in listing.json()["items"]
+                if item["name"] == name
+                ]
+            
+            assert len(matches) == 1

--- a/testing/backend/unit/test_vault_owner_isolation.py
+++ b/testing/backend/unit/test_vault_owner_isolation.py
@@ -67,8 +67,7 @@ class TestVaultOwnerIsolation:
         )
 
         assert r.status_code == 200
-        print(r.json())
-
+        
         names = {item["name"] for item in r.json()["items"]}
 
         assert "bob-secret" in names
@@ -129,37 +128,37 @@ class TestVaultOwnerIsolation:
         assert r.json()["value"] == "alice-secret"
 
     def test_upsert_updates_existing_secret_for_same_owner(self, test_client):
-            name = "duplicate-secret"
+        name = "duplicate-secret"
+        
+        test_client.put(
+            f"/api/v1/vault/{name}",
+            json={"value": "first"},
+            headers=self.OWNER_A,
+            )
 
-            test_client.put(
-                f"/api/v1/vault/{name}",
-                json={"value": "first"},
-                headers=self.OWNER_A,
-                )
-
-            test_client.put(
-                f"/api/v1/vault/{name}",
-                json={"value": "second"},
-                headers=self.OWNER_A,
-                )
-
-            secret = test_client.get(
-                f"/api/v1/vault/{name}",
-                headers=self.OWNER_A,
-                )
-
-            assert secret.status_code == 200
-            assert secret.json()["value"] == "second"
-
-            listing = test_client.get(
-                "/api/v1/vault",
-                 headers=self.OWNER_A,
-                 )
-
-            matches = [
-                item
-                for item in listing.json()["items"]
-                if item["name"] == name
-                ]
-
-            assert len(matches) == 1
+        test_client.put(
+            f"/api/v1/vault/{name}",
+            json={"value": "second"},
+            headers=self.OWNER_A,
+          )
+        
+        secret = test_client.get(
+            f"/api/v1/vault/{name}",
+            headers=self.OWNER_A,
+            )
+        
+        assert secret.status_code == 200
+        assert secret.json()["value"] == "second"
+        
+        listing = test_client.get(
+            "/api/v1/vault",
+             headers=self.OWNER_A,
+            )
+        
+        matches = [
+            item
+            for item in listing.json()["items"]
+            if item["name"] == name
+            ]
+        
+        assert len(matches) == 1

--- a/testing/backend/unit/test_vault_owner_isolation.py
+++ b/testing/backend/unit/test_vault_owner_isolation.py
@@ -67,7 +67,7 @@ class TestVaultOwnerIsolation:
         )
 
         assert r.status_code == 200
-        
+
         names = {item["name"] for item in r.json()["items"]}
 
         assert "bob-secret" in names
@@ -129,7 +129,7 @@ class TestVaultOwnerIsolation:
 
     def test_upsert_updates_existing_secret_for_same_owner(self, test_client):
         name = "duplicate-secret"
-        
+
         test_client.put(
             f"/api/v1/vault/{name}",
             json={"value": "first"},
@@ -141,24 +141,24 @@ class TestVaultOwnerIsolation:
             json={"value": "second"},
             headers=self.OWNER_A,
           )
-        
+
         secret = test_client.get(
             f"/api/v1/vault/{name}",
             headers=self.OWNER_A,
             )
-        
+
         assert secret.status_code == 200
         assert secret.json()["value"] == "second"
-        
+
         listing = test_client.get(
             "/api/v1/vault",
              headers=self.OWNER_A,
             )
-        
+
         matches = [
             item
             for item in listing.json()["items"]
             if item["name"] == name
             ]
-        
+
         assert len(matches) == 1


### PR DESCRIPTION
## Summary

Enforce owner isolation for credential vault operations and preserve per-owner secret uniqueness.

## Changes

* Scope vault list operations by `owner_id`
* Scope vault reads by `owner_id` and secret name
* Scope vault updates/upserts by `owner_id` and secret name
* Scope vault deletes by `owner_id` and secret name
* Add composite uniqueness constraint on `(owner_id, name)` for vault secrets
* Add migration logic to upgrade existing databases to the new uniqueness model
* Add focused owner-isolation regression tests

## Tests Added

* Read isolation between owners
* List isolation between owners
* Overwrite isolation between owners
* Delete isolation between owners
* Same-owner upsert behavior and uniqueness validation

## Validation

```bash
pytest testing/backend/unit/test_vault_owner_isolation.py -v
```

Result:

```text
5 passed
```

## Security Impact

Prevents one owner from viewing, modifying, listing, overwriting, or deleting another owner's vault secrets while maintaining secret-name uniqueness within each owner's vault.
