### PR TITLE
test(plugins): add tls_inspector parser fixture coverage

### DIFF
--- a/testing/backend/unit/fixtures/tls_inspector/malformed_output.txt
+++ b/testing/backend/unit/fixtures/tls_inspector/malformed_output.txt
@@ -1,0 +1,4 @@
+Protocol  : TLSv1.2
+Cipher    : ECDHE-RSA-AES256-GCM-SHA384
+
+Verify return code: 18 (self signed certificate)

--- a/testing/backend/unit/fixtures/tls_inspector/secure_output.txt
+++ b/testing/backend/unit/fixtures/tls_inspector/secure_output.txt
@@ -1,0 +1,8 @@
+Protocol  : TLSv1.3
+Cipher    : TLS_AES_256_GCM_SHA384
+
+-----BEGIN CERTIFICATE-----
+dummy certificate
+-----END CERTIFICATE-----
+
+Verify return code: 0 (ok)

--- a/testing/backend/unit/fixtures/tls_inspector/weak_tls_output.txt
+++ b/testing/backend/unit/fixtures/tls_inspector/weak_tls_output.txt
@@ -1,0 +1,4 @@
+Protocol  : TLSv1.0
+Cipher    : AES128-SHA
+
+Verify return code: 0 (ok)

--- a/testing/backend/unit/test_tls_inspector_plugin.py
+++ b/testing/backend/unit/test_tls_inspector_plugin.py
@@ -1,0 +1,66 @@
+"""Parser fixture coverage for plugins/tls_inspector."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from backend.secuscan.config import settings
+
+PLUGIN_ID = "tls_inspector"
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / PLUGIN_ID
+PARSER_PATH = Path(settings.plugins_dir) / PLUGIN_ID / "parser.py"
+
+
+def _load_tls_inspector_parser():
+    spec = importlib.util.spec_from_file_location(
+        "tls_inspector_parser",
+        PARSER_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_tls_inspector_secure_fixture():
+    parser = _load_tls_inspector_parser()
+
+    raw_output = (FIXTURE_DIR / "secure_output.txt").read_text(
+        encoding="utf-8"
+    )
+
+    parsed = parser.parse(raw_output)
+
+    assert parsed["findings"] == []
+    assert parsed["metadata"]["protocol"] == "TLSv1.3"
+    assert parsed["metadata"]["certificate_verified"] is True
+    assert parsed["metadata"]["has_certificate"] is True
+
+
+def test_tls_inspector_weak_protocol_fixture():
+    parser = _load_tls_inspector_parser()
+
+    raw_output = (FIXTURE_DIR / "weak_tls_output.txt").read_text(
+        encoding="utf-8"
+    )
+
+    parsed = parser.parse(raw_output)
+
+    assert len(parsed["findings"]) == 1
+    assert "Weak TLS Protocol" in parsed["findings"][0]["title"]
+    assert parsed["findings"][0]["severity"] == "medium"
+
+
+def test_tls_inspector_malformed_certificate_fixture():
+    parser = _load_tls_inspector_parser()
+
+    raw_output = (FIXTURE_DIR / "malformed_output.txt").read_text(
+        encoding="utf-8"
+    )
+
+    parsed = parser.parse(raw_output)
+
+    assert parsed["metadata"]["certificate_verified"] is False
+    assert len(parsed["findings"]) == 1
+    assert parsed["findings"][0]["title"] == "SSL Certificate Validation Failed"


### PR DESCRIPTION
## Description

Adds parser fixture coverage for the `tls_inspector` plugin to validate handling of representative TLS inspection outputs.

### Changes

* Added fixture for a secure TLS configuration.
* Added fixture for a weak TLS protocol configuration.
* Added fixture for a malformed/invalid certificate scenario.
* Added parser tests covering all three fixture cases.
* Verified parser behavior remains deterministic across representative outputs.

## Related Issues

Closes #846

## Type of Change

* [x] New feature (non-breaking change which adds functionality)
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## How Has This Been Tested?

Ran the plugin-specific test suite locally:

```bash
py -m pytest testing/backend/unit/test_tls_inspector_plugin.py -v
```

Results:

* Secure TLS fixture parsed successfully.
* Weak TLS fixture produced the expected weak protocol finding.
* Malformed certificate fixture produced the expected certificate validation finding.

All tests passed locally.

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
