### PR TITLE
feat(settings): warn before navigation when there are unsaved changes

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -235,6 +235,9 @@ export default function Settings() {
         return DEFAULT_CONFIG
     })
 
+    const [lastSavedConfig, setLastSavedConfig] = useState(config)
+    const isDirty = JSON.stringify(config) !== JSON.stringify(lastSavedConfig)
+
     const [systemTimezone, setSystemTimezone] = useState('Detecting...')
 
     // Modal state for confirm dialogs
@@ -264,8 +267,19 @@ export default function Settings() {
         refreshNotificationRules()
     }, [])
 
+    useEffect(() => {
+        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+            if (!isDirty) return
+            e.preventDefault()
+            e.returnValue = ''
+        }
+        window.addEventListener('beforeunload', handleBeforeUnload)
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+    }, [isDirty])
+
     const handleSave = () => {
         localStorage.setItem('secuscan-config', JSON.stringify(config))
+        setLastSavedConfig(config)
         addToast("Operational parameters synchronized", "success")
         setTheme(config.theme as 'dark' | 'light')
     }
@@ -278,6 +292,7 @@ export default function Settings() {
             type: "warning",
             onConfirm: () => {
                 setConfig(DEFAULT_CONFIG)
+                setLastSavedConfig(DEFAULT_CONFIG)
                 localStorage.setItem('secuscan-config', JSON.stringify(DEFAULT_CONFIG))
                 addToast("Engine parameters reset to factory defaults", "info")
                 setModalState(prev => ({ ...prev, isOpen: false }))
@@ -854,7 +869,12 @@ export default function Settings() {
                             />
                         </div>
                     </section>
-                    <section className="pt-12">
+                    <section className="pt-12 space-y-3">
+                        {isDirty && (
+                            <p role="status" className="text-[10px] font-black text-rag-amber uppercase tracking-[0.3em] italic">
+                                ● UNSAVED_CHANGES_PENDING
+                            </p>
+                        )}
                         <button
                             onClick={handleSave}
                             className="bg-rag-blue text-black px-12 py-6 text-xs font-black uppercase tracking-[0.3em] shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center gap-4 italic group"

--- a/frontend/testing/unit/pages/SettingsUnsavedChanges.test.tsx
+++ b/frontend/testing/unit/pages/SettingsUnsavedChanges.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Settings from '../../../src/pages/Settings'
+import { ThemeProvider } from '../../../src/components/ThemeContext'
+import { ToastProvider } from '../../../src/components/ToastContext'
+import { listNotificationRules } from '../../../src/api'
+
+vi.mock('../../../src/api', async () => {
+  const actual: any = await vi.importActual('../../../src/api')
+  return {
+    ...actual,
+    listNotificationRules: vi.fn(),
+  }
+})
+
+function renderSettings() {
+  return render(
+    <ThemeProvider>
+      <ToastProvider>
+        <Settings />
+      </ToastProvider>
+    </ThemeProvider>,
+  )
+}
+
+describe('Settings — unsaved changes warning', () => {
+  beforeEach(() => {
+    localStorage.removeItem('secuscan-config')
+    vi.mocked(listNotificationRules).mockResolvedValue([])
+  })
+
+  it('shows no unsaved-changes indicator on initial load', () => {
+    renderSettings()
+
+    expect(screen.queryByText(/unsaved_changes_pending/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the unsaved-changes indicator after editing a field', async () => {
+    const user = userEvent.setup()
+    renderSettings()
+
+    const themeSelect = screen.getByRole('combobox', { name: /visual spectrum theme/i })
+    await user.selectOptions(themeSelect, 'light')
+
+    expect(screen.getByText(/unsaved_changes_pending/i)).toBeInTheDocument()
+  })
+
+  it('clears the unsaved-changes indicator after saving', async () => {
+    const user = userEvent.setup()
+    renderSettings()
+
+    const themeSelect = screen.getByRole('combobox', { name: /visual spectrum theme/i })
+    await user.selectOptions(themeSelect, 'light')
+    expect(screen.getByText(/unsaved_changes_pending/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /COMMIT_ENGINE_CHANGES/i }))
+
+    expect(screen.queryByText(/unsaved_changes_pending/i)).not.toBeInTheDocument()
+  })
+
+  it('warns before unload when there are unsaved changes', async () => {
+    const user = userEvent.setup()
+    renderSettings()
+
+    const themeSelect = screen.getByRole('combobox', { name: /visual spectrum theme/i })
+    await user.selectOptions(themeSelect, 'light')
+
+    const event = new Event('beforeunload', { cancelable: true })
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+    window.dispatchEvent(event)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+  })
+
+  it('does not warn before unload when there are no unsaved changes', () => {
+    renderSettings()
+
+    const event = new Event('beforeunload', { cancelable: true })
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+    window.dispatchEvent(event)
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  it('clears the unsaved-changes indicator after a factory reset', async () => {
+    const user = userEvent.setup()
+    renderSettings()
+
+    const themeSelect = screen.getByRole('combobox', { name: /visual spectrum theme/i })
+    await user.selectOptions(themeSelect, 'light')
+    expect(screen.getByText(/unsaved_changes_pending/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /ENGINE_RESET/i }))
+    await user.click(screen.getByRole('button', { name: /confirm/i }))
+
+    expect(screen.queryByText(/unsaved_changes_pending/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Description

Added an unsaved-changes warning to the Settings page. Previously, editing configuration fields without saving and then refreshing, closing the tab, or navigating away would silently discard changes with no warning.

### Changes

* Track a dirty state by comparing the current configuration against the last saved snapshot.
* Display a visible `UNSAVED_CHANGES_PENDING` indicator near the save button whenever unsaved changes exist.
* Add a `beforeunload` listener that triggers the browser's native confirmation dialog when attempting to close, refresh, or reload the page with unsaved changes.
* Clear the dirty state after a successful save or factory reset.

**Note:** The application currently uses a standard `BrowserRouter`, so React Router's navigation blocking APIs are not available for safe in-app route interception. The implemented `beforeunload` protection covers tab close, refresh, and reload scenarios, which are the most common causes of accidental data loss. Extending protection to in-app navigation would require changes outside the scope of this issue.

## Related Issues

Closes #819 

## Type of Change

* [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added `frontend/testing/unit/pages/SettingsUnsavedChanges.test.tsx` with 6 focused tests:

* No indicator shown on initial load
* Indicator appears after editing a field
* Indicator clears after saving
* `beforeunload` is prevented when unsaved changes exist
* `beforeunload` is not prevented when no unsaved changes exist
* Indicator clears after a factory reset

### Test Command

```bash
npm test
```

### Result

* All 18 Settings-related tests passed locally

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas..
* [x] My changes generate no new warnings.
