### PR TITLE
fix: resolve mobile dashboard status/profile overlap

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -176,16 +176,16 @@ export default function AppShell({ children }: AppShellProps) {
                     {children}
                 </main>
 
-                <nav className="lg:hidden fixed bottom-0 inset-x-0 z-40 h-16 bg-[var(--bg-secondary)] border-t border-accent-silver/10 grid grid-cols-5">
+                <nav className="lg:hidden fixed bottom-0 inset-x-0 z-40 h-16 bg-[var(--bg-secondary)] border-t border-accent-silver/10 grid grid-cols-6">
                     {mobilePrimaryNav.map((item) => (
                         <NavLink
                             key={item.to}
                             to={item.to}
                             className={({ isActive }) =>
-                                `flex flex-col items-center justify-center gap-1 text-[9px] font-bold uppercase tracking-[0.08em] ${
-                                    isActive ? 'text-rag-red bg-rag-red/10' : 'text-silver/70'
-                                }`
-                            }
+    `relative flex flex-col items-center justify-center gap-1 text-[9px] font-bold uppercase tracking-[0.08em] ${
+        isActive ? 'text-rag-red after:absolute after:top-0 after:left-2 after:right-2 after:h-[2px] after:bg-rag-red after:rounded-b' : 'text-silver/70'
+    }`
+}
                         >
                             <span className="material-symbols-outlined text-[18px]">{item.icon}</span>
                             <span>{item.label}</span>

--- a/frontend/src/components/ExecutiveStatsBar.tsx
+++ b/frontend/src/components/ExecutiveStatsBar.tsx
@@ -45,9 +45,9 @@ export const ExecutiveStatsBar: React.FC<ExecutiveStatsBarProps> = ({
       {/* 2. Critical Vulns */}
       <div className="px-6">
         <span className="text-xs font-bold text-white/70 uppercase tracking-[0.3em] block mb-6">Critical Vulns</span>
-        <div className="space-y-8">
+        <div className="space-y-3">
           <span
-            className={`text-8xl font-normal leading-[0.8] block ${hasCritical ? 'text-[var(--rag-red)]' : 'text-white'}`}
+            className={`text-8xl font-normal leading-none block ${hasCritical ? 'text-[var(--rag-red)]' : 'text-white'}`}
             style={{ fontFamily: 'var(--font-display)' }}
           >
             {criticalCount}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -321,7 +321,7 @@ export default function Dashboard() {
         </motion.div>
       </header>
 
-      <main className="flex-1 px-0 pb-20 space-y-12 w-full">
+      <main className="flex-1 px-0 pb-24 space-y-12 w-full">
         <AnimatePresence mode="wait">
           {loading ? (
             <motion.section


### PR DESCRIPTION
## Description

This PR fixes the mobile dashboard layout issue where the status section and profile components overlap on smaller screen sizes.

### Changes Made

* Improved mobile responsiveness of the dashboard layout.
* Adjusted spacing and alignment between dashboard components.
* Prevented overlap between status indicators and profile-related elements.
* Ensured a cleaner and more consistent experience across different mobile viewport sizes.

## Related Issues

Fixes #1170 

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## How Has This Been Tested?

* Ran the application locally using the development environment.
* Tested the dashboard on multiple mobile viewport sizes using browser developer tools.
* Verified that the status section and profile elements no longer overlap.
* Confirmed that existing dashboard functionality remains unaffected.

## Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
* [ ]
<img width="462" height="357" alt="image" src="https://github.com/user-attachments/assets/5486cad9-e8ee-4867-a373-fd969e2715b7" />

