### PR TITLE
fix light and dark theme toggle

### DIFF
--- a/frontend/src/components/ExecutiveStatsBar.tsx
+++ b/frontend/src/components/ExecutiveStatsBar.tsx
@@ -28,7 +28,7 @@ export const ExecutiveStatsBar: React.FC<ExecutiveStatsBarProps> = ({
     <div className="w-full bg-[var(--bg-secondary)] border-y border-white/5 py-16 grid grid-cols-1 md:grid-cols-4 divide-x divide-white/5">
       {/* 1. Risk Profile */}
       <div className="px-6 first:pl-8">
-        <span className="text-xs font-bold text-white/70 uppercase tracking-[0.3em] block mb-6">Status Profile</span>
+        <span className="text-xs font-bold text-silver uppercase tracking-[0.3em] block mb-6">Status Profile</span>
         <div className="space-y-6">
           <span 
             className="text-7xl font-light text-[var(--rag-amber)] leading-none block" 
@@ -36,7 +36,7 @@ export const ExecutiveStatsBar: React.FC<ExecutiveStatsBarProps> = ({
           >
             {riskLabel || 'Moderate'}
           </span>
-          <p className="text-sm text-white/80 leading-relaxed font-light tracking-wide">
+          <p className="text-sm text-silver leading-relaxed font-light tracking-wide">
             {riskNote}
           </p>
         </div>
@@ -44,10 +44,10 @@ export const ExecutiveStatsBar: React.FC<ExecutiveStatsBarProps> = ({
 
       {/* 2. Critical Vulns */}
       <div className="px-6">
-        <span className="text-xs font-bold text-white/70 uppercase tracking-[0.3em] block mb-6">Critical Vulns</span>
+        <span className="text-xs font-bold text-silver uppercase tracking-[0.3em] block mb-6">Critical Vulns</span>
         <div className="space-y-8">
           <span
-            className={`text-8xl font-normal leading-[0.8] block ${hasCritical ? 'text-[var(--rag-red)]' : 'text-white'}`}
+            className={`text-8xl font-normal leading-[0.8] block ${hasCritical ? 'text-[var(--rag-red)]' : 'text-silver-bright'}`}
             style={{ fontFamily: 'var(--font-display)' }}
           >
             {criticalCount}
@@ -60,9 +60,9 @@ export const ExecutiveStatsBar: React.FC<ExecutiveStatsBarProps> = ({
 
       {/* 3. Total Findings */}
       <div className="px-6">
-        <span className="text-xs font-bold text-white/70 uppercase tracking-[0.3em] block mb-6">Total Findings</span>
+        <span className="text-xs font-bold text-silver uppercase tracking-[0.3em] block mb-6">Total Findings</span>
         <div className="space-y-8">
-          <span className="text-8xl font-normal text-white leading-[0.8]" style={{ fontFamily: 'var(--font-display)' }}>
+          <span className="text-8xl font-normal text-silver-bright leading-[0.8]" style={{ fontFamily: 'var(--font-display)' }}>
             {findingCount.toLocaleString()}
           </span>
           <span className="text-xs text-[var(--rag-green)] font-bold uppercase tracking-[0.25em] block">
@@ -73,9 +73,9 @@ export const ExecutiveStatsBar: React.FC<ExecutiveStatsBarProps> = ({
 
       {/* 4. Scan Activity */}
       <div className="px-6 last:pr-8">
-        <span className="text-xs font-bold text-white/70 uppercase tracking-[0.3em] block mb-6">Scan Cycles</span>
+        <span className="text-xs font-bold text-silver uppercase tracking-[0.3em] block mb-6">Scan Cycles</span>
         <div className="space-y-8">
-          <span className="text-8xl font-normal text-white leading-[0.8]" style={{ fontFamily: 'var(--font-display)' }}>
+          <span className="text-8xl font-normal text-silver-bright leading-[0.8]" style={{ fontFamily: 'var(--font-display)' }}>
             {scanCount.toLocaleString()}
           </span>
           <span className="text-xs text-[var(--rag-blue)] font-bold uppercase tracking-[0.25em] block">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,6 +14,8 @@
    Design Tokens
    ============================================ */
 :root {
+  color-scheme: dark;
+
   /* Core Palette - Premium SOC */
   --bg-primary: #0a0b0d;
   /* Deep Onyx */
@@ -63,12 +65,33 @@
   --sidebar-expanded: 280px;
 }
 
+/* Light mode keeps the same semantic palette while swapping its surfaces and
+   text values. Tailwind's custom charcoal/silver utilities resolve to these
+   variables, so one root class updates the entire application. */
+:root.theme-light {
+  color-scheme: light;
+
+  --bg-primary: #f4f6f8;
+  --bg-secondary: #ffffff;
+  --bg-tertiary: #e8edf2;
+  --bg-elevated: #dce3ea;
+
+  --accent-silver: #64748b;
+  --accent-silver-dim: #64748b;
+  --accent-silver-bright: #111827;
+
+  --text-primary: #111827;
+  --text-secondary: #475569;
+  --text-muted: #64748b;
+}
+
 /* Base Overrides */
 body {
   background-color: var(--bg-primary);
   color: var(--accent-silver);
   font-family: var(--font-sans);
   text-rendering: optimizeLegibility;
+  transition: background-color 200ms ease, color 200ms ease;
 }
 
 @layer components {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -7,16 +8,16 @@ export default {
   theme: {
     extend: {
       colors: {
-        'charcoal-dark': '#0a0a0c',
+        'charcoal-dark': 'var(--bg-primary)',
         charcoal: {
-          light: '#1d1d21',
-          DEFAULT: '#121214',
-          dark: '#0a0a0c', /* mapped for backward compatibility */
+          light: 'var(--bg-tertiary)',
+          DEFAULT: 'var(--bg-secondary)',
+          dark: 'var(--bg-primary)', /* mapped for backward compatibility */
         },
         silver: {
-          bright: '#f4f4f5',
-          DEFAULT: '#a1a1aa',
-          dark: '#475569',
+          bright: 'var(--text-primary)',
+          DEFAULT: 'var(--text-secondary)',
+          dark: 'var(--text-muted)',
         },
         rag: {
           red: '#ef4444',
@@ -27,7 +28,7 @@ export default {
           'blue-bright': '#3b82f6',    
         },
         accent: {
-          silver: '#3f3f46'
+          silver: 'var(--accent-silver)'
         }
       },
       fontFamily: {

--- a/frontend/testing/unit/components/ThemeToggle.test.tsx
+++ b/frontend/testing/unit/components/ThemeToggle.test.tsx
@@ -39,6 +39,8 @@ describe('ThemeToggle', () => {
 
     expect(localStorage.getItem(STORAGE_KEY)).toBe('light')
     expect(button).toHaveAttribute('aria-pressed', 'false')
+    expect(document.documentElement).toHaveClass('theme-light')
+    expect(document.documentElement).not.toHaveClass('dark')
   })
 
   it('toggles from light to dark on click and persists to localStorage', async () => {
@@ -53,6 +55,18 @@ describe('ThemeToggle', () => {
 
     expect(localStorage.getItem(STORAGE_KEY)).toBe('dark')
     expect(button).toHaveAttribute('aria-pressed', 'true')
+    expect(document.documentElement).toHaveClass('dark')
+    expect(document.documentElement).not.toHaveClass('theme-light')
+  })
+
+  it('restores a saved light theme when the provider mounts', () => {
+    localStorage.setItem(STORAGE_KEY, 'light')
+
+    renderWithTheme()
+
+    expect(document.documentElement).toHaveClass('theme-light')
+    expect(document.documentElement).not.toHaveClass('dark')
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('aria-label reflects the target theme, not the current one', () => {


### PR DESCRIPTION
Closes #1089

## What changed
- configured Tailwind dark mode to follow the root `.dark` class
- moved shared charcoal and silver utilities onto semantic CSS variables
- added a complete light palette and native `color-scheme` support
- updated dashboard statistics to use semantic text colors in both themes
- expanded theme-toggle coverage for root classes and saved preference restoration

## Root cause
The React theme context already changed the root class and persisted the preference, but Tailwind was still using media-query dark mode and the main palette was compiled to fixed dark colors. As a result, clicking the control changed state without changing the rendered UI.

## Validation
- `npm run typecheck`
- `npm run build -- --logLevel error`
- Playwright browser smoke check: dark `rgb(10, 11, 13)` -> light `rgb(244, 246, 248)`, with `secuscan-theme=light` persisted
- verified dashboard statistic text remains visible in light mode

## Test environment note
The focused Vitest run could not start under the local Node 18 runtime because the project requires Node 20+ and jsdom failed during worker initialization. No test files were loaded; this is recorded here for transparency.