### PR TITLE
test : added unit tests for build_report_filename and _slugify_filename_part helpers

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -20,12 +20,18 @@ from .routes_json_helpers import (
     deserialize_finding_rows,
     parse_json_fields,
 )
+from .routes_report_helpers import (
+    _slugify_filename_part,
+    build_report_filename,
+)
 
 __all__ = [
     "FINDING_JSON_FIELDS",
     "parse_json_fields",
     "deserialize_finding_rows",
     "deserialize_asset_service_rows",
+    "_slugify_filename_part",
+    "build_report_filename",
 ]
 
 def _parse_workflow_steps(raw_steps: Any) -> List[Dict[str, Any]]:
@@ -73,24 +79,6 @@ def _json_payload(value: Any, fallback: str) -> str:
 
 
 from .validation import is_filesystem_target  # noqa: E402
-
-def _slugify_filename_part(value: str, fallback: str) -> str:
-    cleaned = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
-    return cleaned or fallback
-
-def build_report_filename(task: Dict[str, Any], extension: str) -> str:
-    tool = _slugify_filename_part(str(task.get("tool_name") or task.get("plugin_id") or "scan"), "scan")
-
-    raw_target = str(task.get("target") or "")
-    parsed = urlparse(raw_target if "://" in raw_target else f"//{raw_target}")
-    target_source = parsed.netloc or parsed.path or raw_target
-    target = _slugify_filename_part(target_source, "target")
-
-    created_at = str(task.get("created_at") or "")
-    date_match = re.search(r"\d{4}-\d{2}-\d{2}", created_at)
-    date_part = date_match.group(0) if date_match else "report"
-
-    return f"secuscan_{tool}_{target}_{date_part}.{extension}"
 
 logger = logging.getLogger(__name__)
 

--- a/backend/secuscan/routes_report_helpers.py
+++ b/backend/secuscan/routes_report_helpers.py
@@ -1,0 +1,29 @@
+"""
+Pure helpers extracted from routes.py for safe import in unit tests.
+
+These functions contain no FastAPI or database dependencies.
+routes.py re-exports them so existing call sites keep working.
+"""
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+
+def _slugify_filename_part(value: str, fallback: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return cleaned or fallback
+
+
+def build_report_filename(task: Any, extension: str) -> str:
+    tool = _slugify_filename_part(str(task.get("tool_name") or task.get("plugin_id") or "scan"), "scan")
+
+    raw_target = str(task.get("target") or "")
+    parsed = urlparse(raw_target if "://" in raw_target else f"//{raw_target}")
+    target_source = parsed.netloc or parsed.path or raw_target
+    target = _slugify_filename_part(target_source, "target")
+
+    created_at = str(task.get("created_at") or "")
+    date_match = re.search(r"\d{4}-\d{2}-\d{2}", created_at)
+    date_part = date_match.group(0) if date_match else "report"
+
+    return f"secuscan_{tool}_{target}_{date_part}.{extension}"

--- a/testing/backend/unit/test_routes_report_filename.py
+++ b/testing/backend/unit/test_routes_report_filename.py
@@ -1,0 +1,196 @@
+"""
+Unit tests for _slugify_filename_part and build_report_filename helpers.
+
+Imports the real production functions from backend.secuscan.routes so
+a regression in the actual implementation is caught by these tests.
+"""
+
+import re
+from backend.secuscan.routes_report_helpers import _slugify_filename_part, build_report_filename
+
+
+# ---------------------------------------------------------------------------
+# _slugify_filename_part
+# ---------------------------------------------------------------------------
+
+
+def test_slugify_lowercases():
+    """Input is lowercased before slugification."""
+    assert _slugify_filename_part("Nmap", "scan") == "nmap"
+
+
+def test_slugify_replaces_non_alphanumeric_with_dash():
+    """Non-alphanumeric characters are replaced with dashes."""
+    assert _slugify_filename_part("Hello World!", "scan") == "hello-world"
+
+
+def test_slugify_collapse_multiple_dashes():
+    """Multiple consecutive non-alphanumeric chars collapse to a single dash."""
+    assert _slugify_filename_part("hello...world", "scan") == "hello-world"
+    assert _slugify_filename_part("a--b--c", "scan") == "a-b-c"
+
+
+def test_slugify_strips_leading_trailing_dashes():
+    """Leading and trailing dashes are stripped."""
+    assert _slugify_filename_part("!!!scan!!!", "scan") == "scan"
+    assert _slugify_filename_part("--nmap--", "scan") == "nmap"
+
+
+def test_slugify_returns_fallback_on_empty():
+    """Empty result after cleaning returns the fallback string."""
+    assert _slugify_filename_part("!!!", "scan") == "scan"
+    assert _slugify_filename_part("---", "fallback") == "fallback"
+
+
+def test_slugify_already_slug():
+    """Already-slugified input passes through unchanged."""
+    assert _slugify_filename_part("nmap-scanner", "scan") == "nmap-scanner"
+
+
+def test_slugify_with_underscores():
+    """Underscores are treated as non-alphanumeric and replaced with dash."""
+    assert _slugify_filename_part("nmap_scanner", "scan") == "nmap-scanner"
+
+
+def test_slugify_fallback_not_used_when_result_is_valid():
+    """Fallback is not returned when there is a valid result."""
+    result = _slugify_filename_part("tool", "fallback")
+    assert result == "tool"
+    assert result != "fallback"
+
+
+# ---------------------------------------------------------------------------
+# build_report_filename
+# ---------------------------------------------------------------------------
+
+
+def test_filename_includes_tool_target_date():
+    """Filename follows the pattern secuscan_{tool}_{target}_{date}.{ext}."""
+    task = {
+        "tool_name": "nmap",
+        "target": "example.com",
+        "created_at": "2026-06-22T10:00:00Z",
+    }
+    result = build_report_filename(task, "csv")
+    assert result.startswith("secuscan_nmap_example-com_2026-06-22.csv")
+
+
+def test_filename_uses_plugin_id_when_tool_name_absent():
+    """plugin_id is used when tool_name is missing."""
+    task = {
+        "plugin_id": "nmap",
+        "target": "example.com",
+        "created_at": "2026-06-22",
+    }
+    result = build_report_filename(task, "csv")
+    assert "nmap" in result
+    assert "example-com" in result
+    assert result.endswith(".csv")
+
+
+def test_filename_uses_scan_fallback_for_missing_tool():
+    """scan is used as tool fallback when both tool_name and plugin_id are absent."""
+    task = {
+        "target": "example.com",
+        "created_at": "2026-06-22",
+    }
+    result = build_report_filename(task, "csv")
+    assert result.startswith("secuscan_scan_")
+
+
+def test_filename_strips_scheme_from_target():
+    """The scheme (http://) is stripped from target."""
+    task = {
+        "tool_name": "nmap",
+        "target": "http://example.com",
+        "created_at": "2026-06-22",
+    }
+    result = build_report_filename(task, "csv")
+    assert "http://" not in result
+    assert "example-com" in result
+
+
+def test_filename_uses_netloc_for_full_url():
+    """Netloc is extracted from full URL targets."""
+    task = {
+        "tool_name": "nmap",
+        "target": "https://app.example.com/path",
+        "created_at": "2026-06-22",
+    }
+    result = build_report_filename(task, "csv")
+    assert "app-example-com" in result
+
+
+def test_filename_uses_path_for_scheme_less_url():
+    """Path is used when target has no scheme."""
+    task = {
+        "tool_name": "nmap",
+        "target": "example.com",
+        "created_at": "2026-06-22",
+    }
+    result = build_report_filename(task, "csv")
+    assert "example-com" in result
+
+
+def test_filename_uses_report_fallback_when_no_date():
+    """report is used when created_at is missing."""
+    task = {
+        "tool_name": "nmap",
+        "target": "example.com",
+    }
+    result = build_report_filename(task, "csv")
+    assert "_report." in result
+
+
+def test_filename_uses_report_fallback_when_date_not_iso_format():
+    """report is used when created_at does not contain an ISO date."""
+    task = {
+        "tool_name": "nmap",
+        "target": "example.com",
+        "created_at": "not-a-date",
+    }
+    result = build_report_filename(task, "csv")
+    assert "_report." in result
+
+
+def test_filename_handles_html_extension():
+    """html extension is appended correctly."""
+    task = {"tool_name": "nmap", "target": "example.com", "created_at": "2026-06-22"}
+    result = build_report_filename(task, "html")
+    assert result.endswith(".html")
+
+
+def test_filename_handles_pdf_extension():
+    """pdf extension is appended correctly."""
+    task = {"tool_name": "nmap", "target": "example.com", "created_at": "2026-06-22"}
+    result = build_report_filename(task, "pdf")
+    assert result.endswith(".pdf")
+
+
+def test_filename_handles_sarif_extension():
+    """sarif extension is appended correctly."""
+    task = {"tool_name": "nmap", "target": "example.com", "created_at": "2026-06-22"}
+    result = build_report_filename(task, "sarif")
+    assert result.endswith(".sarif")
+
+
+def test_filename_target_fallback():
+    """target is used as target fallback when target is empty."""
+    task = {
+        "tool_name": "nmap",
+        "target": "",
+        "created_at": "2026-06-22",
+    }
+    result = build_report_filename(task, "csv")
+    assert "_target_" in result
+
+
+def test_filename_contains_only_safe_chars():
+    """Output contains only lowercase alphanumerics, underscores, hyphens, dots."""
+    task = {
+        "tool_name": "Nikto",
+        "target": "https://example.com/",
+        "created_at": "2026-06-22",
+    }
+    result = build_report_filename(task, "csv")
+    assert re.match(r"^[a-z0-9_.\-]+$", result)


### PR DESCRIPTION
Closes #1210.

Summary of What Has Been Done:
Extracted _slugify_filename_part and build_report_filename into a small import-safe module (backend/secuscan/routes_report_helpers.py) following the maintainer-approved pattern. Added test_routes_report_filename.py covering 21 cases: slugification edge cases (lowercasing, dash collapsing, fallback behavior) and build_report_filename with various task dict shapes, URL formats, and extensions.

Changes Made:
- New file: backend/secuscan/routes_report_helpers.py (pure helpers, no FastAPI imports)
- New file: testing/backend/unit/test_routes_report_filename.py
- Modified: backend/secuscan/routes.py imports and re-exports from routes_report_helpers

Impact it Made:
These functions drive Content-Disposition headers for all report downloads (CSV, HTML, PDF, SARIF). Direct unit tests prevent filename corruption from regressions in slugification or URL parsing.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.