### PR TITLE
test : added unit tests for Database.connection property guard behavior

### DIFF
--- a/testing/backend/unit/test_database_connection.py
+++ b/testing/backend/unit/test_database_connection.py
@@ -1,0 +1,38 @@
+"""
+Unit tests for Database.__init__ and Database.connection property guard.
+
+Imports the real Database class from backend.secuscan.database so a regression
+in the connection guard is caught by these tests.
+"""
+from backend.secuscan.database import Database
+
+
+def test_database_init_sets_path():
+    """Database.__init__ stores the db_path."""
+    db = Database("/path/to/test.db")
+    assert db.db_path == "/path/to/test.db"
+
+
+def test_database_init_sets_connection_to_none():
+    """Database.__init__ initializes _connection to None."""
+    db = Database("/path/to/test.db")
+    assert db._connection is None
+
+
+def test_connection_property_raises_when_not_connected():
+    """Database.connection raises RuntimeError when _connection is None."""
+    db = Database("/path/to/test.db")
+    try:
+        db.connection
+        assert False, "Expected RuntimeError"
+    except RuntimeError as exc:
+        assert "Did you forget to await connect" in str(exc)
+
+
+def test_connection_property_returns_mock_connection():
+    """Database.connection returns the underlying aiosqlite connection when set."""
+    import aiosqlite
+    db = Database("/path/to/test.db")
+    mock_conn = aiosqlite.connect(":memory:")
+    db._connection = mock_conn
+    assert db.connection is mock_conn


### PR DESCRIPTION
Closes #1212.

Summary of What Has Been Done:
Added testing/backend/unit/test_database_connection.py covering Database.__init__ and the connection property guard. Tests verify that __init__ sets db_path and _connection=None, that connection raises RuntimeError with a clear message when _connection is None, and that it returns the underlying connection when set.

Changes Made:
- New file: testing/backend/unit/test_database_connection.py with 4 test cases

Impact it Made:
Documents the contract of the connection property and guards against regressions where a None connection is silently returned instead of raising a clear error.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.