### PR TITLE
test : added unit tests for FilterPreset and SavedViewCreate Pydantic validators

### DIFF
--- a/testing/backend/unit/test_saved_views.py
+++ b/testing/backend/unit/test_saved_views.py
@@ -362,3 +362,83 @@ async def test_migration_failure_raises_runtime_error(tmp_path):
         if db and db._connection:
             await db.disconnect()
         broken.unlink(missing_ok=True)
+
+
+# ─── FilterPreset model validators ─────────────────────────────────────────────
+
+from backend.secuscan.saved_views import FilterPreset, SavedViewCreate
+from pydantic import ValidationError
+
+
+class TestFilterPresetDefaults:
+    def test_default_severity_is_all(self):
+        preset = FilterPreset()
+        assert preset.severity == "all"
+
+    def test_default_sort_mode_is_severity(self):
+        preset = FilterPreset()
+        assert preset.sortMode == "severity"
+
+    def test_default_scanner_is_all(self):
+        preset = FilterPreset()
+        assert preset.scanner == "all"
+
+
+class TestFilterPresetValidateSortMode:
+    def test_valid_sort_modes(self):
+        for mode in ("severity", "newest", "oldest", "target"):
+            preset = FilterPreset(sortMode=mode)
+            assert preset.sortMode == mode
+
+    def test_invalid_sort_mode_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            FilterPreset(sortMode="invalid_mode")
+        assert "sortMode must be one of" in str(exc_info.value)
+
+
+class TestFilterPresetValidateSeverity:
+    def test_valid_severities(self):
+        for sev in ("all", "critical", "high", "medium", "low", "info"):
+            preset = FilterPreset(severity=sev)
+            assert preset.severity == sev
+
+    def test_invalid_severity_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            FilterPreset(severity="dangerous")
+        assert "severity must be one of" in str(exc_info.value)
+
+
+# ─── SavedViewCreate model validators ──────────────────────────────────────────
+
+class TestSavedViewCreateStripName:
+    def test_valid_name_passes(self):
+        sv = SavedViewCreate(name="My View", filter_json='{"severity":"all"}')
+        assert sv.name == "My View"
+
+    def test_strips_leading_trailing_whitespace(self):
+        sv = SavedViewCreate(name="  trimmed  ", filter_json='{"severity":"all"}')
+        assert sv.name == "trimmed"
+
+    def test_blank_name_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            SavedViewCreate(name="   ", filter_json='{"severity":"all"}')
+        assert "name cannot be blank" in str(exc_info.value)
+
+    def test_empty_string_name_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            SavedViewCreate(name="", filter_json='{"severity":"all"}')
+        # Pydantic's min_length=1 constraint fires before field_validator,
+        # raising string_too_short.
+        assert "string_too_short" in str(exc_info.value)
+
+
+class TestSavedViewCreateValidateFilterJson:
+    def test_valid_json_passes(self):
+        sv = SavedViewCreate(name="v", filter_json='{"severity":"critical"}')
+        assert sv.filter_json == '{"severity":"critical"}'
+
+    def test_malformed_json_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            SavedViewCreate(name="v", filter_json="not json")
+        # pydantic raises an error for invalid JSON in field_validator
+        assert "validation error" in str(exc_info.value).lower()


### PR DESCRIPTION
Closes #1225.

Summary of What Has Been Done:
Added 13 unit tests to testing/backend/unit/test_saved_views.py covering the Pydantic model validators in FilterPreset and SavedViewCreate from backend.secuscan.saved_views. The existing integration tests cover the HTTP routes but not the validator edge cases.

Changes Made:
- FilterPreset defaults: severity defaults to all, sortMode defaults to severity, scanner defaults to all
- FilterPreset.validate_sort_mode: all 4 valid modes pass; invalid mode raises ValueError
- FilterPreset.validate_severity: all 6 valid severities pass; invalid severity raises ValueError
- SavedViewCreate.strip_name: valid name passes, whitespace is trimmed, blank/whitespace-only raises ValidationError (min_length constraint fires for empty string, field_validator fires for whitespace-only)
- SavedViewCreate.validate_filter_json: valid JSON passes, malformed JSON raises ValidationError

Impact it Made:
FilterPreset and SavedViewCreate are the input boundary for the saved-views API. Validator bugs could corrupt stored filter state. Direct unit tests catch regressions in validator logic without needing a full HTTP client.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.