### PR TITLE
feat(reporting): Add Quick Re-run Action Button to Scans List Table

### DIFF
--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -482,15 +482,34 @@ export default function Scans() {
                               {formatLocaleTime(createDate)}
                             </p>
                           </div>
-                          {task.duration_seconds && (
-                            <div className="bg-charcoal-dark border-2 border-black px-4 py-2 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]">
-                              <p className="text-[10px] font-black font-mono text-rag-blue leading-none">
-                                {formatDuration(
-                                  task.duration_seconds,
-                                )?.toUpperCase()}
-                              </p>
-                            </div>
-                          )}
+                          <div className="flex items-center gap-3">
+                            {task.duration_seconds && (
+                              <div className="bg-charcoal-dark border-2 border-black px-4 py-2 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]">
+                                <p className="text-[10px] font-black font-mono text-rag-blue leading-none">
+                                  {formatDuration(
+                                    task.duration_seconds,
+                                  )?.toUpperCase()}
+                                </p>
+                              </div>
+                            )}
+                            {(task.status === "completed" ||
+                              task.status === "failed" ||
+                              task.status === "cancelled") && (
+                              <button
+                                type="button"
+                                aria-label={`Re-run ${task.tool} scan`}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleRescan(task);
+                                }}
+                                className="w-10 h-10 border-4 border-black bg-rag-blue text-black flex items-center justify-center transition-all hover:bg-rag-blue/80 active:translate-x-0.5 active:translate-y-0.5 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)] active:shadow-none"
+                              >
+                                <span className="material-symbols-outlined text-sm font-black">
+                                  replay
+                                </span>
+                              </button>
+                            )}
+                          </div>
                         </div>
                       </div>
 

--- a/frontend/testing/unit/pages/Scans.test.tsx
+++ b/frontend/testing/unit/pages/Scans.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../../../src/api', () => ({
   deleteTask: vi.fn().mockResolvedValue({}),
   clearAllTasks: vi.fn().mockResolvedValue({}),
   bulkDeleteTasks: vi.fn().mockResolvedValue({}),
+  startTask: vi.fn().mockResolvedValue({ task_id: 'new-task-123' }),
 }))
 
 vi.mock('../../../src/routes', () => ({
@@ -212,5 +213,29 @@ describe('Scans — task list', () => {
     await userEvent.click(screen.getByText('Delete_Record'))
 
     await waitFor(() => expect(screen.getByText('Delete Scan Record')).toBeInTheDocument())
+  })
+
+  it('renders quick re-run button for completed tasks and triggers handleRescan', async () => {
+    const tasks = [makeTask({ task_id: 'task-123', status: 'completed', tool: 'nmap' })]
+    mockFetch(tasks)
+    renderScans()
+
+    await waitFor(() => expect(screen.getByText('nmap')).toBeInTheDocument())
+
+    const rerunBtn = screen.getByRole('button', { name: /Re-run nmap scan/i })
+    expect(rerunBtn).toBeInTheDocument()
+
+    const { startTask } = await import('../../../src/api')
+    await userEvent.click(rerunBtn)
+
+    await waitFor(() => {
+      expect(startTask).toHaveBeenCalledWith(
+        'nmap',
+        expect.any(Object),
+        true,
+        undefined,
+        undefined
+      )
+    })
   })
 })


### PR DESCRIPTION
## Description
This PR implements a quick re-run action button next to each completed, failed, or cancelled scan in the Operational Registry (Scans list view). Clicking this button allows users to immediately trigger a rescan using the past scan inputs without having to re-configure the inputs manually.

## Related Issues
Closes #1100

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Added unit tests in `Scans.test.tsx` verifying:
  - Rendering of the quick re-run action button for completed tasks.
  - Clicking the quick re-run button successfully triggers the `startTask` API with correct parameters.
- Executed `npm run test` (Vitest) - all 43 test files and 363 tests passed successfully.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.