### PR TITLE
feat(reporting): Implement Bulk Export of Security Findings (CSV/JSON)

### DIFF
--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -5,6 +5,7 @@ import { getFindings } from '../api'
 import { formatLocaleDate, parseDateSafe, getCurrentTimeZone } from '../utils/date'
 import SavedViewsPanel from '../components/SavedViewsPanel'
 import { useSavedViews, FilterPreset } from '../hooks/useSavedViews'
+import { exportFindingsAsCSV, exportFindingsAsJSON } from '../utils/exportUtils'
 
 type RiskFactor = {
   factor: string
@@ -161,6 +162,10 @@ export default function Findings() {
   const [selectedFindingId, setSelectedFindingId] = useState<string | null>(null)
   const [reviewState, setReviewState] = useState<ReviewState>({})
   const [copiedFindingId, setCopiedFindingId] = useState<string | null>(null)
+
+  // ── Multi-select export state & handlers ───────────────────────────────────
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [exportDropdownOpen, setExportDropdownOpen] = useState(false)
 
   // ── Saved views ────────────────────────────────────────────────────────────
   const { views, loading: viewsLoading, saveView, deleteView, renameView } = useSavedViews()
@@ -323,6 +328,51 @@ export default function Findings() {
     })
   }, [enrichedFindings, filterSeverity, filterTarget, filterScanner, filterAsset, filterKind, filterAnalystStatus, filterValidatedOnly, filterHighConfidence, searchQuery, dateFrom, dateTo])
 
+  // ── Multi-select export state & handlers ───────────────────────────────────
+  const visibleIds = useMemo(() => filteredFindings.map((f) => f.id), [filteredFindings])
+  const isAllSelected = useMemo(() => {
+    if (visibleIds.length === 0) return false
+    return visibleIds.every((id) => selectedIds.has(id))
+  }, [visibleIds, selectedIds])
+
+  const handleSelectAllToggle = () => {
+    if (isAllSelected) {
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        visibleIds.forEach((id) => next.delete(id))
+        return next
+      })
+    } else {
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        visibleIds.forEach((id) => next.add(id))
+        return next
+      })
+    }
+  }
+
+  const handleCheckboxChange = (id: string, checked: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (checked) {
+        next.add(id)
+      } else {
+        next.delete(id)
+      }
+      return next
+    })
+  }
+
+  const handleExportCSV = () => {
+    const selectedFindings = findings.filter((f) => selectedIds.has(f.id))
+    exportFindingsAsCSV(selectedFindings)
+  }
+
+  const handleExportJSON = () => {
+    const selectedFindings = findings.filter((f) => selectedIds.has(f.id))
+    exportFindingsAsJSON(selectedFindings)
+  }
+
   const sortedFindings = useMemo(() => {
     const items = [...filteredFindings]
     switch (sortMode) {
@@ -446,6 +496,7 @@ export default function Findings() {
     setDateFrom('')
     setDateTo('')
     setSearchQuery('')
+    setSelectedIds(new Set())
   }
 
   function updateFindingStatus(id: string, status: FindingStatus) {
@@ -801,15 +852,78 @@ export default function Findings() {
                 <p className="mt-3 text-xs font-mono uppercase tracking-[0.2em] text-silver/15">Adjust filters to reopen the queue.</p>
               </div>
             ) : (
-              <div
-                ref={parentRef}
-                role="listbox"
-                aria-label="Findings list"
-                tabIndex={0}
-                onKeyDown={handleListKeyDown}
-                className="border-2 border-black bg-charcoal shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] focus:outline-none focus:ring-2 focus:ring-rag-red/40"
-                style={{ height: '72vh', overflowY: 'auto' }}
-              >
+              <>
+                {/* Selection & Export Toolbar */}
+                <div className="flex flex-wrap items-center justify-between gap-4 border-2 border-black bg-charcoal p-4 mb-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="checkbox"
+                      id="select-all-findings"
+                      checked={isAllSelected}
+                      onChange={handleSelectAllToggle}
+                      className="h-4 w-4 accent-[var(--accent-rag-red)] cursor-pointer"
+                    />
+                    <label
+                      htmlFor="select-all-findings"
+                      className="text-xs font-black uppercase tracking-wider text-silver-bright cursor-pointer select-none"
+                    >
+                      Select All Visible ({filteredFindings.length})
+                    </label>
+                    {selectedIds.size > 0 && (
+                      <span className="text-[10px] font-mono uppercase tracking-wider text-silver/50 bg-charcoal-dark px-2 py-0.5 border border-silver-bright/10 ml-2">
+                        {selectedIds.size} Selected
+                      </span>
+                    )}
+                  </div>
+
+                  {selectedIds.size > 0 && (
+                    <div className="relative">
+                      <button
+                        type="button"
+                        id="bulk-export-btn"
+                        onClick={() => setExportDropdownOpen(!exportDropdownOpen)}
+                        className="bg-rag-blue text-black border-2 border-black px-4 py-2 text-xs font-black uppercase tracking-wider shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:bg-rag-blue/90 active:translate-x-0.5 active:translate-y-0.5 active:shadow-none transition-all flex items-center gap-2"
+                      >
+                        Bulk Export
+                        <span className="material-symbols-outlined text-sm">arrow_drop_down</span>
+                      </button>
+                      {exportDropdownOpen && (
+                        <div className="absolute right-0 mt-2 w-48 border-2 border-black bg-charcoal-dark shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] z-30">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              handleExportCSV()
+                              setExportDropdownOpen(false)
+                            }}
+                            className="w-full text-left px-4 py-3 text-xs font-mono uppercase tracking-wider text-silver-bright hover:bg-silver-bright/10 transition-all border-b border-black"
+                          >
+                            Export as CSV
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              handleExportJSON()
+                              setExportDropdownOpen(false)
+                            }}
+                            className="w-full text-left px-4 py-3 text-xs font-mono uppercase tracking-wider text-silver-bright hover:bg-silver-bright/10 transition-all"
+                          >
+                            Export as JSON
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <div
+                  ref={parentRef}
+                  role="listbox"
+                  aria-label="Findings list"
+                  tabIndex={0}
+                  onKeyDown={handleListKeyDown}
+                  className="border-2 border-black bg-charcoal shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] focus:outline-none focus:ring-2 focus:ring-rag-red/40"
+                  style={{ height: '72vh', overflowY: 'auto' }}
+                >
                 {/* Virtualizer inner container */}
                 <div
                   style={{ height: virtualizer.getTotalSize(), width: '100%', position: 'relative' }}
@@ -853,82 +967,98 @@ export default function Findings() {
                             const config = severityConfig[finding.severity]
 
                             return (
-                              <button
+                              <div
                                 key={finding.id}
-                                type="button"
-                                role="option"
-                                aria-selected={isSelected}
-                                onClick={() => setSelectedFindingId(finding.id)}
-                                className={`relative block w-full px-5 py-5 text-left transition-all ${
+                                className={`relative flex items-stretch w-full transition-all ${
                                   !isLastInGroup ? 'border-b border-silver-bright/6' : ''
                                 } ${isSelected ? 'bg-silver-bright/6' : 'hover:bg-silver-bright/3'}`}
                               >
-                                <span className={`absolute inset-y-0 left-0 w-1 ${config.rail}`} />
-                                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                                  <div className="min-w-0 flex-1 space-y-3 pl-3">
-                                    <div className="flex flex-wrap items-center gap-2">
-                                      <span className={`px-2 py-1 text-[9px] font-black uppercase tracking-[0.18em] ${config.chip}`}>
-                                        {config.label}
-                                      </span>
-                                      <span className={`border px-2 py-1 text-[9px] font-black uppercase tracking-[0.18em] ${getStatusTone(finding.status)}`}>
-                                        {finding.status}
-                                      </span>
-                                      <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-silver/35">
-                                        {finding.category || 'Uncategorized'}
-                                      </span>
-                                      {finding.finding_kind ? (
-                                        <span className="border border-silver-bright/10 bg-charcoal-dark px-2 py-1 text-[9px] font-mono uppercase tracking-[0.15em] text-silver/70">
-                                          {finding.finding_kind.replace('_', ' ')}
-                                        </span>
-                                      ) : null}
-                                      {finding.cve ? (
-                                        <span className="border border-rag-blue/20 bg-rag-blue/10 px-2 py-1 text-[9px] font-mono uppercase tracking-[0.15em] text-rag-blue">
-                                          {finding.cve}
-                                        </span>
-                                      ) : null}
-                                      {typeof finding.confidence === 'number' ? (
-                                        <span className="border border-silver-bright/10 bg-charcoal-dark px-2 py-1 text-[9px] font-mono uppercase tracking-[0.15em] text-silver-bright">
-                                          {(finding.confidence * 100).toFixed(0)}% confidence
-                                        </span>
-                                      ) : null}
-                                    </div>
+                                {/* Checkbox column */}
+                                <div className="pl-4 pr-1 flex items-center justify-center">
+                                  <input
+                                    type="checkbox"
+                                    aria-label={`Select ${finding.title}`}
+                                    checked={selectedIds.has(finding.id)}
+                                    onChange={(e) => handleCheckboxChange(finding.id, e.target.checked)}
+                                    className="h-4 w-4 accent-[var(--accent-rag-red)] cursor-pointer"
+                                  />
+                                </div>
 
-                                    <div>
-                                      <h3 className="text-xl font-black uppercase tracking-tight text-silver-bright">{finding.title}</h3>
-                                      <p className="mt-2 text-[11px] font-mono uppercase tracking-[0.16em] text-silver/45">
-                                        Target // {finding.target || 'Unknown'} // Observed // {formatLocaleDate(finding.discovered_at)}
+                                {/* Details button */}
+                                <button
+                                  type="button"
+                                  role="option"
+                                  aria-selected={isSelected}
+                                  onClick={() => setSelectedFindingId(finding.id)}
+                                  className="relative block flex-1 px-5 py-5 text-left transition-all focus:outline-none"
+                                >
+                                  <span className={`absolute inset-y-0 left-0 w-1 ${config.rail}`} />
+                                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                                    <div className="min-w-0 flex-1 space-y-3 pl-3">
+                                      <div className="flex flex-wrap items-center gap-2">
+                                        <span className={`px-2 py-1 text-[9px] font-black uppercase tracking-[0.18em] ${config.chip}`}>
+                                          {config.label}
+                                        </span>
+                                        <span className={`border px-2 py-1 text-[9px] font-black uppercase tracking-[0.18em] ${getStatusTone(finding.status)}`}>
+                                          {finding.status}
+                                        </span>
+                                        <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-silver/35">
+                                          {finding.category || 'Uncategorized'}
+                                        </span>
+                                        {finding.finding_kind ? (
+                                          <span className="border border-silver-bright/10 bg-charcoal-dark px-2 py-1 text-[9px] font-mono uppercase tracking-[0.15em] text-silver/70">
+                                            {finding.finding_kind.replace('_', ' ')}
+                                          </span>
+                                        ) : null}
+                                        {finding.cve ? (
+                                          <span className="border border-rag-blue/20 bg-rag-blue/10 px-2 py-1 text-[9px] font-mono uppercase tracking-[0.15em] text-rag-blue">
+                                            {finding.cve}
+                                          </span>
+                                        ) : null}
+                                        {typeof finding.confidence === 'number' ? (
+                                          <span className="border border-silver-bright/10 bg-charcoal-dark px-2 py-1 text-[9px] font-mono uppercase tracking-[0.15em] text-silver-bright">
+                                            {(finding.confidence * 100).toFixed(0)}% confidence
+                                          </span>
+                                        ) : null}
+                                      </div>
+
+                                      <div>
+                                        <h3 className="text-xl font-black uppercase tracking-tight text-silver-bright">{finding.title}</h3>
+                                        <p className="mt-2 text-[11px] font-mono uppercase tracking-[0.16em] text-silver/45">
+                                          Target // {finding.target || 'Unknown'} // Observed // {formatLocaleDate(finding.discovered_at)}
+                                        </p>
+                                      </div>
+
+                                      <p className="max-w-4xl text-sm leading-relaxed text-silver/70">
+                                        {finding.description || 'No description provided.'}
                                       </p>
                                     </div>
 
-                                    <p className="max-w-4xl text-sm leading-relaxed text-silver/70">
-                                      {finding.description || 'No description provided.'}
-                                    </p>
-                                  </div>
+                                    <div className="flex flex-row items-end gap-6 lg:min-w-[140px] lg:flex-col lg:items-end">
+                                      {typeof finding.occurrence_count === 'number' && finding.occurrence_count > 1 ? (
+                                        <div className="text-right">
+                                          <p className="text-[9px] font-black uppercase tracking-[0.2em] text-silver/35">Seen</p>
+                                          <p className="text-2xl font-black italic text-silver-bright">
+                                            {finding.occurrence_count}
+                                          </p>
+                                        </div>
+                                      ) : null}
+                                      {typeof finding.cvss === 'number' ? (
+                                        <div className="text-right">
+                                          <p className="text-[9px] font-black uppercase tracking-[0.2em] text-silver/35">CVSS</p>
+                                          <p className={`text-3xl font-black italic ${finding.cvss >= 9 ? 'text-rag-red' : 'text-silver-bright'}`}>
+                                            {finding.cvss.toFixed(1)}
+                                          </p>
+                                        </div>
+                                      ) : null}
 
-                                  <div className="flex flex-row items-end gap-6 lg:min-w-[140px] lg:flex-col lg:items-end">
-                                    {typeof finding.occurrence_count === 'number' && finding.occurrence_count > 1 ? (
-                                      <div className="text-right">
-                                        <p className="text-[9px] font-black uppercase tracking-[0.2em] text-silver/35">Seen</p>
-                                        <p className="text-2xl font-black italic text-silver-bright">
-                                          {finding.occurrence_count}
-                                        </p>
-                                      </div>
-                                    ) : null}
-                                    {typeof finding.cvss === 'number' ? (
-                                      <div className="text-right">
-                                        <p className="text-[9px] font-black uppercase tracking-[0.2em] text-silver/35">CVSS</p>
-                                        <p className={`text-3xl font-black italic ${finding.cvss >= 9 ? 'text-rag-red' : 'text-silver-bright'}`}>
-                                          {finding.cvss.toFixed(1)}
-                                        </p>
-                                      </div>
-                                    ) : null}
-
-                                    <span className={`material-symbols-outlined text-lg ${isSelected ? 'text-silver-bright' : 'text-silver/30'}`}>
-                                      east
-                                    </span>
+                                      <span className={`material-symbols-outlined text-lg ${isSelected ? 'text-silver-bright' : 'text-silver/30'}`}>
+                                        east
+                                      </span>
+                                    </div>
                                   </div>
-                                </div>
-                              </button>
+                                </button>
+                              </div>
                             )
                           })()
                         )}
@@ -937,19 +1067,20 @@ export default function Findings() {
                   })}
                 </div>
               </div>
-            )}
-            {!loading && findings.length < totalItems && (
-              <div className="flex justify-center py-6">
-                <button
-                  type="button"
-                  onClick={loadMore}
-                  disabled={loadingMore}
-                  className="bg-silver-bright px-6 py-3 text-[11px] font-black uppercase tracking-[0.18em] text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all active:translate-x-0.5 active:translate-y-0.5 active:shadow-none disabled:opacity-50"
-                >
-                  {loadingMore ? 'Loading...' : `Load More (${findings.length}/${totalItems})`}
-                </button>
-              </div>
-            )}
+              {!loading && findings.length < totalItems && (
+                <div className="flex justify-center py-6">
+                  <button
+                    type="button"
+                    onClick={loadMore}
+                    disabled={loadingMore}
+                    className="bg-silver-bright px-6 py-3 text-[11px] font-black uppercase tracking-[0.18em] text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-all active:translate-x-0.5 active:translate-y-0.5 active:shadow-none disabled:opacity-50"
+                  >
+                    {loadingMore ? 'Loading...' : `Load More (${findings.length}/${totalItems})`}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
           </motion.section>
 
           {/* ── Detail Panel (unchanged) ── */}

--- a/frontend/src/utils/exportUtils.ts
+++ b/frontend/src/utils/exportUtils.ts
@@ -1,0 +1,73 @@
+export function escapeCSV(val: any): string {
+  if (val === null || val === undefined) return ''
+  const str = String(val)
+  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+export function serializeFindingsToCSV(findings: any[]): string {
+  const headers = [
+    'ID',
+    'Title',
+    'Severity',
+    'Category',
+    'Target',
+    'Discovered At',
+    'CVSS',
+    'CVE',
+    'Risk Score',
+    'Confidence',
+    'Validated',
+    'Analyst Status',
+    'Description',
+    'Remediation'
+  ]
+
+  const rows = findings.map((f) => [
+    f.id || '',
+    f.title || '',
+    f.severity || '',
+    f.category || '',
+    f.target || '',
+    f.discovered_at || '',
+    f.cvss !== undefined && f.cvss !== null ? String(f.cvss) : '',
+    f.cve || '',
+    f.risk_score !== undefined && f.risk_score !== null ? String(f.risk_score) : '',
+    f.confidence !== undefined && f.confidence !== null ? String(f.confidence) : '',
+    f.validated ? 'true' : 'false',
+    f.analyst_status || '',
+    f.description || '',
+    f.remediation || ''
+  ])
+
+  return [
+    headers.join(','),
+    ...rows.map((row) => row.map(escapeCSV).join(','))
+  ].join('\n')
+}
+
+export function downloadFile(content: string, filename: string, contentType: string): void {
+  const blob = new Blob([content], { type: contentType })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+export function exportFindingsAsCSV(findings: any[]): void {
+  const csvContent = serializeFindingsToCSV(findings)
+  const dateStr = new Date().toISOString().split('T')[0]
+  downloadFile(csvContent, `secuscan_findings_${dateStr}.csv`, 'text/csv;charset=utf-8;')
+}
+
+export function exportFindingsAsJSON(findings: any[]): void {
+  const jsonContent = JSON.stringify(findings, null, 2)
+  const dateStr = new Date().toISOString().split('T')[0]
+  downloadFile(jsonContent, `secuscan_findings_${dateStr}.json`, 'application/json')
+}

--- a/frontend/testing/unit/pages/Findings.test.tsx
+++ b/frontend/testing/unit/pages/Findings.test.tsx
@@ -10,6 +10,13 @@ vi.mock('../../../src/api', () => ({
   getFindings: vi.fn(),
 }))
 
+vi.mock('../../../src/utils/exportUtils', () => ({
+  exportFindingsAsCSV: vi.fn(),
+  exportFindingsAsJSON: vi.fn(),
+}))
+
+import { exportFindingsAsCSV, exportFindingsAsJSON } from '../../../src/utils/exportUtils'
+
 vi.mock('../../../src/utils/date', async (importOriginal: any) => {
   const actual = await importOriginal() as typeof import('../../../src/utils/date')
   return {
@@ -258,5 +265,76 @@ describe('Findings — virtualized list', () => {
 
     const suppressedChips = screen.queryAllByText('suppressed')
     expect(suppressedChips.length).toBeGreaterThan(0)
+  })
+
+  it('individual checkbox click selects finding for export but doesn\'t change selected finding details', async () => {
+    const findings = [
+      makeFinding({ id: 'f1', title: 'SQL Injection', severity: 'critical' }),
+      makeFinding({ id: 'f2', title: 'CSRF Vulnerability', severity: 'high' }),
+    ]
+    vi.mocked(getFindings).mockResolvedValue({ findings })
+
+    render(<Findings />)
+    await waitFor(() => expect(screen.queryByText('Synchronizing findings feed...')).not.toBeInTheDocument())
+
+    const checkboxF2 = screen.getByLabelText('Select CSRF Vulnerability')
+    expect(checkboxF2).not.toBeChecked()
+
+    await userEvent.click(checkboxF2)
+    expect(checkboxF2).toBeChecked()
+
+    expect(screen.getByRole('button', { name: /Bulk Export/i })).toBeInTheDocument()
+
+    expect(screen.getByRole('heading', { name: /SQL Injection/i, level: 2 })).toBeInTheDocument()
+  })
+
+  it('select all checkbox toggles selection for all visible findings', async () => {
+    const findings = [
+      makeFinding({ id: 'f1', title: 'SQL Injection', severity: 'critical' }),
+      makeFinding({ id: 'f2', title: 'CSRF Vulnerability', severity: 'high' }),
+    ]
+    vi.mocked(getFindings).mockResolvedValue({ findings })
+
+    render(<Findings />)
+    await waitFor(() => expect(screen.queryByText('Synchronizing findings feed...')).not.toBeInTheDocument())
+
+    const selectAllCheckbox = screen.getByLabelText(/Select All Visible/i)
+    await userEvent.click(selectAllCheckbox)
+
+    expect(screen.getByLabelText('Select SQL Injection')).toBeChecked()
+    expect(screen.getByLabelText('Select CSRF Vulnerability')).toBeChecked()
+
+    await userEvent.click(selectAllCheckbox)
+    expect(screen.getByLabelText('Select SQL Injection')).not.toBeChecked()
+    expect(screen.getByLabelText('Select CSRF Vulnerability')).not.toBeChecked()
+  })
+
+  it('trigger CSV and JSON bulk export calls utility function', async () => {
+    const findings = [
+      makeFinding({ id: 'f1', title: 'SQL Injection', severity: 'critical' }),
+    ]
+    vi.mocked(getFindings).mockResolvedValue({ findings })
+
+    render(<Findings />)
+    await waitFor(() => expect(screen.queryByText('Synchronizing findings feed...')).not.toBeInTheDocument())
+
+    await userEvent.click(screen.getByLabelText('Select SQL Injection'))
+
+    const bulkExportBtn = screen.getByRole('button', { name: /Bulk Export/i })
+    await userEvent.click(bulkExportBtn)
+
+    const csvExportBtn = screen.getByRole('button', { name: /Export as CSV/i })
+    const jsonExportBtn = screen.getByRole('button', { name: /Export as JSON/i })
+
+    expect(csvExportBtn).toBeInTheDocument()
+    expect(jsonExportBtn).toBeInTheDocument()
+
+    await userEvent.click(csvExportBtn)
+    expect(exportFindingsAsCSV).toHaveBeenCalled()
+
+    await userEvent.click(bulkExportBtn)
+    const newJsonExportBtn = await screen.findByRole('button', { name: /Export as JSON/i })
+    await userEvent.click(newJsonExportBtn)
+    expect(exportFindingsAsJSON).toHaveBeenCalled()
   })
 })

--- a/frontend/testing/unit/pages/Reports.preferredFormat.test.tsx
+++ b/frontend/testing/unit/pages/Reports.preferredFormat.test.tsx
@@ -51,7 +51,7 @@ describe('Reports — preferred export format', () => {
         const user = userEvent.setup()
         renderReports()
 
-        await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
+        await user.click(await screen.findByRole('button', { name: /^pdf$/ }))
 
         expect(localStorage.getItem('secuscan:preferred-export-format')).toBe('pdf')
     })
@@ -60,7 +60,7 @@ describe('Reports — preferred export format', () => {
         const user = userEvent.setup()
         renderReports()
 
-        await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
+        await user.click(await screen.findByRole('button', { name: /^pdf$/ }))
         await user.click(screen.getByRole('button', { name: /^csv$/i }))
 
         expect(localStorage.getItem('secuscan:preferred-export-format')).toBe('csv')
@@ -81,7 +81,7 @@ describe('Reports — preferred export format', () => {
 
         await screen.findByRole('button', { name: /^csv$/i })
 
-        const buttons = screen.getAllByRole('button', { name: /^(pdf|html|csv)$/i })
+        const buttons = screen.getAllByRole('button', { name: /^(pdf|html|csv)$/ })
         expect(buttons[0].textContent?.toLowerCase()).toBe('csv')
     })
 

--- a/frontend/testing/unit/pages/Reports.test.tsx
+++ b/frontend/testing/unit/pages/Reports.test.tsx
@@ -129,15 +129,15 @@ describe('Reports — export buttons on a ready report', () => {
 
   it('shows PDF, HTML and CSV buttons for a ready report', async () => {
     renderReports()
-    expect(await screen.findByRole('button', { name: /^pdf$/i })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /^pdf$/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^html$/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^csv$/i })).toBeInTheDocument()
   })
 
   it('export buttons are enabled for a ready report', async () => {
     renderReports()
-    await screen.findByRole('button', { name: /^pdf$/i })
-    expect(screen.getByRole('button', { name: /^pdf$/i })).not.toBeDisabled()
+    await screen.findByRole('button', { name: /^pdf$/ })
+    expect(screen.getByRole('button', { name: /^pdf$/ })).not.toBeDisabled()
     expect(screen.getByRole('button', { name: /^html$/i })).not.toBeDisabled()
     expect(screen.getByRole('button', { name: /^csv$/i })).not.toBeDisabled()
   })
@@ -145,7 +145,7 @@ describe('Reports — export buttons on a ready report', () => {
   it('clicking PDF opens the correct backend URL', async () => {
     const user = userEvent.setup()
     renderReports()
-    await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
+    await user.click(await screen.findByRole('button', { name: /^pdf$/ }))
     expect(openSpy).toHaveBeenCalledWith(
       expect.stringContaining('/task/' + readyReport.task_id + '/report/pdf'), '_blank')
   })
@@ -169,7 +169,7 @@ describe('Reports — export buttons on a ready report', () => {
   it('does not use the old placeholder latest-report route', async () => {
     const user = userEvent.setup()
     renderReports()
-    await user.click(await screen.findByRole('button', { name: /^pdf$/i }))
+    await user.click(await screen.findByRole('button', { name: /^pdf$/ }))
     expect(openSpy).not.toHaveBeenCalledWith(expect.stringContaining('latest'), expect.anything())
   })
 })
@@ -218,8 +218,8 @@ describe('Reports — export buttons on a generating report', () => {
 
   it('export buttons are disabled when report is generating', async () => {
     renderReports()
-    await screen.findByRole('button', { name: /^pdf$/i })
-    expect(screen.getByRole('button', { name: /^pdf$/i })).toBeDisabled()
+    await screen.findByRole('button', { name: /^pdf$/ })
+    expect(screen.getByRole('button', { name: /^pdf$/ })).toBeDisabled()
     expect(screen.getByRole('button', { name: /^html$/i })).toBeDisabled()
     expect(screen.getByRole('button', { name: /^csv$/i })).toBeDisabled()
   })
@@ -227,8 +227,8 @@ describe('Reports — export buttons on a generating report', () => {
   it('clicking a disabled button does not open any URL', async () => {
     const user = userEvent.setup()
     renderReports()
-    await screen.findByRole('button', { name: /^pdf$/i })
-    await user.click(screen.getByRole('button', { name: /^pdf$/i }))
+    await screen.findByRole('button', { name: /^pdf$/ })
+    await user.click(screen.getByRole('button', { name: /^pdf$/ }))
     expect(openSpy).not.toHaveBeenCalled()
   })
 })
@@ -242,8 +242,8 @@ describe('Reports — export buttons on a failed report', () => {
 
   it('export buttons are enabled for a failed report since backend supports it', async () => {
     renderReports()
-    await screen.findByRole('button', { name: /^pdf$/i })
-    expect(screen.getByRole('button', { name: /^pdf$/i })).not.toBeDisabled()
+    await screen.findByRole('button', { name: /^pdf$/ })
+    expect(screen.getByRole('button', { name: /^pdf$/ })).not.toBeDisabled()
     expect(screen.getByRole('button', { name: /^html$/i })).not.toBeDisabled()
     expect(screen.getByRole('button', { name: /^csv$/i })).not.toBeDisabled()
   })

--- a/frontend/testing/unit/utils/exportUtils.test.ts
+++ b/frontend/testing/unit/utils/exportUtils.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "vitest";
+import { escapeCSV, serializeFindingsToCSV } from "../../../src/utils/exportUtils";
+
+describe("exportUtils utility", () => {
+  test("escapeCSV handles standard inputs", () => {
+    expect(escapeCSV("hello")).toBe("hello");
+    expect(escapeCSV(123)).toBe("123");
+    expect(escapeCSV(null)).toBe("");
+    expect(escapeCSV(undefined)).toBe("");
+  });
+
+  test("escapeCSV escapes quotes, commas, and newlines", () => {
+    expect(escapeCSV('hello, world')).toBe('"hello, world"');
+    expect(escapeCSV('hello "world"')).toBe('"hello ""world"""');
+    expect(escapeCSV('hello\nworld')).toBe('"hello\nworld"');
+  });
+
+  test("serializeFindingsToCSV generates correct headers and mapped rows", () => {
+    const sampleFindings = [
+      {
+        id: "f-1",
+        title: "SQL Injection",
+        severity: "critical",
+        category: "Database",
+        target: "http://target1.local",
+        discovered_at: "2026-05-12T10:30:00Z",
+        cvss: 9.8,
+        cve: "CVE-2026-1234",
+        risk_score: 9.5,
+        confidence: 0.9,
+        validated: true,
+        analyst_status: "confirmed",
+        description: "An injection vulnerability in input parameter.",
+        remediation: "Use parameterized queries."
+      },
+      {
+        id: "f-2",
+        title: "Information Disclosure, Version Leak",
+        severity: "info",
+        category: "Information",
+        target: "http://target2.local",
+        discovered_at: "2026-05-12T10:35:00Z",
+        cvss: null,
+        cve: undefined,
+        risk_score: 1.0,
+        confidence: 1.0,
+        validated: false,
+        analyst_status: "new",
+        description: "Version string \"1.2.3\" disclosed.",
+        remediation: "Disable version banners."
+      }
+    ];
+
+    const csvContent = serializeFindingsToCSV(sampleFindings);
+    
+    // Header check
+    expect(csvContent).toContain("ID,Title,Severity,Category,Target,Discovered At,CVSS,CVE,Risk Score,Confidence,Validated,Analyst Status,Description,Remediation");
+    
+    // Row checks
+    expect(csvContent).toContain("f-1,SQL Injection,critical,Database,http://target1.local,2026-05-12T10:30:00Z,9.8,CVE-2026-1234,9.5,0.9,true,confirmed,An injection vulnerability in input parameter.,Use parameterized queries.");
+    
+    // Check comma escaping in title, quote escaping in description
+    expect(csvContent).toContain('"Information Disclosure, Version Leak"');
+    expect(csvContent).toContain('"Version string ""1.2.3"" disclosed."');
+  });
+});


### PR DESCRIPTION
## Description
This PR adds checkbox selection controls to the findings table with a "select all" toggle and a "Bulk Export" dropdown menu. Selected findings can be exported to CSV or JSON format client-side.

## Related Issues
Closes #1099

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Added unit tests in `exportUtils.test.ts` and `Findings.test.tsx` verifying:
  - Correct CSV escaping and serialization.
  - Selecting individual rows and checking the "Select All" toggle.
  - Triggering the CSV/JSON download callbacks.
- Executed `npm run test` (Vitest) - all 44 test files passed successfully.