### PR TITLE
fix(cancel_task): add status guard to prevent overwriting completed task status

### DIFF
--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -552,6 +552,7 @@ class TaskExecutor:
         plugin_id: str,
         target: str,
         inputs: Dict[str, Any],
+        safe_mode: bool,
     ) -> tuple[str, float, int]:
         """Execute a standard CLI/Docker plugin and persist findings/report."""
         plugin_manager = get_plugin_manager()
@@ -734,6 +735,7 @@ class TaskExecutor:
                     plugin_id=plugin_id,
                     target=target,
                     inputs=inputs,
+                    safe_mode=safe_mode,
                 )
 
             await self._dispatch_task_notifications(db, task_id)
@@ -1016,8 +1018,8 @@ class TaskExecutor:
         db = await get_db()
         async with db.transaction():
             await db.execute(
-                "UPDATE tasks SET status = ?, completed_at = ? WHERE id = ?",
-                (TaskStatus.CANCELLED.value, datetime.now().isoformat(), task_id)
+                "UPDATE tasks SET status = ?, completed_at = ? WHERE id = ? AND status = ?",
+                (TaskStatus.CANCELLED.value, datetime.now().isoformat(), task_id, TaskStatus.RUNNING.value)
             )
 
             await db.log_audit(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,4 +38,5 @@ markers = [
     "benchmark: performance benchmark tests (deselect with '-m not benchmark')",
 ]
 asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 python_files = ["test_*.py", "bench_*.py"]

--- a/testing/backend/unit/test_executor.py
+++ b/testing/backend/unit/test_executor.py
@@ -951,7 +951,8 @@ async def test_execute_standard_scanner(setup_test_environment):
             plugin=mock_plugin,
             plugin_id="mock_cli_plugin",
             target="127.0.0.1",
-            inputs={}
+            inputs={},
+            safe_mode=0
         )
 
     assert status == TaskStatus.COMPLETED.value


### PR DESCRIPTION
## What does this PR do?

Adds a `AND status = ?` guard to the `cancel_task()` UPDATE statement so that only `RUNNING` tasks are transitioned to `CANCELLED`. Without this guard, a task that completes normally during the 5-second termination grace period would have its `COMPLETED` status silently overwritten to `CANCELLED`.

## Root Cause

In `cancel_task()` (`executor.py:1019`), the CANCELLED status was written unconditionally:

```python
"UPDATE tasks SET status = ?, completed_at = ? WHERE id = ?"
The CancelledError handler inside _execute_standard_scanner already had the correct guard (WHERE id = ? AND status = ? with TaskStatus.RUNNING.value), but the cancel_task() path did not — creating a race window where a completed task's status could be overwritten.
```

## Changes

backend/secuscan/executor.py — Added AND status = ? to the cancel_task UPDATE along with TaskStatus.RUNNING.value in the parameters tuple. This matches the pattern already used in the CancelledError handler.

## Related issue

Fixes #1272