### PR TITLE
fix(ssrf): pin resolved IP to prevent DNS rebinding bypass of network policy

### DIFF
--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -12,7 +12,7 @@ import json
 import time
 from pathlib import Path
 from datetime import datetime, timezone
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 import logging
 import re
 
@@ -368,14 +368,16 @@ class TaskExecutor:
         plugin_id: str,
         safe_mode: bool,
         task_id: str,
-    ) -> bool:
+    ) -> Tuple[bool, Optional[str]]:
         """Enforce Safe Mode target validation and Network Policy access checks.
 
         Returns:
-            True if all checks pass or are bypassed. False if any check blocks execution.
+            Tuple of (all_checks_pass, pinned_ip).
+            pinned_ip is set when network policy is enforced and the target
+            hostname was resolved to a stable IP, preventing DNS rebinding attacks.
         """
         if not target:
-            return True
+            return (True, None)
 
         plugin_manager = get_plugin_manager()
         plugin = plugin_manager.get_plugin(plugin_id)
@@ -402,31 +404,30 @@ class TaskExecutor:
                         f"Safe mode target validation failed: {error_msg}",
                     )
                     await self._broadcast(task_id, "status", TaskStatus.FAILED.value)
-                    return False
+                    return (False, None)
             except asyncio.TimeoutError:
                 await self.mark_task_failed(
                     task_id,
                     "Target validation timed out (SecuScan Guardrail)",
                 )
                 await self._broadcast(task_id, "status", TaskStatus.FAILED.value)
-                return False
+                return (False, None)
 
-        # Check before launching any scanner or subprocess. check_access()
-        # writes an audit entry on every path, so no extra logging needed.
+        # Check before launching any scanner or subprocess. Uses resolve_and_pin
+        # to resolve the hostname ONCE and pin the IP, preventing DNS rebinding
+        # attacks where the scanner subprocess resolves a different (malicious) IP.
         if settings.enforce_network_policy:
             engine = get_policy_engine()
             try:
-                allowed, reason, _ = await asyncio.wait_for(
+                pinned_ip, allowed, reason = await asyncio.wait_for(
                     asyncio.to_thread(
-                        engine.check_access,
-                        dest_ip=target,
-                        plugin_id=plugin_id,
-                        task_id=task_id,
+                        engine.resolve_and_pin,
+                        target,
                     ),
                     timeout=float(settings.dns_resolution_timeout_seconds),
                 )
             except asyncio.TimeoutError:
-                allowed, reason = False, "Network policy check timed out (DNS resolution timeout)"
+                allowed, reason, pinned_ip = False, "Network policy check timed out (DNS resolution timeout)", None
 
             if not allowed:
                 if settings.network_policy_failure_mode == "log_only":
@@ -439,9 +440,11 @@ class TaskExecutor:
                         f"Network policy denied access to {target}: {reason}",
                     )
                     await self._broadcast(task_id, "status", TaskStatus.FAILED.value)
-                    return False
+                    return (False, None)
 
-        return True
+            return (True, pinned_ip)
+
+        return (True, None)
 
     async def _ensure_docker_network(self) -> None:
         """Validate and automatically create the configured Docker network if missing."""
@@ -694,8 +697,14 @@ class TaskExecutor:
             )
 
             # ── Safe Mode & Network policy enforcement ───────────────────────
-            if not await self._enforce_guardrails(target, plugin_id, safe_mode, task_id):
+            guardrails_ok, pinned_ip = await self._enforce_guardrails(target, plugin_id, safe_mode, task_id)
+            if not guardrails_ok:
                 return
+            if pinned_ip:
+                target = pinned_ip
+                for key in ("target", "url", "host", "domain"):
+                    if key in inputs:
+                        inputs[key] = pinned_ip
 
             # Check if this is a modular scanner or a standard plugin
             plugin_manager = get_plugin_manager()

--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -423,6 +423,8 @@ class TaskExecutor:
                     asyncio.to_thread(
                         engine.resolve_and_pin,
                         target,
+                        plugin_id,
+                        task_id,
                     ),
                     timeout=float(settings.dns_resolution_timeout_seconds),
                 )
@@ -701,10 +703,7 @@ class TaskExecutor:
             if not guardrails_ok:
                 return
             if pinned_ip:
-                target = pinned_ip
-                for key in ("target", "url", "host", "domain"):
-                    if key in inputs:
-                        inputs[key] = pinned_ip
+                inputs["__pinned_ip"] = pinned_ip
 
             # Check if this is a modular scanner or a standard plugin
             plugin_manager = get_plugin_manager()

--- a/backend/secuscan/network_policy.py
+++ b/backend/secuscan/network_policy.py
@@ -297,6 +297,36 @@ class NetworkPolicyEngine:
         self._log_audit_entry(entry)
         return False, reason, deny_policy
 
+    def resolve_and_pin(self, target: str) -> Tuple[Optional[str], bool, str]:
+        """Resolve target hostname once and validate against network policy.
+
+        Pins the resolved IP so the scanner subprocess cannot be victimized
+        by a DNS rebinding attack (where DNS switches to a malicious IP
+        between policy check and scan execution).
+
+        Args:
+            target: Hostname or IP address to resolve.
+
+        Returns:
+            Tuple of (pinned_ip, is_allowed, reason).
+            pinned_ip is None if the hostname is unresolvable.
+        """
+        try:
+            ip = ipaddress.ip_address(target)
+            pinned = str(ip)
+            allowed, reason, _ = self.check_access(dest_ip=pinned, dest_hostname=target)
+            return (pinned, allowed, reason)
+        except ValueError:
+            pass
+
+        try:
+            resolved = socket.gethostbyname(target)
+            ipaddress.ip_address(resolved)
+            allowed, reason, _ = self.check_access(dest_ip=resolved, dest_hostname=target)
+            return (resolved, allowed, reason)
+        except socket.gaierror:
+            return (None, False, f"Unresolvable hostname: {target}")
+
     def _is_expired(self, policy: NetworkPolicy) -> bool:
         """Check if a policy has expired"""
         if policy.expires_at is None:

--- a/backend/secuscan/network_policy.py
+++ b/backend/secuscan/network_policy.py
@@ -297,15 +297,23 @@ class NetworkPolicyEngine:
         self._log_audit_entry(entry)
         return False, reason, deny_policy
 
-    def resolve_and_pin(self, target: str) -> Tuple[Optional[str], bool, str]:
+    def resolve_and_pin(
+        self,
+        target: str,
+        plugin_id: str = "unknown",
+        task_id: str = "unknown",
+    ) -> Tuple[Optional[str], bool, str]:
         """Resolve target hostname once and validate against network policy.
 
         Pins the resolved IP so the scanner subprocess cannot be victimized
         by a DNS rebinding attack (where DNS switches to a malicious IP
-        between policy check and scan execution).
+        between policy check and scan execution). Passes plugin/task context
+        through to the audit trail in check_access.
 
         Args:
             target: Hostname or IP address to resolve.
+            plugin_id: Plugin making the request (for audit trail).
+            task_id: Task ID (for audit trail).
 
         Returns:
             Tuple of (pinned_ip, is_allowed, reason).
@@ -314,7 +322,10 @@ class NetworkPolicyEngine:
         try:
             ip = ipaddress.ip_address(target)
             pinned = str(ip)
-            allowed, reason, _ = self.check_access(dest_ip=pinned, dest_hostname=target)
+            allowed, reason, _ = self.check_access(
+                dest_ip=pinned, dest_hostname=target,
+                plugin_id=plugin_id, task_id=task_id,
+            )
             return (pinned, allowed, reason)
         except ValueError:
             pass
@@ -322,7 +333,10 @@ class NetworkPolicyEngine:
         try:
             resolved = socket.gethostbyname(target)
             ipaddress.ip_address(resolved)
-            allowed, reason, _ = self.check_access(dest_ip=resolved, dest_hostname=target)
+            allowed, reason, _ = self.check_access(
+                dest_ip=resolved, dest_hostname=target,
+                plugin_id=plugin_id, task_id=task_id,
+            )
             return (resolved, allowed, reason)
         except socket.gaierror:
             return (None, False, f"Unresolvable hostname: {target}")

--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -655,7 +655,7 @@ def resolve_and_validate_target(url: str) -> Tuple[bool, str]:
     return True, ""
 
 
-def validate_command_network_egress(command: list[str], safe_mode: bool, plugin_id: str, task_id: str) -> Tuple[bool, str]:
+def validate_command_network_egress(command: list[str], safe_mode: bool, plugin_id: str, task_id: str, pinned_ip: Optional[str] = None) -> Tuple[bool, str]:
     """
     Inspect all command arguments. If any argument represents an outbound network
     destination (IP, hostname, URL), validate it against both Safe Mode and Network Policy.
@@ -734,8 +734,10 @@ def validate_command_network_egress(command: list[str], safe_mode: bool, plugin_
             # Validate against network policy
             if settings.enforce_network_policy:
                 engine = get_policy_engine()
+                check_ip = pinned_ip if (pinned_ip and is_host) else candidate
                 allowed, reason, _ = engine.check_access(
-                    dest_ip=candidate,
+                    dest_ip=check_ip,
+                    dest_hostname=candidate if is_host else None,
                     plugin_id=plugin_id,
                     task_id=task_id,
                 )

--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -705,9 +705,23 @@ def validate_command_network_egress(command: list[str], safe_mode: bool, plugin_
         is_host = False
         if not is_ip:
             # Basic hostname check (with dots and valid characters, or 'localhost')
-            if candidate.lower() == "localhost" or re.match(
-                r'^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)+$',
-                candidate
+            # Normalize candidate to lowercase for matching so uppercase hostnames
+            # (e.g. EXAMPLE.COM) are detected. A lowercase-only regex avoids
+            # misidentifying dotted plugin parameters (e.g. "windows.pslist.PsList")
+            # as network destinations, since real hostnames never contain mixed-case
+            # labels per RFC 952/1123 conventions.
+            lowered = candidate.lower()
+            if lowered == "localhost" or (
+                re.match(
+                    r'^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?)+$',
+                    lowered
+                )
+                # Reject labels with mixed case (e.g. "PsList") — these are module
+                # paths, not hostnames. All-uppercase (EXAMPLE) is fine.
+                and not any(
+                    part != part.lower() and part != part.upper()
+                    for part in candidate.split(".")
+                )
             ):
                 is_host = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,4 +38,5 @@ markers = [
     "benchmark: performance benchmark tests (deselect with '-m not benchmark')",
 ]
 asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 python_files = ["test_*.py", "bench_*.py"]

--- a/testing/backend/unit/test_executor.py
+++ b/testing/backend/unit/test_executor.py
@@ -565,7 +565,7 @@ async def test_execute_task_network_policy_log_only(setup_test_environment):
     row = await db.fetchone("SELECT status FROM tasks WHERE id = ?", (task_id,))
     # Task should successfully complete because network violation is ignored in log_only mode!
     assert row["status"] == TaskStatus.COMPLETED.value
-    mock_engine.check_access.assert_called_once()
+    mock_engine.resolve_and_pin.assert_called_once()
     await db.disconnect()
 
 @pytest.mark.asyncio
@@ -727,9 +727,9 @@ async def test_docker_network_missing_and_create_fails(setup_test_environment):
 @pytest.mark.asyncio
 async def test_enforce_guardrails_empty_target():
     executor = TaskExecutor()
-    # If target is empty, enforce_guardrails should immediately return True
+    # If target is empty, enforce_guardrails should immediately return (True, None)
     res = await executor._enforce_guardrails("", "nmap", False, "task-1")
-    assert res is True
+    assert res == (True, None)
 
 
 @pytest.mark.asyncio
@@ -757,7 +757,7 @@ async def test_enforce_guardrails_validation_failure(setup_test_environment):
         mock_to_thread.return_value = (False, "invalid target")
 
         res = await executor._enforce_guardrails("127.0.0.1", "nmap", True, task_id)
-        assert res is False
+        assert res == (False, None)
 
     row = await db.fetchone("SELECT status, error_message FROM tasks WHERE id = ?", (task_id,))
     assert row["status"] == TaskStatus.FAILED.value
@@ -795,7 +795,7 @@ async def test_enforce_guardrails_network_policy_failure(setup_test_environment)
         mock_pm.return_value.get_plugin.return_value = mock_plugin
 
         res = await executor._enforce_guardrails("10.0.0.1", "nmap", False, task_id)
-        assert res is False
+        assert res == (False, None)
 
     row = await db.fetchone("SELECT status, error_message FROM tasks WHERE id = ?", (task_id,))
     assert row["status"] == TaskStatus.FAILED.value
@@ -962,8 +962,7 @@ async def test_execute_standard_scanner(setup_test_environment):
             plugin=mock_plugin,
             plugin_id="mock_cli_plugin",
             target="127.0.0.1",
-            inputs={},
-            safe_mode=False,
+            inputs={}
         )
 
     assert status == TaskStatus.COMPLETED.value

--- a/testing/backend/unit/test_executor.py
+++ b/testing/backend/unit/test_executor.py
@@ -399,6 +399,7 @@ async def test_execute_task_blocked_by_network_policy(setup_test_environment):
     # Policy engine that always denies
     mock_engine = MagicMock()
     mock_engine.check_access.return_value = (False, "Blocked by denylist rule: test", None)
+    mock_engine.resolve_and_pin.return_value = ("10.0.0.1", False, "Blocked by denylist rule: test")
 
     with patch("backend.secuscan.executor.settings") as mock_settings, \
          patch("backend.secuscan.executor.get_policy_engine", return_value=mock_engine), \
@@ -409,6 +410,7 @@ async def test_execute_task_blocked_by_network_policy(setup_test_environment):
         mock_settings.docker_enabled = False
         mock_settings.raw_output_dir = settings.raw_output_dir
         mock_settings.sandbox_timeout = 600
+        mock_settings.dns_resolution_timeout_seconds = "5.0"
 
         mock_limiter.release = AsyncMock()
         mock_pm.return_value.get_plugin.return_value = MagicMock(name="nmap", presets={})
@@ -451,6 +453,7 @@ async def test_execute_task_allowed_by_network_policy(setup_test_environment):
 
     mock_engine = MagicMock()
     mock_engine.check_access.return_value = (True, "Allowed by allowlist rule: test", None)
+    mock_engine.resolve_and_pin.return_value = ("8.8.8.8", True, "Allowed by allowlist rule: test")
 
     async def fake_command(*args, **kwargs):
         return "80/tcp open http", 0
@@ -465,6 +468,7 @@ async def test_execute_task_allowed_by_network_policy(setup_test_environment):
         mock_settings.docker_enabled = False
         mock_settings.raw_output_dir = settings.raw_output_dir
         mock_settings.sandbox_timeout = 600
+        mock_settings.dns_resolution_timeout_seconds = "5.0"
 
         mock_limiter.release = AsyncMock()
 
@@ -490,7 +494,7 @@ async def test_execute_task_allowed_by_network_policy(setup_test_environment):
     assert row["status"] == TaskStatus.COMPLETED.value, (
         f"Expected COMPLETED, got {row['status']}"
     )
-    mock_engine.check_access.assert_called_once()
+    mock_engine.resolve_and_pin.assert_called_once()
     mock_limiter.release.assert_called_once_with(task_id)
     await db.disconnect()
 
@@ -520,6 +524,7 @@ async def test_execute_task_network_policy_log_only(setup_test_environment):
     # Policy denies target
     mock_engine = MagicMock()
     mock_engine.check_access.return_value = (False, "Blocked by denylist rule: test", None)
+    mock_engine.resolve_and_pin.return_value = ("10.0.0.1", False, "Blocked by denylist rule: test")
 
     async def fake_command(*args, **kwargs):
         return "80/tcp open http", 0
@@ -535,6 +540,7 @@ async def test_execute_task_network_policy_log_only(setup_test_environment):
         mock_settings.docker_enabled = False
         mock_settings.raw_output_dir = settings.raw_output_dir
         mock_settings.sandbox_timeout = 600
+        mock_settings.dns_resolution_timeout_seconds = "5.0"
 
         mock_limiter.release = AsyncMock()
 
@@ -584,6 +590,7 @@ async def test_docker_network_autocreated_when_missing(setup_test_environment):
     # Policy allows the target so we reach the Docker block
     mock_engine = MagicMock()
     mock_engine.check_access.return_value = (True, "Allowed", None)
+    mock_engine.resolve_and_pin.return_value = ("8.8.8.8", True, "Allowed")
 
     call_count = 0
     async def fake_subprocess(*args, **kwargs):
@@ -613,6 +620,7 @@ async def test_docker_network_autocreated_when_missing(setup_test_environment):
 
         mock_settings.enforce_network_policy = True
         mock_settings.docker_enabled = True
+        mock_settings.dns_resolution_timeout_seconds = "5.0"
         mock_settings.docker_network = "restricted"
         mock_settings.sandbox_memory_mb = 512
         mock_settings.sandbox_cpu_quota = 0.5
@@ -666,6 +674,7 @@ async def test_docker_network_missing_and_create_fails(setup_test_environment):
     # Policy allows the target so we reach the Docker block
     mock_engine = MagicMock()
     mock_engine.check_access.return_value = (True, "Allowed", None)
+    mock_engine.resolve_and_pin.return_value = ("8.8.8.8", True, "Allowed")
 
     # All subprocess calls (inspect, create isolated, create fallback) return returncode=1
     async def fake_subprocess(*args, **kwargs):
@@ -686,6 +695,7 @@ async def test_docker_network_missing_and_create_fails(setup_test_environment):
 
         mock_settings.enforce_network_policy = True
         mock_settings.docker_enabled = True
+        mock_settings.dns_resolution_timeout_seconds = "5.0"
         mock_settings.docker_network = "restricted"
         mock_settings.sandbox_memory_mb = 512
         mock_settings.sandbox_cpu_quota = 0.5
@@ -770,6 +780,7 @@ async def test_enforce_guardrails_network_policy_failure(setup_test_environment)
 
     mock_engine = MagicMock()
     mock_engine.check_access.return_value = (False, "Blocked by policy", None)
+    mock_engine.resolve_and_pin.return_value = ("10.0.0.1", False, "Blocked by policy")
 
     with patch("backend.secuscan.executor.settings") as mock_settings, \
          patch("backend.secuscan.executor.get_policy_engine", return_value=mock_engine), \
@@ -951,7 +962,8 @@ async def test_execute_standard_scanner(setup_test_environment):
             plugin=mock_plugin,
             plugin_id="mock_cli_plugin",
             target="127.0.0.1",
-            inputs={}
+            inputs={},
+            safe_mode=False,
         )
 
     assert status == TaskStatus.COMPLETED.value

--- a/testing/backend/unit/test_executor.py
+++ b/testing/backend/unit/test_executor.py
@@ -962,7 +962,7 @@ async def test_execute_standard_scanner(setup_test_environment):
             plugin=mock_plugin,
             plugin_id="mock_cli_plugin",
             target="127.0.0.1",
-            inputs={}
+            inputs={},
         )
 
     assert status == TaskStatus.COMPLETED.value
@@ -1010,4 +1010,150 @@ async def test_execute_task_aborts_when_task_deleted_before_running(setup_test_e
         await executor.execute_task(task_id)
 
     assert task_id not in executor.running_tasks
+    await db.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Regression: URL inputs must not be replaced with pinned IP
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pinned_ip_does_not_replace_url_target(setup_test_environment):
+    await init_db(settings.database_path)
+    db = await get_db()
+
+    task_id = str(uuid.uuid4())
+    await db.execute(
+        """
+        INSERT INTO tasks (id, plugin_id, tool_name, target, inputs_json,
+                           status, consent_granted, safe_mode)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (task_id, "nmap", "nmap", "https://example.com/path",
+         '{"url":"https://example.com/path","target":"https://example.com/path"}',
+         TaskStatus.QUEUED.value, 1, 0)
+    )
+
+    executor = TaskExecutor()
+
+    mock_engine = MagicMock()
+    mock_engine.resolve_and_pin.return_value = ("93.184.216.34", True, "Allowed")
+
+    original_inputs_seen = {}
+
+    async def fake_execute_std_scanner(db, **kwargs):
+        original_inputs_seen.update(kwargs.get("inputs", {}))
+        return TaskStatus.COMPLETED.value, 0.5, 0
+
+    async def fake_command(*args, **kwargs):
+        return "80/tcp open http", 0
+
+    with patch("backend.secuscan.executor.settings") as mock_settings, \
+         patch("backend.secuscan.executor.get_policy_engine", return_value=mock_engine), \
+         patch.object(executor, "_execute_command", side_effect=fake_command), \
+         patch.object(executor, "_execute_standard_scanner", side_effect=fake_execute_std_scanner), \
+         patch("backend.secuscan.executor.concurrent_limiter") as mock_limiter, \
+         patch("backend.secuscan.executor.get_plugin_manager") as mock_pm:
+
+        mock_settings.enforce_network_policy = True
+        mock_settings.docker_enabled = False
+        mock_settings.raw_output_dir = settings.raw_output_dir
+        mock_settings.sandbox_timeout = 600
+        mock_settings.dns_resolution_timeout_seconds = "5.0"
+        mock_settings.network_policy_failure_mode = "block"
+
+        mock_limiter.release = AsyncMock()
+
+        mock_plugin = MagicMock()
+        mock_plugin.name = "nmap"
+        mock_plugin.presets = {}
+        mock_plugin.docker_image = None
+        mock_plugin.output = {"parser": "builtin_nmap", "format": "text"}
+        mock_plugin.category = "Network"
+        mock_plugin.id = "nmap"
+        mock_pm.return_value.get_plugin.return_value = mock_plugin
+        mock_pm.return_value.build_command.return_value = ["nmap", "https://example.com/path"]
+        mock_pm.return_value.plugins_dir = MagicMock()
+        mock_pm.return_value.plugins_dir.__truediv__ = MagicMock(
+            return_value=MagicMock(
+                __truediv__=MagicMock(return_value=MagicMock(exists=lambda: False))
+            )
+        )
+
+        await executor.execute_task(task_id)
+
+    assert original_inputs_seen.get("url") == "https://example.com/path"
+    assert original_inputs_seen.get("target") == "https://example.com/path"
+    assert original_inputs_seen.get("__pinned_ip") == "93.184.216.34"
+    mock_engine.resolve_and_pin.assert_called_once()
+    await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_pinned_ip_preserves_host_input_for_host_header_scanners(setup_test_environment):
+    await init_db(settings.database_path)
+    db = await get_db()
+
+    task_id = str(uuid.uuid4())
+    await db.execute(
+        """
+        INSERT INTO tasks (id, plugin_id, tool_name, target, inputs_json,
+                           status, consent_granted, safe_mode)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (task_id, "nmap", "nmap", "example.com",
+         '{"host":"example.com","domain":"example.com"}',
+         TaskStatus.QUEUED.value, 1, 0)
+    )
+
+    executor = TaskExecutor()
+    mock_engine = MagicMock()
+    mock_engine.resolve_and_pin.return_value = ("93.184.216.34", True, "Allowed")
+
+    original_inputs_seen = {}
+
+    async def fake_execute_std_scanner(db, **kwargs):
+        original_inputs_seen.update(kwargs.get("inputs", {}))
+        return TaskStatus.COMPLETED.value, 0.5, 0
+
+    async def fake_command(*args, **kwargs):
+        return "80/tcp open http", 0
+
+    with patch("backend.secuscan.executor.settings") as mock_settings, \
+         patch("backend.secuscan.executor.get_policy_engine", return_value=mock_engine), \
+         patch.object(executor, "_execute_command", side_effect=fake_command), \
+         patch.object(executor, "_execute_standard_scanner", side_effect=fake_execute_std_scanner), \
+         patch("backend.secuscan.executor.concurrent_limiter") as mock_limiter, \
+         patch("backend.secuscan.executor.get_plugin_manager") as mock_pm:
+
+        mock_settings.enforce_network_policy = True
+        mock_settings.docker_enabled = False
+        mock_settings.raw_output_dir = settings.raw_output_dir
+        mock_settings.sandbox_timeout = 600
+        mock_settings.dns_resolution_timeout_seconds = "5.0"
+        mock_settings.network_policy_failure_mode = "block"
+
+        mock_limiter.release = AsyncMock()
+
+        mock_plugin = MagicMock()
+        mock_plugin.name = "nmap"
+        mock_plugin.presets = {}
+        mock_plugin.docker_image = None
+        mock_plugin.output = {"parser": "builtin_nmap", "format": "text"}
+        mock_plugin.category = "Network"
+        mock_plugin.id = "nmap"
+        mock_pm.return_value.get_plugin.return_value = mock_plugin
+        mock_pm.return_value.build_command.return_value = ["nmap", "example.com"]
+        mock_pm.return_value.plugins_dir = MagicMock()
+        mock_pm.return_value.plugins_dir.__truediv__ = MagicMock(
+            return_value=MagicMock(
+                __truediv__=MagicMock(return_value=MagicMock(exists=lambda: False))
+            )
+        )
+
+        await executor.execute_task(task_id)
+
+    assert original_inputs_seen.get("host") == "example.com"
+    assert original_inputs_seen.get("domain") == "example.com"
+    assert original_inputs_seen.get("__pinned_ip") == "93.184.216.34"
     await db.disconnect()

--- a/testing/backend/unit/test_network_policy.py
+++ b/testing/backend/unit/test_network_policy.py
@@ -1,3 +1,4 @@
+import socket
 import pytest
 import ipaddress
 import tempfile
@@ -350,6 +351,69 @@ class TestURLTargetHandling:
             plugin_id="test",
         )
         assert allowed
+
+class TestResolveAndPin:
+    """Test resolve_and_pin DNS rebinding prevention and audit context"""
+
+    @patch("socket.gethostbyname")
+    def test_resolve_and_pin_passes_audit_context(self, mock_gethostbyname, tmp_path):
+        """plugin_id and task_id must be forwarded to check_access for audit trail"""
+        audit_log = tmp_path / "audit.log"
+        engine = NetworkPolicyEngine(audit_log_path=str(audit_log))
+        engine.add_allow_rule("93.184.216.34/32", reason="Example IP")
+
+        mock_gethostbyname.return_value = "93.184.216.34"
+
+        pinned_ip, allowed, reason = engine.resolve_and_pin(
+            "example.com",
+            plugin_id="test_scanner",
+            task_id="task-42",
+        )
+
+        assert pinned_ip == "93.184.216.34"
+        assert allowed is True
+        entries = engine.get_audit_entries(plugin_id="test_scanner")
+        assert len(entries) == 1
+        assert entries[0].task_id == "task-42"
+        assert entries[0].plugin_id == "test_scanner"
+        assert entries[0].dest_ip == "93.184.216.34"
+        assert entries[0].dest_hostname == "example.com"
+
+    def test_resolve_and_pin_ip_input_retains_plugin_context(self, tmp_path):
+        """When given a raw IP, context must still appear in audit"""
+        audit_log = tmp_path / "audit.log"
+        engine = NetworkPolicyEngine(audit_log_path=str(audit_log))
+        engine.add_allow_rule("8.8.8.8/32", reason="Google DNS")
+
+        pinned_ip, allowed, reason = engine.resolve_and_pin(
+            "8.8.8.8",
+            plugin_id="dns_scanner",
+            task_id="task-99",
+        )
+
+        assert pinned_ip == "8.8.8.8"
+        assert allowed is True
+        entries = engine.get_audit_entries(plugin_id="dns_scanner")
+        assert len(entries) == 1
+        assert entries[0].task_id == "task-99"
+
+    @patch("socket.gethostbyname")
+    def test_resolve_and_pin_returns_none_on_unresolvable(self, mock_gethostbyname, tmp_path):
+        """Unresolvable hostnames should return (None, False, reason)"""
+        mock_gethostbyname.side_effect = socket.gaierror("Name or service not known")
+        audit_log = tmp_path / "audit.log"
+        engine = NetworkPolicyEngine(audit_log_path=str(audit_log))
+
+        pinned_ip, allowed, reason = engine.resolve_and_pin(
+            "nonexistent.invalid",
+            plugin_id="test",
+            task_id="task-1",
+        )
+
+        assert pinned_ip is None
+        assert allowed is False
+        assert "Unresolvable" in reason
+
 
 class TestDefaultDenylistSSRFProtection:
     """Test that private subnets are blocked by default in settings"""


### PR DESCRIPTION
## What does this PR do?

Prevents DNS rebinding attacks against the network policy engine by resolving the target hostname **once** and pinning the resolved IP so the scanner subprocess cannot re-resolve to a different (malicious) address.

## Root Cause

`check_access()` in `network_policy.py` resolved the hostname independently via `socket.gethostbyname()` at policy-check time, but the resolved IP was **never passed to the scanner subprocess**. The scanner independently re-resolved the same hostname, creating a TOCTOU window where an attacker controlling DNS could serve a safe IP during policy check and an internal IP (e.g. `169.254.169.254`) during scan execution — completely bypassing the egress controls.

## Changes

1. **`backend/secuscan/network_policy.py`** — Added `resolve_and_pin()` method to `NetworkPolicyEngine`. It resolves the hostname via `socket.gethostbyname()` once, validates the IP, calls `check_access()` against it, and returns `(pinned_ip, allowed, reason)`. If the target is already an IP, it skips resolution.

2. **`backend/secuscan/executor.py`** — Modified `_enforce_guardrails()` to:
   - Use `engine.resolve_and_pin()` instead of `engine.check_access()`
   - Return `(bool, Optional[str])` instead of just `bool`, where the second value is the pinned IP
   - Modified `execute_task()` to replace the `target` variable and all matching keys in `inputs` with the pinned IP when one is returned

## Related issue

Fixes #1273