### PR TITLE
test : added JSONFormatter and RequestIDFilter edge-case tests

### DIFF
--- a/testing/backend/unit/test_logging_utils.py
+++ b/testing/backend/unit/test_logging_utils.py
@@ -68,3 +68,95 @@ def test_json_formatter_serializes_exception():
 
     assert "exception" in result
     assert "ValueError" in result["exception"]
+
+
+def test_request_id_filter_adds_request_id_field():
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+
+    filt = RequestIDFilter()
+    assert filt.filter(record) is True
+    assert hasattr(record, "request_id")
+    assert record.request_id != ""
+
+
+def test_json_formatter_adds_request_id_field():
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+
+    formatter = JSONFormatter()
+    result = json.loads(formatter.format(record))
+
+    assert "request_id" in result
+
+
+def test_json_formatter_timestamp_is_iso_format():
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+
+    formatter = JSONFormatter()
+    result = json.loads(formatter.format(record))
+
+    from datetime import datetime
+    ts = result["timestamp"]
+    # ISO format with timezone
+    assert "T" in ts
+    assert "+" in ts or "Z" in ts
+    # Should parse as datetime
+    assert datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def test_json_formatter_log_level_names():
+    for level, name in [(logging.DEBUG, "DEBUG"), (logging.INFO, "INFO"),
+                        (logging.WARNING, "WARNING"), (logging.ERROR, "ERROR")]:
+        record = logging.LogRecord(
+            name="test",
+            level=level,
+            pathname=__file__,
+            lineno=1,
+            msg="msg",
+            args=(),
+            exc_info=None,
+        )
+        formatter = JSONFormatter()
+        result = json.loads(formatter.format(record))
+        assert result["level"] == name
+
+
+def test_json_formatter_no_exception_key_when_no_exc_info():
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="normal log",
+        args=(),
+        exc_info=None,
+    )
+
+    formatter = JSONFormatter()
+    result = json.loads(formatter.format(record))
+
+    assert "exception" not in result
+    assert result["message"] == "normal log"


### PR DESCRIPTION
Closes #1321.

Summary of What Has Been Done:
Expanded `testing/backend/unit/test_logging_utils.py` from 3 to 8 tests, covering edge cases for JSONFormatter and RequestIDFilter.

Changes Made:
- `test_request_id_filter_adds_request_id_field` — filter always adds request_id attribute
- `test_json_formatter_adds_request_id_field` — formatted output always contains request_id
- `test_json_formatter_timestamp_is_iso_format` — timestamp is ISO 8601 formatted
- `test_json_formatter_log_level_names` — log level name appears in output
- `test_json_formatter_no_exception_key_when_no_exc_info` — no exception key when no exc_info

Impact it Made:
- Ensures structured logging remains reliable with complex messages
- No functional changes to production code
- All 8 tests pass with `pytest --noconftest`

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.