### PR TITLE
fix(backend): validate preset names on task start

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -105,7 +105,7 @@ from .ratelimit import (
     scheduler_tick_limiter,
 )
 from .rate_limiter import check_scan_rate_limit
-from .validation import validate_target, validate_task_start_payload, validate_url
+from .validation import validate_target, validate_task_start_payload, validate_url, validate_preset_name
 from .reporting import reporting
 from .vault import VaultCrypto
 from .workflows import scheduler, _finalize_workflow_run
@@ -342,6 +342,15 @@ async def start_task(
     if not plugin:
         logger.warning(f"Task start failed: Plugin not found: {request.plugin_id}")
         raise HTTPException(status_code=404, detail=f"Plugin not found: {request.plugin_id}")
+
+    preset_ok, preset_error = validate_preset_name(
+        request.plugin_id,
+        request.preset,
+        plugin.presets,
+    )
+    if not preset_ok:
+        logger.warning("Task start failed: %s", preset_error)
+        raise HTTPException(status_code=400, detail=preset_error)
 
     db = await get_db()
     target_policy = await get_target_policy(db, owner, execution_context.get("target_policy_id"))

--- a/backend/secuscan/validation.py
+++ b/backend/secuscan/validation.py
@@ -527,6 +527,22 @@ def validate_task_start_payload(
     return True, 0, ""
 
 
+def validate_preset_name(
+    plugin_id: str,
+    preset: Optional[str],
+    presets: Optional[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Validate that an optional preset name exists for the selected plugin."""
+    if preset in (None, ""):
+        return True, ""
+
+    available_presets = presets or {}
+    if preset not in available_presets:
+        return False, f"Unknown preset '{preset}' for plugin '{plugin_id}'"
+
+    return True, ""
+
+
 def _check_field(key: str, value: Any) -> Tuple[bool, int, str]:
     """Check a single input field value (string or list)."""
     if isinstance(value, str):

--- a/testing/backend/integration/test_routes.py
+++ b/testing/backend/integration/test_routes.py
@@ -1,7 +1,9 @@
 import time
+import sqlite3
 from unittest.mock import patch
 
 from backend.secuscan.models import TaskStatus
+from backend.secuscan.config import settings
 
 def test_health_check(test_client):
     """Test health check endpoint."""
@@ -127,6 +129,25 @@ def test_start_task_missing_plugin(test_client):
     assert response.status_code == 404
     detail = response.json().get("detail", "")
     assert missing_id in detail or "plugin" in detail.lower()
+
+
+def test_start_task_rejects_unknown_preset_before_queueing(test_client):
+    """Starting a task with an unknown preset should fail before a task row is created."""
+    payload = {
+        "plugin_id": "http_inspector",
+        "preset": "stale-preset-name",
+        "inputs": {"url": "http://127.0.0.1:8000"},
+        "consent_granted": True,
+    }
+
+    response = test_client.post("/api/v1/task/start", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unknown preset 'stale-preset-name' for plugin 'http_inspector'"
+
+    with sqlite3.connect(settings.database_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+    assert count == 0
 
 class TestSafeModeCIDRBypass:
     """


### PR DESCRIPTION
## Description
This PR adds explicit preset-name validation during task submission so stale or unknown preset values are rejected at `POST /api/v1/task/start` before executor startup.

The change keeps the existing execution flow intact for valid requests, but closes a gap where invalid preset names could pass route handling and fail later in a less clear way. Validation now returns a consistent `400` error immediately, and an integration test verifies that no task row is created when the preset is invalid.

## Related Issues
Closes #805

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran focused backend validation and route-contract checks in the project virtual environment:

```bash
.venv/bin/pytest -q testing/backend/integration/test_routes.py -k unknown_preset
.venv/bin/pytest -q testing/backend/integration/test_routes.py
.venv/bin/ruff check backend/secuscan/routes.py backend/secuscan/validation.py testing/backend/integration/test_routes.py
```

Results:
- Added integration coverage for invalid preset rejection
- Verified adjacent task route tests still pass
- Verified touched files pass linting

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

