### PR TITLE
fix(backend): degrade dashboard summary on query failure

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -916,37 +916,56 @@ async def get_dashboard_summary(owner: str = Depends(get_current_owner)):
     async def build():
         db = await get_db()
 
+        async def query_or_default(label: str, query_fn: Callable[[], Any], default: Any) -> Any:
+            try:
+                return await query_fn()
+            except Exception as exc:
+                logger.warning("Dashboard summary query '%s' failed for owner %s: %s", label, owner, exc)
+                return default
+
         # Get data
         # Push severity aggregation to DB — avoids full table scan in Python.
         # Every aggregate below is scoped to the caller so the dashboard never
         # surfaces another user/workspace's tasks or findings (issue #401).
-        severity_rows = await db.fetchall(
-            """
-            SELECT severity, COUNT(*) AS cnt
-            FROM findings
-            WHERE owner_id = ?
-            GROUP BY severity
-            """,
-            (owner,),
+        severity_rows = await query_or_default(
+            "severity_counts",
+            lambda: db.fetchall(
+                """
+                SELECT severity, COUNT(*) AS cnt
+                FROM findings
+                WHERE owner_id = ?
+                GROUP BY severity
+                """,
+                (owner,),
+            ),
+            [],
         )
         severity_counts = {row["severity"]: row["cnt"] for row in severity_rows}
 
-        task_stats = await db.fetchone(
-            """
-            SELECT
-                COUNT(*) AS total,
-                COUNT(*) FILTER (WHERE status = 'completed') AS completed,
-                COUNT(*) FILTER (WHERE status = 'running') AS running
-            FROM tasks
-            WHERE owner_id = ?
-            """,
-            (owner,),
+        task_stats = await query_or_default(
+            "task_stats",
+            lambda: db.fetchone(
+                """
+                SELECT
+                    COUNT(*) AS total,
+                    COUNT(*) FILTER (WHERE status = 'completed') AS completed,
+                    COUNT(*) FILTER (WHERE status = 'running') AS running
+                FROM tasks
+                WHERE owner_id = ?
+                """,
+                (owner,),
+            ),
+            {"total": 0, "completed": 0, "running": 0},
         )
 
-        total_findings_row = await db.fetchone(
-            "SELECT COUNT(*) AS total FROM findings WHERE owner_id = ?", (owner,)
+        total_findings_row = await query_or_default(
+            "total_findings",
+            lambda: db.fetchone(
+                "SELECT COUNT(*) AS total FROM findings WHERE owner_id = ?", (owner,)
+            ),
+            None,
         )
-        total_findings = total_findings_row["total"] if total_findings_row else 0
+        total_findings = total_findings_row["total"] if total_findings_row else sum(severity_counts.values())
 
         critical_findings: int = severity_counts.get("critical", 0)
         high_findings: int = severity_counts.get("high", 0)
@@ -955,19 +974,23 @@ async def get_dashboard_summary(owner: str = Depends(get_current_owner)):
         info_findings: int = severity_counts.get("info", 0)
 
         # Fetch only the 5 most recent findings — not the entire table
-        recent_rows = await db.fetchall(
-            """
-            SELECT id, title, category, severity, target, description,
-                remediation, proof, cvss, cve, discovered_at,
-                validated, validation_method, confidence_reason,
-                service_fingerprint, cpe, risk_score, risk_factors_json,
-                evidence_json, asset_refs_json, references_json, metadata_json
-            FROM findings
-            WHERE owner_id = ?
-            ORDER BY discovered_at DESC
-            LIMIT 5
-            """,
-            (owner,),
+        recent_rows = await query_or_default(
+            "recent_findings",
+            lambda: db.fetchall(
+                """
+                SELECT id, title, category, severity, target, description,
+                    remediation, proof, cvss, cve, discovered_at,
+                    validated, validation_method, confidence_reason,
+                    service_fingerprint, cpe, risk_score, risk_factors_json,
+                    evidence_json, asset_refs_json, references_json, metadata_json
+                FROM findings
+                WHERE owner_id = ?
+                ORDER BY discovered_at DESC
+                LIMIT 5
+                """,
+                (owner,),
+            ),
+            [],
         )
         recent_findings: List[Dict] = parse_json_fields(
             recent_rows,
@@ -1005,16 +1028,24 @@ async def get_dashboard_summary(owner: str = Depends(get_current_owner)):
                 "running": int(task_stats["running"]) if task_stats and task_stats.get("running") is not None else 0,
             },
             "running_tasks": parse_json_fields(
-                await db.fetchall(
-                    "SELECT id, plugin_id, tool_name, target, status, created_at FROM tasks WHERE owner_id = ? AND status = 'running' ORDER BY created_at DESC LIMIT 5",
-                    (owner,),
+                await query_or_default(
+                    "running_tasks",
+                    lambda: db.fetchall(
+                        "SELECT id, plugin_id, tool_name, target, status, created_at FROM tasks WHERE owner_id = ? AND status = 'running' ORDER BY created_at DESC LIMIT 5",
+                        (owner,),
+                    ),
+                    [],
                 ),
                 []
             ),
             "recent_tasks": parse_json_fields(
-                await db.fetchall(
-                    "SELECT id, plugin_id, tool_name, target, status, created_at, duration_seconds FROM tasks WHERE owner_id = ? ORDER BY created_at DESC LIMIT 5",
-                    (owner,),
+                await query_or_default(
+                    "recent_tasks",
+                    lambda: db.fetchall(
+                        "SELECT id, plugin_id, tool_name, target, status, created_at, duration_seconds FROM tasks WHERE owner_id = ? ORDER BY created_at DESC LIMIT 5",
+                        (owner,),
+                    ),
+                    [],
                 ),
                 []
             )

--- a/testing/backend/integration/test_dashboard_cache.py
+++ b/testing/backend/integration/test_dashboard_cache.py
@@ -139,3 +139,42 @@ def test_dashboard_summary_cache_invalidated_when_task_enters_running(test_clien
     assert r2.json()["scan_activity"]["running"] == 1, (
         "dashboard must show running count after cache invalidation on task start"
     )
+
+
+def test_dashboard_summary_degrades_cleanly_when_one_query_fails(test_client):
+    """A single dashboard subquery failure must not take down the whole response."""
+    async def fake_fetchall(_self, query, params=()):
+        if "GROUP BY severity" in query:
+            raise RuntimeError("severity aggregation failed")
+        if "status = 'running'" in query:
+            return [{"id": "task-running-1", "status": "running", "plugin_id": "http_inspector"}]
+        if "duration_seconds" in query:
+            return [{"id": "task-recent-1", "status": "completed", "plugin_id": "http_inspector"}]
+        return []
+
+    async def fake_fetchone(_self, query, params=()):
+        if "COUNT(*) AS total FROM findings" in query:
+            return {"total": 7}
+        if "FROM tasks" in query:
+            return {"total": 3, "completed": 2, "running": 1}
+        return None
+
+    with (
+        patch("backend.secuscan.database.Database.fetchall", new=fake_fetchall),
+        patch("backend.secuscan.database.Database.fetchone", new=fake_fetchone),
+    ):
+        response = test_client.get("/api/v1/dashboard/summary")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["total_findings"] == 7
+    assert data["critical_findings"] == 0
+    assert data["high_findings"] == 0
+    assert data["medium_findings"] == 0
+    assert data["low_findings"] == 0
+    assert data["info_findings"] == 0
+    assert data["recent_findings"] == []
+    assert data["scan_activity"] == {"total": 3, "completed": 2, "running": 1}
+    assert data["running_tasks"] == [{"id": "task-running-1", "status": "running", "plugin_id": "http_inspector"}]
+    assert data["recent_tasks"] == [{"id": "task-recent-1", "status": "completed", "plugin_id": "http_inspector"}]


### PR DESCRIPTION
## Description
This PR makes the dashboard summary endpoint degrade gracefully when one of its aggregation queries fails.

Previously, a single failing summary subquery could cause the full `/api/v1/dashboard/summary` response to fail. This change isolates the dashboard’s individual query blocks so the endpoint can still return `200 OK` with safe defaults for the failed section while preserving successfully computed task and findings data from the other queries.

It also adds focused integration coverage to lock in that contract by simulating a partial dashboard query failure and verifying that the rest of the summary payload still returns normally.

## Related Issues
Closes #807

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran the targeted backend tests covering the touched route and adjacent dashboard contract behavior:

```bash
../SecuScan/.venv/bin/pytest -q testing/backend/integration/test_dashboard_cache.py
../SecuScan/.venv/bin/pytest -q testing/backend/integration/test_database_indexes.py -k dashboard
../SecuScan/.venv/bin/ruff check backend/secuscan/routes.py testing/backend/integration/test_dashboard_cache.py
```

What these verify:
- Dashboard summary still responds successfully when one subquery fails
- Existing dashboard cache behavior remains intact
- Adjacent dashboard route coverage still passes
- Touched files pass linting without new warnings

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.