### PR TITLE
add cache-key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,8 +271,24 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          PLAYWRIGHT_VERSION=$(node -e "const lock = require('./package-lock.json');const packages = lock.packages || {}; const entry = Object.entries(packages).find(([name]) => name === 'node_modules/playwright' || name === 'node_modules/@playwright/test'); if (!entry) { console.error('Unable to resolve Playwright version from package-lock.json'); process.exit(1); } console.log(entry[1].version);")
+          echo "version=$PLAYWRIGHT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Using Playwright version $PLAYWRIGHT_VERSION for browser cache key"
+      - name: Restore Playwright browser cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
+            ${{ runner.os }}-playwright-
       - name: Install frontend dependencies
         run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
       - name: Run npm audit
         id: npm_audit
         run: |

--- a/testing/test_ci_playwright_cache.py
+++ b/testing/test_ci_playwright_cache.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_ci_workflow_caches_playwright_browsers_by_version():
+    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "Resolve Playwright version" in workflow
+    assert "actions/cache@v4" in workflow
+    assert "~/.cache/ms-playwright" in workflow
+    assert "npx playwright install --with-deps chromium" in workflow
+    assert "steps.playwright-version.outputs.version" in workflow


### PR DESCRIPTION
## Description
This change adds Playwright browser cache hygiene to CI so browser downloads are reused when the Playwright version has not changed, while still invalidating cleanly when the dependency version changes.

The workflow in ci.yml now:

Resolves the Playwright version from package-lock.json.
Uses that version in the cache key for the Playwright browser cache.
Restores the browser cache before installation.
Installs Chromium through Playwright in a dedicated step.

A regression test was also added in testing/test_ci_playwright_cache.py to verify that the Playwright cache configuration remains present in the CI workflow.

## Related Issues
Closes #894

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
pytest testing/test_ci_playwright_cache.py

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
