### PR TITLE
test : added unit tests for validation _parse_url_hostname

### DIFF
--- a/testing/backend/unit/test_validation.py
+++ b/testing/backend/unit/test_validation.py
@@ -418,3 +418,57 @@ class TestValidateWebhookTarget:
         ok, err = validate_webhook_target("http://nonexistent.example.com/hook")
         assert ok is False
         assert "could not be resolved" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# _parse_url_hostname tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_url_hostname_https_url():
+    """Extracts hostname from a standard https URL."""
+    from backend.secuscan.validation import _parse_url_hostname
+    assert _parse_url_hostname("https://example.com") == "example.com"
+
+
+def test_parse_url_hostname_http_url():
+    """Extracts hostname from a standard http URL."""
+    from backend.secuscan.validation import _parse_url_hostname
+    assert _parse_url_hostname("http://example.com") == "example.com"
+
+
+def test_parse_url_hostname_with_port():
+    """Strips port from hostname when present."""
+    from backend.secuscan.validation import _parse_url_hostname
+    assert _parse_url_hostname("https://example.com:8080") == "example.com"
+
+
+def test_parse_url_hostname_with_path():
+    """Strips path from hostname."""
+    from backend.secuscan.validation import _parse_url_hostname
+    assert _parse_url_hostname("https://example.com/api/v1") == "example.com"
+
+
+def test_parse_url_hostname_localhost():
+    """Handles localhost URLs."""
+    from backend.secuscan.validation import _parse_url_hostname
+    assert _parse_url_hostname("http://localhost:8000") == "localhost"
+
+
+def test_parse_url_hostname_ipv4():
+    """Handles IPv4 addresses."""
+    from backend.secuscan.validation import _parse_url_hostname
+    result = _parse_url_hostname("http://127.0.0.1:8000")
+    assert result is not None
+
+
+def test_parse_url_hostname_empty_string():
+    """Returns None for empty string."""
+    from backend.secuscan.validation import _parse_url_hostname
+    assert _parse_url_hostname("") is None
+
+
+def test_parse_url_hostname_none():
+    """Returns None for None input."""
+    from backend.secuscan.validation import _parse_url_hostname
+    assert _parse_url_hostname(None) is None


### PR DESCRIPTION
Closes #1375.

Summary of What Has Been Done:
Added unit tests for `_parse_url_hostname` in `backend/secuscan/validation.py`. This function extracts the hostname from a URL string and is used by webhook validation functions.

Changes Made:
- Added 8 focused test cases to `testing/backend/unit/test_validation.py`
- Tests cover https/http URLs, ports, paths, localhost, IPv4 addresses, empty string, and None
- Import the real production function directly from `backend.secuscan.validation`

Impact it Made:
- Improves test coverage for the validation module
- Documents expected behavior of URL hostname extraction
- Prevents regressions in webhook URL validation

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.