### PR TITLE
test : added VaultCrypto key_fingerprint property unit tests

### DIFF
--- a/testing/backend/unit/test_vault.py
+++ b/testing/backend/unit/test_vault.py
@@ -92,3 +92,60 @@ def test_decrypt_roundtrip_empty_string():
     assert encrypted
     decrypted = crypto.decrypt(encrypted)
     assert decrypted == ""
+
+
+class TestKeyFingerprint:
+    def test_key_fingerprint_is_accessible(self):
+        """key_fingerprint property is accessible on VaultCrypto instance."""
+        import base64
+        key_bytes = b"a1" + b"b2" * 15  # exactly 32 bytes
+        key = base64.urlsafe_b64encode(key_bytes).decode("ascii")
+        crypto = VaultCrypto(key)
+        assert hasattr(crypto, "key_fingerprint")
+        assert crypto.key_fingerprint is not None
+
+    def test_key_fingerprint_matches_compute_fingerprint(self):
+        """key_fingerprint returns the same value as _compute_fingerprint on the raw key."""
+        import base64
+        key_bytes = b"c3" + b"d4" * 15  # exactly 32 bytes
+        key = base64.urlsafe_b64encode(key_bytes).decode("ascii")
+        crypto = VaultCrypto(key)
+        expected = VaultCrypto._compute_fingerprint(key_bytes)
+        assert crypto.key_fingerprint == expected
+
+    def test_key_fingerprint_is_stable(self):
+        """Calling key_fingerprint multiple times returns the same value."""
+        key = _make_key()
+        crypto = VaultCrypto(key)
+        fp1 = crypto.key_fingerprint
+        fp2 = crypto.key_fingerprint
+        fp3 = crypto.key_fingerprint
+        assert fp1 == fp2 == fp3
+
+    def test_key_fingerprint_is_colon_separated_hex(self):
+        """Fingerprint is formatted as 8 colon-separated lowercase hex pairs."""
+        import base64
+        key_bytes = b"0123456789abcdef0123456789abcdef"
+        key = base64.urlsafe_b64encode(key_bytes).decode("ascii")
+        crypto = VaultCrypto(key)
+        fp = crypto.key_fingerprint
+        parts = fp.split(":")
+        assert len(parts) == 8
+        for part in parts:
+            assert len(part) == 2
+            int(part, 16)  # raises ValueError if not valid hex
+
+    def test_different_keys_produce_different_fingerprints(self):
+        """Two distinct keys produce two distinct fingerprints."""
+        import base64
+        key1 = base64.urlsafe_b64encode(b"11111111111111111111111111111111").decode("ascii")
+        key2 = base64.urlsafe_b64encode(b"22222222222222222222222222222222").decode("ascii")
+        crypto1 = VaultCrypto(key1)
+        crypto2 = VaultCrypto(key2)
+        assert crypto1.key_fingerprint != crypto2.key_fingerprint
+
+    def test_key_fingerprint_property_is_read_only(self):
+        """key_fingerprint has no setter — it cannot be overwritten."""
+        key = _make_key()
+        crypto = VaultCrypto(key)
+        assert not hasattr(type(crypto).key_fingerprint, "fset") or type(crypto).key_fingerprint.fset is None


### PR DESCRIPTION
Closes #1384.

Summary of What Has Been Done:
Added a dedicated test class `TestKeyFingerprint` to `testing/backend/unit/test_vault.py` covering the `VaultCrypto.key_fingerprint` property. The property returns a domain-separated SHA-256 fingerprint of the vault key, formatted as 8 colon-separated hex pairs.

Changes Made:
- Added 6 new tests to `testing/backend/unit/test_vault.py`:
  - `test_key_fingerprint_is_accessible`: verifies the property is accessible and non-None
  - `test_key_fingerprint_matches_compute_fingerprint`: verifies the property value matches `_compute_fingerprint` output
  - `test_key_fingerprint_is_stable`: verifies repeated calls return the same value
  - `test_key_fingerprint_is_colon_separated_hex`: verifies the format (8 pairs)
  - `test_different_keys_produce_different_fingerprints`: verifies uniqueness
  - `test_key_fingerprint_property_is_read_only`: verifies no setter exists

Impact it Made:
- Covers the key-identity diagnostic feature used by operators to verify key state across deployments
- Guards against regressions in fingerprint computation and domain-separation logic
- Complements the existing encryption/decryption test suite

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.