### PR TITLE
test : added risk_scoring _recency_detail helper unit tests

### DIFF
--- a/testing/backend/unit/test_risk_scoring_helpers.py
+++ b/testing/backend/unit/test_risk_scoring_helpers.py
@@ -123,3 +123,56 @@ class TestConfidenceScore:
         """Confidence of 0.5 maps to 5.0."""
         from backend.secuscan.risk_scoring import _confidence_score
         assert _confidence_score(0.5) == 5.0
+
+
+class TestRecencyDetail:
+    def test_none_discovered_at_returns_assumed_recency_message(self):
+        """When discovered_at is None, returns the 'assumed moderate recency' message."""
+        from backend.secuscan.risk_scoring import _recency_detail
+        result = _recency_detail(None, 5.0)
+        assert result == "No discovery date — assumed moderate recency"
+
+    def test_future_date_returns_treated_as_recent_message(self):
+        """A future discovered_at (negative days) returns 'treated as very recent'."""
+        from backend.secuscan.risk_scoring import _recency_detail
+        from datetime import datetime, timezone, timedelta
+        future = datetime.now(timezone.utc) + timedelta(days=5)
+        result = _recency_detail(future, 10.0)
+        assert "future" in result.lower() or "very recent" in result.lower()
+
+    def test_today_returns_maximum_recency_message(self):
+        """A discovered_at of today (0 days ago) returns the 'maximum recency' message."""
+        from backend.secuscan.risk_scoring import _recency_detail
+        from datetime import datetime, timezone, timedelta
+        today = datetime.now(timezone.utc) - timedelta(hours=2)
+        result = _recency_detail(today, 10.0)
+        assert "today" in result.lower()
+        assert "maximum recency" in result.lower()
+
+    def test_one_day_ago_includes_day_count(self):
+        """A discovered_at of 1 day ago includes the day count in the message."""
+        from backend.secuscan.risk_scoring import _recency_detail
+        from datetime import datetime, timezone, timedelta
+        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+        result = _recency_detail(yesterday, 10.0)
+        assert "1 day ago" in result
+        assert "10.0" in result
+
+    def test_multiple_days_ago_includes_correct_count(self):
+        """A discovered_at of multiple days ago includes the correct day count."""
+        from backend.secuscan.risk_scoring import _recency_detail
+        from datetime import datetime, timezone, timedelta
+        for days, expected_rv in [(7, 7.5), (30, 7.5), (60, 5.0), (90, 5.0), (180, 2.5), (400, 1.0)]:
+            past = datetime.now(timezone.utc) - timedelta(days=days)
+            result = _recency_detail(past, expected_rv)
+            assert str(days) in result, f"Expected {days} days in: {result}"
+            assert f"{expected_rv:.1f}" in result, f"Expected rv {expected_rv} in: {result}"
+
+    def test_naive_datetime_handled(self):
+        """A naive (non-UTC) datetime is handled without raising."""
+        from backend.secuscan.risk_scoring import _recency_detail
+        from datetime import datetime, timedelta
+        naive = datetime.now() - timedelta(days=10)
+        result = _recency_detail(naive, 5.0)
+        assert isinstance(result, str)
+        assert len(result) > 0


### PR DESCRIPTION
Closes #1385.

Summary of What Has Been Done:
Added a `TestRecencyDetail` class to `testing/backend/unit/test_risk_scoring_helpers.py` covering the `_recency_detail` pure helper from `backend/secuscan/risk_scoring.py`. This function produces human-readable explanation strings for the recency factor in risk scoring.

Changes Made:
- Added 6 new tests covering all branches:
  - None discovered_at returns "No discovery date — assumed moderate recency"
  - Future date returns "treated as very recent" message
  - 0 days (today) returns "Discovered today — maximum recency score"
  - 1 day ago includes "1 day ago" and the recency score
  - Multiple days (7/30/60/90/180/400) includes correct day count and score
  - Naive (non-UTC) datetime is handled without raising

Impact it Made:
- Documents the recency detail strings explicitly
- Ensures future date logic changes do not silently break user-facing explanation strings
- Enables isolated testing without spinning up the full compute_risk_factors call

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.