### PR TITLE
fix(reporting): prevent resource leakage by guaranteeing buffer cleanup and normalizing exceptions-#798

### DIFF
--- a/backend/secuscan/reporting.py
+++ b/backend/secuscan/reporting.py
@@ -92,9 +92,12 @@ class ReportGenerator:
             y_offset += bar_height + spacing
 
         output = io.BytesIO()
-        img.save(output, format="PNG")
-        encoded = base64.b64encode(output.getvalue()).decode("ascii")
-        return f"data:image/png;base64,{encoded}"
+        try:
+            img.save(output, format="PNG")
+            encoded = base64.b64encode(output.getvalue()).decode("ascii")
+            return f"data:image/png;base64,{encoded}"
+        finally:
+            output.close()
 
     @classmethod
     def _get_ai_summary(cls, findings):
@@ -157,9 +160,12 @@ class ReportGenerator:
             draw.ellipse((22, 33, 26, 37), fill=fg)
 
         output = io.BytesIO()
-        image.save(output, format="PNG")
-        encoded = base64.b64encode(output.getvalue()).decode("ascii")
-        return f"data:image/png;base64,{encoded}"
+        try:
+            image.save(output, format="PNG")
+            encoded = base64.b64encode(output.getvalue()).decode("ascii")
+            return f"data:image/png;base64,{encoded}"
+        finally:
+            output.close()
 
     @classmethod
     def _clean_text(cls, value: Any) -> str:
@@ -692,13 +698,30 @@ class ReportGenerator:
 
     @classmethod
     def generate_pdf_report(cls, task: Dict[str, Any], result: Dict[str, Any]) -> bytes:
-        """Generate the PDF from the same HTML used by the browser report."""
+        """Generate the PDF from the same HTML used by the browser report.
+
+        Contract:
+            - Returns raw PDF bytes on success.
+            - Raises RuntimeError("Failed to render SecuScan HTML report as PDF")
+              on any render failure (pisa error flag or unexpected exception).
+            - The internal BytesIO buffer is always closed before returning or
+              raising, regardless of the failure mode.
+            - No temporary files are written to disk; if this ever changes, the
+              same try/finally guarantee must be preserved.
+        """
         html_report = cls._generate_pdf_html_report(task, result)
         output = io.BytesIO()
-        pdf = pisa.CreatePDF(src=html_report, dest=output, encoding="utf-8")
-        if pdf.err:
-            raise RuntimeError("Failed to render SecuScan HTML report as PDF")
-        return output.getvalue()
+        try:
+            pdf = pisa.CreatePDF(src=html_report, dest=output, encoding="utf-8")
+            if pdf.err:
+                raise RuntimeError("Failed to render SecuScan HTML report as PDF")
+            return output.getvalue()
+        except RuntimeError:
+            raise
+        except Exception as exc:
+            raise RuntimeError("Failed to render SecuScan HTML report as PDF") from exc
+        finally:
+            output.close()
 
     @classmethod
     def generate_html_report(cls, task: Dict[str, Any], result: Dict[str, Any]) -> str:
@@ -1079,46 +1102,57 @@ class ReportGenerator:
 
     @classmethod
     def generate_csv_report(cls, task: Dict[str, Any], result: Dict[str, Any]) -> str:
-        """Generate a structured CSV export."""
+        """Generate a structured CSV export.
+
+        Contract:
+            - Returns a UTF-8 CSV string on success.
+            - Raises RuntimeError on unexpected generation failure.
+            - The internal StringIO buffer is always closed.
+        """
         payload = cls._build_report_payload(task, result)
         output = io.StringIO()
-        writer = csv.writer(output)
-        writer.writerow(
-            [
-                "Severity",
-                "Title",
-                "Category",
-                "Target",
-                "CVSS",
-                "CVE",
-                "CPE",
-                "Validated",
-                "Validation Method",
-                "Confidence Reason",
-                "Description",
-                "Evidence",
-                "Remediation",
-            ]
-        )
-        for finding in payload["findings"]:
+        try:
+            writer = csv.writer(output)
             writer.writerow(
                 [
-                    finding["severity"],
-                    finding["title"],
-                    finding["category"],
-                    finding["target"] or payload["target"],
-                    finding["cvss"] if finding["cvss"] is not None else "",
-                    finding["cve"],
-                    finding["cpe"],
-                    "yes" if finding["validated"] else "no",
-                    finding["validation_method"],
-                    finding["confidence_reason"],
-                    finding["description"],
-                    finding["proof"],
-                    finding["remediation"],
+                    "Severity",
+                    "Title",
+                    "Category",
+                    "Target",
+                    "CVSS",
+                    "CVE",
+                    "CPE",
+                    "Validated",
+                    "Validation Method",
+                    "Confidence Reason",
+                    "Description",
+                    "Evidence",
+                    "Remediation",
                 ]
             )
-        return output.getvalue()
+            for finding in payload["findings"]:
+                writer.writerow(
+                    [
+                        finding["severity"],
+                        finding["title"],
+                        finding["category"],
+                        finding["target"] or payload["target"],
+                        finding["cvss"] if finding["cvss"] is not None else "",
+                        finding["cve"],
+                        finding["cpe"],
+                        "yes" if finding["validated"] else "no",
+                        finding["validation_method"],
+                        finding["confidence_reason"],
+                        finding["description"],
+                        finding["proof"],
+                        finding["remediation"],
+                    ]
+                )
+            return output.getvalue()
+        except Exception as exc:
+            raise RuntimeError("Failed to generate CSV report") from exc
+        finally:
+            output.close()
 
     @classmethod
     def generate_sarif_report(cls, task: Dict[str, Any], result: Dict[str, Any]) -> str:

--- a/testing/backend/unit/test_reporting.py
+++ b/testing/backend/unit/test_reporting.py
@@ -1,4 +1,5 @@
 from backend.secuscan.reporting import ReportGenerator
+import pytest
 
 
 def sample_task():
@@ -92,3 +93,118 @@ def test_build_report_payload_includes_parameters_and_command():
     labels = {item["label"] for item in payload["scan_parameters"]}
     assert {"Target", "Plugin", "Preset", "Display Options", "Safe Mode", "Command"} <= labels
     assert payload["command_used"].startswith("nikto -h")
+
+
+def test_generate_pdf_report_closes_buffer_on_pisa_error(monkeypatch):
+    """Buffer must be closed even when pisa reports a render error."""
+    import io as _io
+
+    closed_buffers = []
+    real_BytesIO = _io.BytesIO
+
+    class TrackingBytesIO(real_BytesIO):
+        def close(self):
+            closed_buffers.append(True)
+            super().close()
+
+    monkeypatch.setattr(_io, "BytesIO", TrackingBytesIO)
+
+    class FakePisaResult:
+        err = True
+
+    import xhtml2pdf.pisa as pisa_mod
+    monkeypatch.setattr(pisa_mod, "CreatePDF", lambda **kw: FakePisaResult())
+
+    with pytest.raises(RuntimeError, match="Failed to render"):
+        ReportGenerator.generate_pdf_report(sample_task(), sample_result())
+
+    assert closed_buffers, "BytesIO.close() was never called on render failure"
+
+
+def test_generate_pdf_report_closes_buffer_on_unexpected_exception(monkeypatch):
+    """Buffer must be closed and exception normalized to RuntimeError on crash."""
+    import io as _io
+
+    closed_buffers = []
+    real_BytesIO = _io.BytesIO
+
+    class TrackingBytesIO(real_BytesIO):
+        def close(self):
+            closed_buffers.append(True)
+            super().close()
+
+    monkeypatch.setattr(_io, "BytesIO", TrackingBytesIO)
+
+    import xhtml2pdf.pisa as pisa_mod
+    monkeypatch.setattr(pisa_mod, "CreatePDF", lambda **kw: (_ for _ in ()).throw(OSError("disk full")))
+
+    with pytest.raises(RuntimeError, match="Failed to render"):
+        ReportGenerator.generate_pdf_report(sample_task(), sample_result())
+
+    assert closed_buffers, "BytesIO.close() was never called on unexpected exception"
+
+
+def test_generate_pdf_report_chains_original_exception(monkeypatch):
+    """The original cause must be preserved via exception chaining."""
+    import xhtml2pdf.pisa as pisa_mod
+    original = OSError("disk full")
+    monkeypatch.setattr(pisa_mod, "CreatePDF", lambda **kw: (_ for _ in ()).throw(original))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        ReportGenerator.generate_pdf_report(sample_task(), sample_result())
+
+    assert exc_info.value.__cause__ is original
+
+
+def test_generate_csv_report_closes_buffer_on_success(monkeypatch):
+    """StringIO.close() must be called even on the happy path."""
+    import io as _io
+
+    closed_buffers = []
+    real_StringIO = _io.StringIO
+
+    class TrackingStringIO(real_StringIO):
+        def close(self):
+            closed_buffers.append(True)
+            super().close()
+
+    monkeypatch.setattr(_io, "StringIO", TrackingStringIO)
+
+    result = ReportGenerator.generate_csv_report(sample_task(), sample_result())
+    assert "Severity" in result
+    assert closed_buffers, "StringIO.close() was never called on success"
+
+
+def test_generate_csv_report_closes_buffer_on_failure(monkeypatch):
+    """StringIO.close() must be called even when CSV writing fails."""
+    import io as _io
+    import csv as csv_mod
+
+    closed_buffers = []
+    real_StringIO = _io.StringIO
+
+    class TrackingStringIO(real_StringIO):
+        def close(self):
+            closed_buffers.append(True)
+            super().close()
+
+    monkeypatch.setattr(_io, "StringIO", TrackingStringIO)
+    monkeypatch.setattr(csv_mod, "writer", lambda f: (_ for _ in ()).throw(RuntimeError("bad writer")))
+
+    with pytest.raises(RuntimeError):
+        ReportGenerator.generate_csv_report(sample_task(), sample_result())
+
+    assert closed_buffers, "StringIO.close() was never called on CSV failure"
+
+
+def test_generate_pdf_report_raises_runtime_error_on_pisa_err(monkeypatch):
+    """Route layer depends on RuntimeError; never a raw pisa-internal type."""
+    import xhtml2pdf.pisa as pisa_mod
+
+    class BadResult:
+        err = 1  # truthy
+
+    monkeypatch.setattr(pisa_mod, "CreatePDF", lambda **kw: BadResult())
+
+    with pytest.raises(RuntimeError):
+        ReportGenerator.generate_pdf_report(sample_task(), sample_result())


### PR DESCRIPTION
Closes #798


## Description
This PR addresses potential resource leakage during report generation failures or network disconnects. It ensures that in-memory buffers are explicitly closed under all execution paths and that API-level exceptions are consistently normalized.

Key changes:
- **Buffer Cleanup Strategy**: Wrapped all in-memory buffers (`io.BytesIO` and `io.StringIO`) inside `try/finally` blocks in `generate_pdf_report`, `generate_csv_report`, `_generate_severity_chart`, and `_icon_data_uri` to guarantee that `.close()` is called regardless of failure mode or unexpected interrupts.
- **Exception Normalization**: Normalized unexpected rendering and write exceptions inside the public PDF and CSV generators into `RuntimeError` instances. The original traceback is preserved using explicit exception chaining (`from exc`), keeping the route layer error-handling contract robust and predictable.
- **Improved Test Coverage**: Added 6 new focused unit tests verifying buffer closure (on success, pisa rendering failures, and unexpected exceptions) along with normalization and chaining verification.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
We executed the full suite of reporting unit and integration tests inside the local isolated python virtual environment:
1. **Unit tests for the reporting module**:
   ```bash
   .\venv_tests\Scripts\pytest testing/backend/unit/test_reporting.py testing/backend/unit/test_reporting_core.py testing/backend/unit/test_reporting_charts.py -v

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
