### PR TITLE
test: add missing-binary regression check for whois_lookup plugin mes…

### DIFF
--- a/testing/backend/test_whois_lookup_plugin.py
+++ b/testing/backend/test_whois_lookup_plugin.py
@@ -16,11 +16,11 @@ def test_whois_lookup_missing_binary_graceful_fallback():
     the plugin catches the failure gracefully and returns an error dictionary instead of crashing.
     """
     mock_error_msg = "Error: whois binary not found on the system host environment."
-    
+
     # Use a standard Exception which plugins/whois_lookup/whois_tool.py line 18 is built to catch
     with patch("whois.whois", side_effect=Exception(mock_error_msg)):
         result = lookup("example.com")
-        
+
         # Verify the tool safely intercepted the crash and returned the message string under the "error" key
         assert isinstance(result, dict)
         assert "error" in result

--- a/testing/backend/test_whois_lookup_plugin.py
+++ b/testing/backend/test_whois_lookup_plugin.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+# Ensure our local repo root is in the Python search path
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+# Import the lookup function from our target plugin tool
+from plugins.whois_lookup.whois_tool import lookup
+
+def test_whois_lookup_missing_binary_graceful_fallback():
+    """
+    Test that when the system whois wrapper fails (simulating a missing binary or execution fault),
+    the plugin catches the failure gracefully and returns an error dictionary instead of crashing.
+    """
+    mock_error_msg = "Error: whois binary not found on the system host environment."
+    
+    # Use a standard Exception which plugins/whois_lookup/whois_tool.py line 18 is built to catch
+    with patch("whois.whois", side_effect=Exception(mock_error_msg)):
+        result = lookup("example.com")
+        
+        # Verify the tool safely intercepted the crash and returned the message string under the "error" key
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert mock_error_msg in result["error"]


### PR DESCRIPTION
…saging (#891)

## Description
Added a missing-binary regression test for the ` whois_lookup plugin`. The test uses mocking to simulate a missing or failing system host environment for the third-party library, ensuring that the tool catches execution errors gracefully and returns an actionable error message instead of throwing an unhandled exception or crashing.

## Related Issues
Closes #891

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran the targeted backend test suite locally via Python's module runner using the following command:
python -m pytest testing/backend/test_whois_lookup_plugin.py

The test successfully passes (1 passed) in under 0.19 seconds by confirming an error payload is returned when a dependency fault occurs.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
