### PR TITLE
docs: clarify runtime generated artifact policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -424,7 +424,29 @@ Never commit these auto-generated paths:
 - `frontend/.vite/`
 - `.vite/deps/`
 
+### Runtime Generated Scan Artifacts
+
+Never commit runtime-generated scan outputs such as:
+
+- `output/`
+- `data/raw/`
+- `data/reports/`
+- `backend/data/raw/`
+- `backend/data/reports/`
+- `logs/`
+
+These directories contain runtime-generated artifacts such as PDF reports, scan results, and other temporary outputs. They should never be committed to the repository. Only intentionally maintained placeholder files such as `.gitkeep` should be tracked.
+
+If you accidentally commit a generated artifact, remove it from Git tracking:
+
+```bash
+git rm --cached <generated-file-or-directory>
+```
+
+Before committing again, verify that the generated artifact path is covered by `.gitignore` so it is not tracked in future commits.
+
 If CI fails, run:
 ```bash
-git rm --cached <file>
-echo 'frontend/dist/' >> .gitignore
+git rm --cached <generated-file-or-directory>
+
+# Ensure the generated artifact path is ignored in .gitignore


### PR DESCRIPTION
## Description
Updated the contributor documentation to better explain the policy for runtime-generated scan artifacts.

Changes include:
- Added a dedicated section for runtime-generated scan artifacts.
- Documented directories that should never be committed (such as `output/`, `data/raw/`, `data/reports/`, `backend/data/raw/`, `backend/data/reports/`, and `logs/`).
- Added guidance for removing accidentally committed generated artifacts using `git rm --cached`.
- Clarified that generated artifact paths should be ignored by `.gitignore` before committing again.
- Updated the existing CI troubleshooting example to use a generic generated artifact path.

## Related Issues
Closes #585 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- Reviewed the existing artifact guard documentation.
- Verified the runtime-generated artifact guidance against the current repository structure.
- Confirmed that the documented paths are consistent with the existing artifact policy.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
