### PR TITLE
feat: add provenance metadata to SARIF exports

### DIFF
--- a/backend/secuscan/reporting.py
+++ b/backend/secuscan/reporting.py
@@ -6,9 +6,11 @@ import json
 import re
 from .redaction import redact, redact_dict
 from .ai_summary import generate_summary
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import lru_cache
 from typing import Any, Dict, List
+
+from backend import __version__
 
 from PIL import Image, ImageDraw
 from xhtml2pdf import pisa
@@ -1247,8 +1249,15 @@ class ReportGenerator:
                             "name": tool_name,
                             "version": "1.0.0",
                             "informationUri": "https://github.com/utksh1/SecuScan",
-                            "rules": rules
+                            "rules": rules,
+                            "properties": {
+                                "generatorVersion": __version__,
+                            },
                         }
+                    },
+                    "properties": {
+                        "pluginId": task.get("plugin_id"),
+                        "exportTimestamp": datetime.now(timezone.utc).isoformat(),
                     },
                     "results": results
                 }

--- a/testing/backend/integration/test_routes_sarif.py
+++ b/testing/backend/integration/test_routes_sarif.py
@@ -81,6 +81,13 @@ def test_download_sarif_report_success(test_client):
     assert sarif["version"] == "2.1.0"
     assert sarif["runs"][0]["tool"]["driver"]["name"] == "http_inspector"
 
+    driver = sarif["runs"][0]["tool"]["driver"]
+    assert driver["properties"]["generatorVersion"]
+
+    run_properties = sarif["runs"][0]["properties"]
+    assert run_properties["pluginId"] == "http_inspector"
+    assert run_properties["exportTimestamp"]
+
     results = sarif["runs"][0]["results"]
     assert len(results) == 1
     assert results[0]["ruleId"] == "cve-2026-0001"


### PR DESCRIPTION
## Description
This PR adds provenance metadata to exported SARIF reports to improve auditability.

### Changes
- Added `generatorVersion` using the backend package version.
- Added `pluginId` to the SARIF run properties.
- Added `exportTimestamp` (UTC ISO-8601) to the SARIF run properties.
- Updated the SARIF integration tests to verify the new metadata.

## Related Issues
Closes #806 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran the following checks:

```bash
ruff check backend testing
pytest testing/backend/integration/test_routes_sarif.py -v
```

Results:
- `ruff check backend testing`  Passed
- `pytest testing/backend/integration/test_routes_sarif.py -v`  8 tests passed

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
