### PR TITLE
test(frontend): add unit test coverage for single-task delete failure on Scans page #1397

### DIFF
--- a/frontend/testing/unit/pages/Scans.test.tsx
+++ b/frontend/testing/unit/pages/Scans.test.tsx
@@ -275,4 +275,37 @@ describe('Scans — task list', () => {
 
     alertSpy.mockRestore()
   })
+
+  it('handles deleteTask failure correctly', async () => {
+    const { deleteTask } = await import('../../../src/api')
+    vi.mocked(deleteTask).mockRejectedValueOnce(new Error('Delete failed'))
+
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+
+    const tasks = [makeTask({ task_id: 'task-1', tool: 'nmap', status: 'completed' })]
+    mockFetch(tasks)
+    renderScans()
+
+    await waitFor(() => expect(screen.getByText('nmap')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('nmap').closest('[class*="cursor-pointer"]')!)
+    await waitFor(() => expect(screen.getByText('Delete_Record')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('Delete_Record'))
+
+    await waitFor(() => expect(screen.getByText('Delete Scan Record')).toBeInTheDocument())
+
+    const confirmBtn = screen.getByRole('button', { name: /Confirm/i })
+    await userEvent.click(confirmBtn)
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Failed to delete task. It might still be running.'
+      )
+    })
+
+    expect(screen.getAllByText('nmap')[0]).toBeInTheDocument()
+
+    alertSpy.mockRestore()
+  })
 })

--- a/frontend/testing/unit/pages/Scans.test.tsx
+++ b/frontend/testing/unit/pages/Scans.test.tsx
@@ -238,4 +238,41 @@ describe('Scans — task list', () => {
       )
     })
   })
+
+  it('handles clearAllTasks failure correctly', async () => {
+    const { clearAllTasks } = await import('../../../src/api')
+    vi.mocked(clearAllTasks).mockRejectedValueOnce(new Error('Purge failed'))
+
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+
+    const tasks = [makeTask({ task_id: 'task-1', tool: 'nmap' })]
+    mockFetch(tasks)
+    renderScans()
+
+    await waitFor(() => expect(screen.getByText('nmap')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByRole('button', { name: /Select_All/i }))
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+
+    const purgeBtn = screen.getByRole('button', { name: /Purge_All_Records/i })
+    await userEvent.click(purgeBtn)
+
+    expect(screen.getByText('CRITICAL OPERATION')).toBeInTheDocument()
+
+    const confirmBtn = screen.getByRole('button', { name: /Confirm/i })
+    await userEvent.click(confirmBtn)
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Failed to clear history. Ensure no tasks are currently running.'
+      )
+    })
+
+    expect(screen.getByText('nmap')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+
+    alertSpy.mockRestore()
+  })
 })


### PR DESCRIPTION
Closes #1397


## Description
This PR adds frontend unit test coverage for the single-task deletion failure scenario on the Scans page. The new test verifies that:
- Mocking the `deleteTask` API function to reject behaves correctly.
- A user-facing error feedback dialog (`window.alert`) is displayed with the appropriate message: `"Failed to delete task. It might still be running."`.
- The failed task remains in the tasks list to maintain a predictable, reliable component state.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran the newly added test suite inside `frontend/testing/unit/pages/Scans.test.tsx` and validated that all 14 tests pass.
powershell
npx vitest run testing/unit/pages/Scans.test.tsx

Also, the code has been verified that there are no regressions across the entire project test suite using
npm run test

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
