### PR TITLE
feat(ci): add repository hygiene check blocking committed Python cache files #1451

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,17 @@ jobs:
       - name: Validate documentation anchors
         run: python scripts/validate_doc_anchors.py
 
+  repository-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check repository hygiene (Python cache files)
+        run: python scripts/check_hygiene.py
+
   backend-lint:
     needs: detect-changes
     if: needs.detect-changes.outputs.run_backend == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,18 @@ python scripts/validate_issue_template_labels.py
 
 The CI workflow also runs this validation and will fail if an issue template references a label that is not included in the approved label taxonomy.
 
+## Repository Hygiene Maintenance
+
+The repository hygiene check ensures that no generated Python cache files (`__pycache__/` or `*.pyc`) are accidentally tracked or committed in the repository.
+
+Before opening a pull request, you can run the hygiene check locally:
+
+```bash
+python scripts/check_hygiene.py
+```
+
+The CI workflow runs this check on every pull request and commit, and will fail if any Python cache files are committed.
+
 ## Local Setup
 
 ### Prerequisites

--- a/frontend/testing/unit/pages/Scans.test.tsx
+++ b/frontend/testing/unit/pages/Scans.test.tsx
@@ -308,4 +308,46 @@ describe('Scans — task list', () => {
 
     alertSpy.mockRestore()
   })
+
+  it('handles bulkDeleteTasks failure correctly', async () => {
+    const { bulkDeleteTasks } = await import('../../../src/api')
+    vi.mocked(bulkDeleteTasks).mockRejectedValueOnce(new Error('Bulk delete failed'))
+
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+
+    const tasks = [
+      makeTask({ task_id: 'task-1', tool: 'nmap' }),
+      makeTask({ task_id: 'task-2', tool: 'sqlmap' }),
+    ]
+    mockFetch(tasks)
+    renderScans()
+
+    await waitFor(() => expect(screen.getByText('nmap')).toBeInTheDocument())
+    expect(screen.getByText('sqlmap')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /Select_All/i }))
+    await waitFor(() => {
+      expect(screen.getByText('2')).toBeInTheDocument()
+    })
+
+    const pruneBtn = screen.getByRole('button', { name: /Prune_Selected_Records/i })
+    await userEvent.click(pruneBtn)
+
+    expect(screen.getByText('Bulk Delete Records')).toBeInTheDocument()
+
+    const confirmBtn = screen.getByRole('button', { name: /Confirm/i })
+    await userEvent.click(confirmBtn)
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Failed to delete some tasks. Ensure they are not currently running.'
+      )
+    })
+
+    expect(screen.getByText('nmap')).toBeInTheDocument()
+    expect(screen.getByText('sqlmap')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+
+    alertSpy.mockRestore()
+  })
 })

--- a/frontend/testing/unit/pages/Scans.test.tsx
+++ b/frontend/testing/unit/pages/Scans.test.tsx
@@ -275,4 +275,37 @@ describe('Scans — task list', () => {
 
     alertSpy.mockRestore()
   })
+
+  it('handles deleteTask failure correctly', async () => {
+    const { deleteTask } = await import('../../../src/api')
+    vi.mocked(deleteTask).mockRejectedValueOnce(new Error('Delete failed'))
+
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+
+    const tasks = [makeTask({ task_id: 'task-1', tool: 'nmap', status: 'completed' })]
+    mockFetch(tasks)
+    renderScans()
+
+    await waitFor(() => expect(screen.getByText('nmap')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('nmap').closest('[class*="cursor-pointer"]')!)
+    await waitFor(() => expect(screen.getByText('Delete_Record')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('Delete_Record'))
+
+    await waitFor(() => expect(screen.getByText('Delete Scan Record')).toBeInTheDocument())
+
+    const confirmBtn = screen.getByRole('button', { name: /Confirm/i })
+    await userEvent.click(confirmBtn)
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Failed to delete task. It might still be running.'
+      )
+    })
+
+    expect(screen.getAllByText('nmap')[0]).toBeInTheDocument()
+
+    alertSpy.mockRestore()
+  })
 })

--- a/frontend/testing/unit/pages/Scans.test.tsx
+++ b/frontend/testing/unit/pages/Scans.test.tsx
@@ -238,4 +238,41 @@ describe('Scans — task list', () => {
       )
     })
   })
+
+  it('handles clearAllTasks failure correctly', async () => {
+    const { clearAllTasks } = await import('../../../src/api')
+    vi.mocked(clearAllTasks).mockRejectedValueOnce(new Error('Purge failed'))
+
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+
+    const tasks = [makeTask({ task_id: 'task-1', tool: 'nmap' })]
+    mockFetch(tasks)
+    renderScans()
+
+    await waitFor(() => expect(screen.getByText('nmap')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByRole('button', { name: /Select_All/i }))
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+
+    const purgeBtn = screen.getByRole('button', { name: /Purge_All_Records/i })
+    await userEvent.click(purgeBtn)
+
+    expect(screen.getByText('CRITICAL OPERATION')).toBeInTheDocument()
+
+    const confirmBtn = screen.getByRole('button', { name: /Confirm/i })
+    await userEvent.click(confirmBtn)
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Failed to clear history. Ensure no tasks are currently running.'
+      )
+    })
+
+    expect(screen.getByText('nmap')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+
+    alertSpy.mockRestore()
+  })
 })

--- a/scripts/check_hygiene.py
+++ b/scripts/check_hygiene.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import os
+import pathlib
+import subprocess
+import sys
+
+VENV_NAMES = {".venv", "venv", ".venv-codex", "env", "venv_tests"}
+
+def is_virtualenv_segment(segment):
+    s = segment.lower()
+    return (
+        s in VENV_NAMES
+        or s.startswith("venv")
+        or s.startswith(".venv")
+        or s.endswith("-venv")
+        or s.endswith("_venv")
+    )
+
+def get_git_root():
+    try:
+        res = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return pathlib.Path(res.stdout.strip()).resolve()
+    except Exception:
+        return pathlib.Path(__file__).parent.parent.resolve()
+
+def get_tracked_files(git_root):
+    try:
+        res = subprocess.run(
+            ["git", "ls-files"],
+            cwd=git_root,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return [line.strip() for line in res.stdout.splitlines() if line.strip()]
+    except Exception as e:
+        print(f"Error running git ls-files: {e}", file=sys.stderr)
+        return []
+
+def is_in_virtualenv(relative_path, git_root):
+    # 1. Check path segments
+    path_obj = pathlib.Path(relative_path)
+    parts = path_obj.parts
+    dir_parts = parts[:-1] if len(parts) > 1 else ()
+    for part in dir_parts:
+        if is_virtualenv_segment(part):
+            return True
+
+    # 2. Check physical folders up to git root for pyvenv.cfg
+    abs_path = (git_root / relative_path).resolve()
+    current = abs_path.parent
+    while True:
+        if (current / "pyvenv.cfg").exists():
+            return True
+        if current == git_root or current == current.parent:
+            break
+        current = current.parent
+
+    return False
+
+def is_pycache_or_pyc(relative_path):
+    path_obj = pathlib.Path(relative_path)
+    if path_obj.suffix == ".pyc":
+        return True
+    if "__pycache__" in path_obj.parts:
+        return True
+    return False
+
+def main():
+    git_root = get_git_root()
+    tracked_files = get_tracked_files(git_root)
+    
+    violation_files = []
+    
+    for f in tracked_files:
+        # Normalize to forward slashes for unified parsing
+        normalized_path = f.replace("\\", "/")
+        if is_pycache_or_pyc(normalized_path):
+            if not is_in_virtualenv(normalized_path, git_root):
+                violation_files.append(f)
+                
+    if violation_files:
+        print("ERROR: Tracked Python cache files (__pycache__ or *.pyc) found in repository:")
+        for f in violation_files:
+            print(f"  - {f}")
+        print("\nFix:")
+        print("  git rm --cached <file>")
+        print("  Add the pattern to .gitignore to prevent recommitting.")
+        sys.exit(1)
+        
+    print("Repository hygiene check passed: no tracked __pycache__ or pyc files found.")
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_hygiene.py
+++ b/scripts/check_hygiene.py
@@ -74,16 +74,16 @@ def is_pycache_or_pyc(relative_path):
 def main():
     git_root = get_git_root()
     tracked_files = get_tracked_files(git_root)
-    
+
     violation_files = []
-    
+
     for f in tracked_files:
         # Normalize to forward slashes for unified parsing
         normalized_path = f.replace("\\", "/")
         if is_pycache_or_pyc(normalized_path):
             if not is_in_virtualenv(normalized_path, git_root):
                 violation_files.append(f)
-                
+
     if violation_files:
         print("ERROR: Tracked Python cache files (__pycache__ or *.pyc) found in repository:")
         for f in violation_files:
@@ -92,7 +92,7 @@ def main():
         print("  git rm --cached <file>")
         print("  Add the pattern to .gitignore to prevent recommitting.")
         sys.exit(1)
-        
+
     print("Repository hygiene check passed: no tracked __pycache__ or pyc files found.")
     sys.exit(0)
 

--- a/scripts/select_tests.py
+++ b/scripts/select_tests.py
@@ -75,6 +75,7 @@ def classify_file(filepath):
         or (
             filepath.startswith("scripts/")
             and not filepath.endswith("check-artifacts.sh")
+            and not filepath.endswith("check_hygiene.py")
         )
     ):
         return "BACKEND"

--- a/testing/backend/unit/test_check_hygiene.py
+++ b/testing/backend/unit/test_check_hygiene.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import pathlib
+
+# Add root directory to sys.path so we can import from scripts
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+)
+
+from scripts.check_hygiene import (
+    is_virtualenv_segment,
+    is_pycache_or_pyc,
+    is_in_virtualenv,
+)
+
+def test_is_virtualenv_segment():
+    # Standard virtualenv names
+    assert is_virtualenv_segment(".venv") is True
+    assert is_virtualenv_segment("venv") is True
+    assert is_virtualenv_segment(".venv-codex") is True
+    assert is_virtualenv_segment("venv_tests") is True
+    assert is_virtualenv_segment("my-venv") is True
+    assert is_virtualenv_segment("my_venv") is True
+    assert is_virtualenv_segment("env") is True
+    
+    # Non-virtualenv names
+    assert is_virtualenv_segment("backend") is False
+    assert is_virtualenv_segment("secuscan") is False
+    assert is_virtualenv_segment("testing") is False
+    assert is_virtualenv_segment("myvenv") is False  # doesn't match start/end patterns
+
+def test_is_pycache_or_pyc():
+    assert is_pycache_or_pyc("backend/secuscan/__pycache__/routes.cpython-311.pyc") is True
+    assert is_pycache_or_pyc("backend/secuscan/routes.pyc") is True
+    assert is_pycache_or_pyc("backend/secuscan/__pycache__/routes.py") is True
+    
+    assert is_pycache_or_pyc("backend/secuscan/routes.py") is False
+    assert is_pycache_or_pyc("backend/secuscan/pycache/routes.py") is False
+
+def test_is_in_virtualenv_by_segment_match(tmp_path):
+    git_root = tmp_path
+    
+    # Test path that contains venv directory segment
+    assert is_in_virtualenv(".venv-codex/lib/python3.11/site-packages/__pycache__/foo.pyc", git_root) is True
+    assert is_in_virtualenv("testing/venv_tests/lib/python3.11/site-packages/__pycache__/foo.pyc", git_root) is True
+    
+    # Test path that doesn't contain venv directory segment
+    assert is_in_virtualenv("backend/secuscan/__pycache__/routes.cpython-311.pyc", git_root) is False
+
+def test_is_in_virtualenv_by_cfg_file(tmp_path):
+    git_root = tmp_path
+    
+    # Create a dummy virtualenv folder with pyvenv.cfg
+    custom_venv_dir = git_root / "my_custom_env"
+    custom_venv_dir.mkdir()
+    (custom_venv_dir / "pyvenv.cfg").write_text("version = 3.11.0", encoding="utf-8")
+    
+    # The file path relative to git_root
+    rel_path = "my_custom_env/lib/__pycache__/foo.pyc"
+    
+    # Create the nested directory structure physically so it can be resolved on disk
+    (custom_venv_dir / "lib" / "__pycache__").mkdir(parents=True, exist_ok=True)
+    (custom_venv_dir / "lib" / "__pycache__" / "foo.pyc").touch()
+    
+    # Verify that it detects the virtualenv due to the physical pyvenv.cfg file
+    assert is_in_virtualenv(rel_path, git_root) is True

--- a/testing/backend/unit/test_check_hygiene.py
+++ b/testing/backend/unit/test_check_hygiene.py
@@ -22,7 +22,7 @@ def test_is_virtualenv_segment():
     assert is_virtualenv_segment("my-venv") is True
     assert is_virtualenv_segment("my_venv") is True
     assert is_virtualenv_segment("env") is True
-    
+
     # Non-virtualenv names
     assert is_virtualenv_segment("backend") is False
     assert is_virtualenv_segment("secuscan") is False
@@ -33,34 +33,34 @@ def test_is_pycache_or_pyc():
     assert is_pycache_or_pyc("backend/secuscan/__pycache__/routes.cpython-311.pyc") is True
     assert is_pycache_or_pyc("backend/secuscan/routes.pyc") is True
     assert is_pycache_or_pyc("backend/secuscan/__pycache__/routes.py") is True
-    
+
     assert is_pycache_or_pyc("backend/secuscan/routes.py") is False
     assert is_pycache_or_pyc("backend/secuscan/pycache/routes.py") is False
 
 def test_is_in_virtualenv_by_segment_match(tmp_path):
     git_root = tmp_path
-    
+
     # Test path that contains venv directory segment
     assert is_in_virtualenv(".venv-codex/lib/python3.11/site-packages/__pycache__/foo.pyc", git_root) is True
     assert is_in_virtualenv("testing/venv_tests/lib/python3.11/site-packages/__pycache__/foo.pyc", git_root) is True
-    
+
     # Test path that doesn't contain venv directory segment
     assert is_in_virtualenv("backend/secuscan/__pycache__/routes.cpython-311.pyc", git_root) is False
 
 def test_is_in_virtualenv_by_cfg_file(tmp_path):
     git_root = tmp_path
-    
+
     # Create a dummy virtualenv folder with pyvenv.cfg
     custom_venv_dir = git_root / "my_custom_env"
     custom_venv_dir.mkdir()
     (custom_venv_dir / "pyvenv.cfg").write_text("version = 3.11.0", encoding="utf-8")
-    
+
     # The file path relative to git_root
     rel_path = "my_custom_env/lib/__pycache__/foo.pyc"
-    
+
     # Create the nested directory structure physically so it can be resolved on disk
     (custom_venv_dir / "lib" / "__pycache__").mkdir(parents=True, exist_ok=True)
     (custom_venv_dir / "lib" / "__pycache__" / "foo.pyc").touch()
-    
+
     # Verify that it detects the virtualenv due to the physical pyvenv.cfg file
     assert is_in_virtualenv(rel_path, git_root) is True

--- a/testing/backend/unit/test_select_tests.py
+++ b/testing/backend/unit/test_select_tests.py
@@ -38,6 +38,7 @@ def test_classify_file_shared_or_config():
     assert classify_file("setup.sh") == "SHARED_OR_CONFIG"
     assert classify_file("docker-compose.yml") == "SHARED_OR_CONFIG"
     assert classify_file("scripts/check-artifacts.sh") == "SHARED_OR_CONFIG"
+    assert classify_file("scripts/check_hygiene.py") == "SHARED_OR_CONFIG"
 
 
 def test_select_tests_empty():


### PR DESCRIPTION
Closes #1451


## Description
This PR introduces a Git repository hygiene check that blocks accidentally committed or tracked Python cache files (`__pycache__/` and `*.pyc`).
It includes:
- A new validation script `scripts/check_hygiene.py` that queries tracked files via `git ls-files` and verifies no Python cache files are tracked.
- Automatic and correct virtual environment directory exclusion (using segment matching like `.venv`, `venv`, `.venv-codex`, `env`, etc., as well as physical verification of parent directories containing `pyvenv.cfg`).
- A new `repository-hygiene` check job added to `.github/workflows/ci.yml` that runs on all PRs and push events.
- Updated change detection in `scripts/select_tests.py` to classify changes to `check_hygiene.py` as a `SHARED_OR_CONFIG` change, triggering the full CI suite.
- Documented instructions on how to run the hygiene check locally in `CONTRIBUTING.md`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
1. **Automated Unit Tests**:
   - Created `testing/backend/unit/test_check_hygiene.py` to assert segment-based venv detection, `pyvenv.cfg`-based physical venv detection, and cache file matching. Run via:
     ```bash
     python -m pytest testing/backend/unit/test_check_hygiene.py
     ```
   - Updated `testing/backend/unit/test_select_tests.py` to ensure `check_hygiene.py` is correctly classified as `SHARED_OR_CONFIG`. Run via:
     ```bash
     python -m pytest testing/backend/unit/test_select_tests.py
     ```
2. **Manual Testing**:
   - Executed `python scripts/check_hygiene.py` locally and verified that it successfully passed.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
