### PR TITLE
ci: ensure local virtual env folders are ignored consistently #1452

### DIFF
--- a/.github/workflows/check-artifacts.yml
+++ b/.github/workflows/check-artifacts.yml
@@ -11,6 +11,9 @@ on:
       - "logs/**"
       - "scripts/check-artifacts.sh"
       - ".github/workflows/check-artifacts.yml"
+      - "venv/**"
+      - ".venv/**"
+      - ".venv-codex/**"
 
 jobs:
   artifact-check:

--- a/scripts/check-artifacts.sh
+++ b/scripts/check-artifacts.sh
@@ -14,6 +14,10 @@ BLOCKED_PATTERNS=(
   "backend/data/raw/"
   "backend/data/reports/"
   "logs/"
+  # Python virtual environments (local development and automation)
+  "venv/"
+  ".venv/"
+  ".venv-codex/"
 )
 
 # ── Check 1: files already tracked in git history ─────────────────────────────


### PR DESCRIPTION
Closes #1452


## Description
This pull request resolves the issue where local virtual environment folders (such as `venv`, `.venv`, and `.venv-codex`) were not consistently covered by project artifact checking rules in the CI pipeline. 

To address this:
1. Updated [check-artifacts.sh](file:///d:/GSSoC/utksh1-SecuScan/SecuScan/scripts/check-artifacts.sh) to include `"venv/"`, `".venv/"`, and `".venv-codex/"` in the `BLOCKED_PATTERNS` array, preventing these virtualenvs from being committed to repository history.
2. Updated [check-artifacts.yml](file:///d:/GSSoC/utksh1-SecuScan/SecuScan/.github/workflows/check-artifacts.yml) to add the paths `"venv/**"`, `".venv/**"`, and `".venv-codex/**"` to the `paths` trigger list, ensuring the check runs whenever changes are staged or committed under those directories.

This implementation preserves existing dependency lock files and does not modify the `.gitignore` file.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
The implementation was verified locally using the following steps:
1. **Testing `venv/` block**: Created a dummy file within `venv/` (`venv/dummy.txt`), force-staged it (`git add -f venv/dummy.txt`), and executed `bash scripts/check-artifacts.sh HEAD`. Verified the script failed and correctly highlighted the tracked dummy file.
2. **Testing `.venv-codex/` block**: Created a dummy file within `.venv-codex/` (`.venv-codex/dummy.txt`), staged it (`git add .venv-codex/dummy.txt`), and executed `bash scripts/check-artifacts.sh HEAD`. Verified the script failed and flagged the file.
3. Cleaned up the test staging areas and verified the script returns `All clear!` under clean conditions.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
