### PR TITLE
feat(api): add optimistic notification rule conflicts

### DIFF
--- a/backend/secuscan/notification_service.py
+++ b/backend/secuscan/notification_service.py
@@ -207,6 +207,14 @@ class DeliveryResult:
     error_message: Optional[str] = None
 
 
+class NotificationRuleConflictError(Exception):
+    """Raised when a notification rule update loses an optimistic lock race."""
+
+    def __init__(self, current_rule: Dict[str, Any]) -> None:
+        super().__init__("Notification rule was updated by another request")
+        self.current_rule = current_rule
+
+
 def severity_meets_threshold(finding_severity: str, rule_threshold: str) -> bool:
     """Return True when finding severity is at or above the rule threshold."""
     finding_rank = _SEVERITY_RANK.get(str(finding_severity).lower())
@@ -652,6 +660,44 @@ async def process_task_notifications(
     for row in findings:
         results.extend(await process_finding_notifications(db, str(row["id"])))
     return results
+
+
+async def update_notification_rule(
+    db: Database,
+    *,
+    current_rule: Dict[str, Any],
+    updates: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Apply an optimistic-lock update to a notification rule row."""
+    assignments = [f"{column} = ?" for column in updates]
+    params = list(updates.values())
+    assignments.append("updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now')")
+    params.extend((current_rule["id"], current_rule["updated_at"]))
+
+    cursor = await db.execute(
+        f"""
+        UPDATE notification_rules
+        SET {', '.join(assignments)}
+        WHERE id = ? AND updated_at = ?
+        """,
+        tuple(params),
+    )
+    if cursor.rowcount == 0:
+        latest = await db.fetchone(
+            "SELECT * FROM notification_rules WHERE id = ?",
+            (current_rule["id"],),
+        )
+        if latest is None:
+            raise KeyError(current_rule["id"])
+        raise NotificationRuleConflictError(latest)
+
+    updated = await db.fetchone(
+        "SELECT * FROM notification_rules WHERE id = ?",
+        (current_rule["id"],),
+    )
+    if updated is None:
+        raise KeyError(current_rule["id"])
+    return updated
 
 
 async def process_slack_notification(db: Database, task_id: str) -> None:

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -2136,6 +2136,11 @@ async def get_notification_rule(rule_id: str, owner: str = Depends(get_current_o
 
 @router.patch("/notifications/rules/{rule_id}")
 async def update_notification_rule(rule_id: str, payload: NotificationRuleUpdate, owner: str = Depends(get_current_owner)):
+    """Patch a notification rule.
+
+    Returns ``409 Conflict`` with the latest persisted rule when an optimistic
+    update loses a concurrent edit race so clients can refresh and retry.
+    """
     db = await get_db()
     row = await _verify_notification_rule_owner(db, rule_id, owner)
 

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -2154,15 +2154,13 @@ async def update_notification_rule(rule_id: str, payload: NotificationRuleUpdate
     db = await get_db()
     row = await _verify_notification_rule_owner(db, rule_id, owner)
 
-    updates: List[str] = []
-    params: List[Any] = []
+    updates: Dict[str, Any] = {}
 
     if payload.name is not None:
         name = payload.name.strip()
         if not name:
             raise HTTPException(status_code=400, detail="Rule name is required")
-        updates.append("name = ?")
-        params.append(name)
+        updates["name"] = name
 
     effective_channel = (
         payload.channel_type
@@ -2174,42 +2172,45 @@ async def update_notification_rule(rule_id: str, payload: NotificationRuleUpdate
             effective_channel,
             payload.target_url_or_email,
         )
-        updates.append("target_url_or_email = ?")
-        params.append(target)
+        updates["target_url_or_email"] = target
     elif payload.channel_type is not None:
         target = _validate_notification_target(
             effective_channel,
             row["target_url_or_email"],
         )
-        updates.append("target_url_or_email = ?")
-        params.append(target)
+        updates["target_url_or_email"] = target
 
     if payload.severity_threshold is not None:
-        updates.append("severity_threshold = ?")
-        params.append(payload.severity_threshold.value)
+        updates["severity_threshold"] = payload.severity_threshold.value
 
     if payload.channel_type is not None:
-        updates.append("channel_type = ?")
-        params.append(payload.channel_type.value)
+        updates["channel_type"] = payload.channel_type.value
 
     if payload.is_active is not None:
-        updates.append("is_active = ?")
-        params.append(1 if payload.is_active else 0)
+        updates["is_active"] = 1 if payload.is_active else 0
 
     if not updates:
         raise HTTPException(status_code=400, detail="No update fields provided")
 
-    updates.append("updated_at = datetime('now')")
-    params.append(rule_id)
-    await db.execute(
-        f"UPDATE notification_rules SET {', '.join(updates)} WHERE id = ?",
-        tuple(params),
-    )
-    updated = await db.fetchone(
-        "SELECT * FROM notification_rules WHERE id = ?",
-        (rule_id,),
-    )
-    if not updated:
+    try:
+        updated = await notification_service.update_notification_rule(
+            db,
+            current_rule=row,
+            updates=updates,
+        )
+    except notification_service.NotificationRuleConflictError as exc:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "notification_rule_conflict",
+                "message": (
+                    "Notification rule was updated by another request. "
+                    "Refresh the rule and retry your changes."
+                ),
+                "current_rule": _serialize_notification_rule(exc.current_rule),
+            },
+        )
+    except KeyError:
         raise HTTPException(status_code=404, detail="Notification rule not found")
     return _serialize_notification_rule(updated)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -55,6 +55,40 @@ curl "http://localhost:8000/api/v1/tasks?page=2&per_page=10"
 curl "http://localhost:8000/api/v1/tasks?status=completed&plugin_id=nmap&page=1&per_page=20"
 ```
 
+## Notifications API
+
+### Update Notification Rule
+
+**Endpoint:** `PATCH /api/v1/notifications/rules/{rule_id}`
+
+**Description:** Updates the caller's notification rule. This endpoint uses
+optimistic locking on the row's `updated_at` value to prevent silent
+last-write-wins overwrites during concurrent edits.
+
+**Success Response (200 OK):** Returns the updated rule snapshot.
+
+**Conflict Response (409 Conflict):** Returned when another request updates the
+same rule after the caller's snapshot was loaded but before its PATCH is
+applied. Clients should refresh from `current_rule`, reconcile local changes,
+and retry with a new request.
+
+```json
+{
+  "error": "notification_rule_conflict",
+  "message": "Notification rule was updated by another request. Refresh the rule and retry your changes.",
+  "current_rule": {
+    "id": "rule-id",
+    "name": "Critical alerts",
+    "severity_threshold": "high",
+    "channel_type": "webhook",
+    "target_url_or_email": "https://example.com/hook",
+    "is_active": true,
+    "created_at": "2026-06-29T07:39:22Z",
+    "updated_at": "2026-06-29T07:41:05Z"
+  }
+}
+```
+
 ## See Also
 
 * [API Authentication](api-authentication.md) — How requests are authenticated with the API key and authorized per owner (`X-User-Id` → `owner_id`), including the cross-owner test requirement.

--- a/testing/backend/integration/test_notification_routes.py
+++ b/testing/backend/integration/test_notification_routes.py
@@ -101,6 +101,9 @@ def test_notification_rule_accepts_email_target(test_client):
 async def test_notification_rule_update_returns_409_on_concurrent_conflict(
     setup_test_environment, monkeypatch
 ):
+    # API contract: concurrent PATCH requests use optimistic locking. The loser
+    # gets 409 plus the current persisted rule so the client can refresh before
+    # retrying local edits.
     await rate_limiter.reset()
     async with concurrent_limiter.lock:
         concurrent_limiter.running_tasks.clear()

--- a/testing/backend/integration/test_notification_routes.py
+++ b/testing/backend/integration/test_notification_routes.py
@@ -1,6 +1,18 @@
+import asyncio
 import uuid
 
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend.secuscan import auth as auth_module
+from backend.secuscan import database as database_module
+from backend.secuscan import notification_service
+from backend.secuscan.config import settings
+from backend.secuscan.database import init_db
+from backend.secuscan.main import app
 from backend.secuscan.models import NotificationDeliveryStatus
+from backend.secuscan.plugins import init_plugins
+from backend.secuscan.ratelimit import concurrent_limiter, rate_limiter
 
 
 def _rule_payload(
@@ -85,9 +97,86 @@ def test_notification_rule_accepts_email_target(test_client):
     assert response.json()["target_url_or_email"] == "alerts@example.com"
 
 
-def test_notification_history_list_contract(test_client):
-    import asyncio
+@pytest.mark.asyncio
+async def test_notification_rule_update_returns_409_on_concurrent_conflict(
+    setup_test_environment, monkeypatch
+):
+    await rate_limiter.reset()
+    async with concurrent_limiter.lock:
+        concurrent_limiter.running_tasks.clear()
+    await init_db(settings.database_path)
+    await init_plugins(settings.plugins_dir)
+    api_key = auth_module.init_api_key(settings.data_dir)
 
+    gate = asyncio.Event()
+    reached = 0
+    reached_lock = asyncio.Lock()
+    real_update_rule = notification_service.update_notification_rule
+
+    async def gated_update_rule(db, *, current_rule, updates):
+        nonlocal reached
+        async with reached_lock:
+            reached += 1
+            if reached == 2:
+                gate.set()
+        await gate.wait()
+        return await real_update_rule(
+            db,
+            current_rule=current_rule,
+            updates=updates,
+        )
+
+    monkeypatch.setattr(
+        notification_service,
+        "update_notification_rule",
+        gated_update_rule,
+    )
+
+    transport = ASGITransport(app=app)
+    headers = {"X-Api-Key": api_key}
+
+    try:
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            headers=headers,
+        ) as client:
+            create_response = await client.post(
+                "/api/v1/notifications/rules",
+                json=_rule_payload(),
+            )
+            assert create_response.status_code == 200
+            rule_id = create_response.json()["id"]
+
+            responses = await asyncio.gather(
+                client.patch(
+                    f"/api/v1/notifications/rules/{rule_id}",
+                    json={"name": "Concurrent rename"},
+                ),
+                client.patch(
+                    f"/api/v1/notifications/rules/{rule_id}",
+                    json={"severity_threshold": "high"},
+                ),
+            )
+    finally:
+        if database_module.db is not None:
+            await database_module.db.disconnect()
+            database_module.db = None
+
+    status_codes = sorted(response.status_code for response in responses)
+    assert status_codes == [200, 409]
+
+    conflict_response = next(
+        response for response in responses if response.status_code == 409
+    )
+    body = conflict_response.json()
+    assert body["error"] == "notification_rule_conflict"
+    assert "Refresh the rule and retry your changes." in body["message"]
+    assert body["current_rule"]["id"] == rule_id
+    assert body["current_rule"]["updated_at"]
+
+
+def test_notification_history_list_contract(test_client):
     from backend.secuscan.database import get_db
 
     create_response = test_client.post(

--- a/testing/backend/unit/test_notification_service.py
+++ b/testing/backend/unit/test_notification_service.py
@@ -17,10 +17,12 @@ from backend.secuscan.models import (
     NotificationSeverityThreshold,
 )
 from backend.secuscan.notification_service import (
+    NotificationRuleConflictError,
     build_alert_payload,
     deliver_via_rule,
     process_finding_notifications,
     severity_meets_threshold,
+    update_notification_rule,
     was_already_delivered,
 )
 from backend.secuscan.redaction import REDACTED
@@ -229,6 +231,35 @@ async def test_email_placeholder_records_success(test_db):
     assert len(results) == 1
     assert results[0].status == NotificationDeliveryStatus.SUCCESS
     assert results[0].skipped is False
+
+
+@pytest.mark.asyncio
+async def test_update_notification_rule_detects_stale_snapshot(test_db):
+    rule_id = await _seed_rule(test_db)
+    current_rule = await test_db.fetchone(
+        "SELECT * FROM notification_rules WHERE id = ?",
+        (rule_id,),
+    )
+    assert current_rule is not None
+
+    await test_db.execute(
+        """
+        UPDATE notification_rules
+        SET name = ?, updated_at = datetime('now', '+1 second')
+        WHERE id = ?
+        """,
+        ("Updated elsewhere", rule_id),
+    )
+
+    with pytest.raises(NotificationRuleConflictError) as exc_info:
+        await update_notification_rule(
+            test_db,
+            current_rule=current_rule,
+            updates={"name": "My stale update"},
+        )
+
+    assert exc_info.value.current_rule["id"] == rule_id
+    assert exc_info.value.current_rule["name"] == "Updated elsewhere"
 
 
 def _mock_async_client(mock_post):


### PR DESCRIPTION
## Description
This PR adds optimistic conflict handling for notification rule updates. If two requests try to edit the same rule concurrently, the second update now fails with a clear `409 Conflict` response instead of silently overwriting the newer change.

The update flow now uses an optimistic compare-and-swap on the rule’s `updated_at` value, and the API returns the current rule data in the conflict response so clients can refresh and retry safely.

Closes #815.

## Related Issues
- #815

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `../SecuScan/.venv/bin/pytest testing/backend/unit/test_notification_service.py -q`
- `../SecuScan/.venv/bin/pytest testing/backend/integration/test_notification_routes.py -q`

These cover stale snapshot detection at the service layer and the concurrent PATCH route behavior that returns `409 Conflict`.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.