### PR TITLE
test : added unit tests for _now_iso in finding_intelligence.py

### DIFF
--- a/testing/backend/unit/test_finding_intelligence_timestamp.py
+++ b/testing/backend/unit/test_finding_intelligence_timestamp.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import pytest
 from datetime import datetime, timezone
 
-from backend.secuscan.finding_intelligence import _parse_timestamp, _stable_id
+from backend.secuscan.finding_intelligence import _now_iso, _parse_timestamp, _stable_id
 
 
 # ---------------------------------------------------------------------------
@@ -123,3 +123,33 @@ class TestStableId:
     def test_many_parts(self):
         sig = _stable_id("finding", "a", "b", "c", "d", "e")
         assert sig.startswith("finding:")
+
+
+# ---------------------------------------------------------------------------
+# _now_iso
+# ---------------------------------------------------------------------------
+
+class TestNowIso:
+    def test_returns_string(self):
+        """_now_iso returns a string."""
+        result = _now_iso()
+        assert isinstance(result, str)
+
+    def test_returns_valid_iso8601_format(self):
+        """_now_iso returns a valid ISO 8601 formatted datetime string."""
+        result = _now_iso()
+        parsed = datetime.fromisoformat(result.replace("Z", "+00:00"))
+        assert isinstance(parsed, datetime)
+
+    def test_returns_utc_timezone(self):
+        """_now_iso returns a UTC timezone-aware datetime string."""
+        result = _now_iso()
+        assert result.endswith("+00:00") or result.endswith("Z")
+
+    def test_result_is_reasonable_current_time(self):
+        """_now_iso returns a time within a few seconds of now."""
+        before = datetime.now(timezone.utc)
+        result = _now_iso()
+        after = datetime.now(timezone.utc)
+        parsed = datetime.fromisoformat(result.replace("Z", "+00:00"))
+        assert before <= parsed <= after


### PR DESCRIPTION
Closes #1474.

Summary of What Has Been Done:
Added unit tests for the _now_iso helper function in backend/secuscan/finding_intelligence.py. This pure helper returns the current UTC datetime as an ISO string and is used across correlation and deduplication code paths.

Changes Made:
- Extended testing/backend/unit/test_finding_intelligence_timestamp.py with TestNowIso class:
  - test_returns_string: verifies the return type is a string
  - test_returns_valid_iso8601_format: verifies parseable ISO 8601 format
  - test_returns_utc_timezone: verifies the returned string ends with +00:00 or Z
  - test_result_is_reasonable_current_time: verifies the timestamp is within seconds of now

Impact it Made:
- Increases unit test coverage for finding_intelligence.py
- Guards against accidental changes to the datetime format used in correlation timestamps

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.