### PR TITLE
feat(frontend): dedupe repeated backend error toasts

### DIFF
--- a/frontend/src/components/ToastContext.tsx
+++ b/frontend/src/components/ToastContext.tsx
@@ -1,12 +1,15 @@
-import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react'
+import React, { createContext, useContext, useState, useCallback, useRef, useEffect, ReactNode } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 
 type ToastType = 'success' | 'error' | 'info' | 'warning';
+
+const TOAST_TTL_MS = 5000
 
 interface Toast {
     id: string
     message: string
     type: ToastType
+    count: number
 }
 
 interface ToastContextType {
@@ -25,17 +28,47 @@ export const useToast = () => {
 
 export const ToastProvider = ({ children }: { children: ReactNode }) => {
     const [toasts, setToasts] = useState<Toast[]>([])
+    const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
 
-    const addToast = useCallback((message: string, type: ToastType = 'success') => {
-        const id = Math.random().toString(36).substring(2, 9)
-        setToasts((prev) => [...prev, { id, message, type }])
-        setTimeout(() => {
-            setToasts((prev) => prev.filter((t) => t.id !== id))
-        }, 5000)
+    const clearTimer = useCallback((id: string) => {
+        const handle = timers.current[id]
+        if (handle) {
+            clearTimeout(handle)
+            delete timers.current[id]
+        }
     }, [])
 
     const removeToast = useCallback((id: string) => {
+        clearTimer(id)
         setToasts((prev) => prev.filter((t) => t.id !== id))
+    }, [clearTimer])
+
+    const scheduleRemoval = useCallback((id: string) => {
+        clearTimer(id)
+        timers.current[id] = setTimeout(() => removeToast(id), TOAST_TTL_MS)
+    }, [clearTimer, removeToast])
+
+    const addToast = useCallback((message: string, type: ToastType = 'success') => {
+        setToasts((prev) => {
+            // Collapse repeated identical notifications into a single entry instead of
+            // stacking duplicates (e.g. a backend call that keeps failing).
+            const existing = prev.find((t) => t.message === message && t.type === type)
+            if (existing) {
+                scheduleRemoval(existing.id)
+                return prev.map((t) =>
+                    t.id === existing.id ? { ...t, count: t.count + 1 } : t,
+                )
+            }
+            const id = Math.random().toString(36).substring(2, 9)
+            scheduleRemoval(id)
+            return [...prev, { id, message, type, count: 1 }]
+        })
+    }, [scheduleRemoval])
+
+    // Clear any pending dismissal timers on unmount.
+    useEffect(() => () => {
+        Object.values(timers.current).forEach(clearTimeout)
+        timers.current = {}
     }, [])
 
     return (
@@ -81,6 +114,14 @@ export function ToastContainer() {
                             </span>
                             <span className="text-xs font-black uppercase tracking-tight truncate">{toast.message}</span>
                         </div>
+                        {toast.count > 1 && (
+                            <span
+                                className="shrink-0 px-2 py-0.5 bg-black text-white text-[10px] font-black tabular-nums"
+                                aria-label={`Repeated ${toast.count} times`}
+                            >
+                                ×{toast.count}
+                            </span>
+                        )}
                         <button
                             type="button"
                             className="opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity absolute top-2 right-2"

--- a/frontend/testing/unit/components/ToastContext.test.tsx
+++ b/frontend/testing/unit/components/ToastContext.test.tsx
@@ -47,3 +47,46 @@ describe('Toast accessibility', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent(/error message/i)
   })
 })
+
+describe('Toast deduplication', () => {
+  it('collapses repeated identical notifications into a single toast with a count', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ToastProvider>
+        <ToastTrigger type="error" />
+      </ToastProvider>,
+    )
+
+    const trigger = screen.getByRole('button', { name: /show toast/i })
+    await user.click(trigger)
+    await user.click(trigger)
+    await user.click(trigger)
+
+    const alerts = await screen.findAllByRole('alert')
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toHaveTextContent(/error message/i)
+    expect(alerts[0]).toHaveTextContent('×3')
+    expect(screen.getByLabelText(/repeated 3 times/i)).toBeInTheDocument()
+  })
+
+  it('keeps notifications with different message or type separate', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ToastProvider>
+        <ToastTrigger type="success" />
+        <ToastTrigger type="error" />
+      </ToastProvider>,
+    )
+
+    const [successTrigger, errorTrigger] = screen.getAllByRole('button', { name: /show toast/i })
+    await user.click(successTrigger)
+    await user.click(errorTrigger)
+
+    expect(await screen.findByRole('status')).toHaveTextContent(/success message/i)
+    expect(await screen.findByRole('alert')).toHaveTextContent(/error message/i)
+    // Neither is collapsed, so no count badge appears.
+    expect(screen.queryByText(/^×\d+$/)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Repeated identical backend-error toasts now collapse into a single entry with a count,
instead of stacking a new toast each time. Implemented entirely in the shared
`ToastContext` so every caller benefits; no page-level changes and the visual language is
unchanged.

## Problem

`addToast` appended a new toast on every call, so a backend call that keeps failing (or a
repeated user action) spammed the screen with N identical stacked toasts.

## Changes (`frontend/src/components/ToastContext.tsx`)

- **Dedup by `message` + `type`:** if an identical toast is already visible, `addToast`
  now **increments that toast's `count` and resets its 5s dismissal timer** (so the single
  entry stays visible while errors keep arriving) instead of pushing a duplicate.
- **`×N` count badge:** shown only when `count > 1`, with `aria-label="Repeated N times"`.
  The toast is already `aria-atomic` / `role="alert"`, so the count update re-announces the
  one toast rather than emitting N separate alerts.
- **Timer management:** replaced the fire-and-forget `setTimeout` with a `timers` ref +
  `clearTimer` / `scheduleRemoval` helpers; `removeToast` clears the toast's timer and an
  unmount effect clears any pending timers (fixes a latent timer leak in the original).

> Note: `frontend/src/api.ts` was in the suggested scope but needs **no change** — it
> doesn't create toasts; backend errors are surfaced by callers via `addToast(msg, 'error')`,
> so deduping in the context covers all of them.

## Tests (`frontend/testing/unit/components/ToastContext.test.tsx`)

Added a `Toast deduplication` block: three identical triggers collapse to one alert showing
`×3` (and the `repeated 3 times` label); distinct message/type stay separate with no badge.
The existing accessibility tests are unchanged.

## Verification

- `npx vitest run testing/unit/components/ToastContext.test.tsx` → 4/4 pass.
- `npm run typecheck` → clean.
- `npm run quality` → passed (only the pre-existing 2000ms `CopyToClipboard` animation
  warning, unrelated to this change).
- `npm run build` → built OK (pre-existing chunk-size warning only).
- Diff = 2 files (`ToastContext.tsx`, its test).

Closes #828.

---

## ⚠️ Separate heads-up: API key leaked in e2e tests

Not part of this PR (also flagged in #1470), re-surfacing for visibility. A **GitGuardian
"Generic High Entropy Secret"** alert (severity **High**, *publicly visible*) fired on a
hardcoded 64-character hex API key committed across three Playwright e2e specs:

- `frontend/testing/e2e/settings-persistence.spec.ts` (added in #674)
- `frontend/testing/e2e/workflow.spec.ts` — `const API_KEY = "…"` (added in #714)
- `frontend/testing/e2e/mobile-navigation.spec.ts` (added in #1316)

It's only used to pre-seed `localStorage["secuscan_api_key"]` so tests skip the API-key
setup screen, so real-world risk is low — but it's a real secret-shaped value flagged on
every scan of the public repo, currently on `main`. **Suggested fix:** swap the literal for
an env var / obvious placeholder, e.g.
`const API_KEY = process.env.E2E_API_KEY ?? "e2e-dummy-key-not-a-secret";`
(value intentionally not pasted here to avoid another exposure point.)

**@utksh1 — want me to fix this?** Happy to open a separate PR doing that swap across all
three specs. Just say the word.

---

@utksh1 please review this PR. 
