### PR TITLE
test: cover network policy URL parsing failures

### DIFF
--- a/backend/secuscan/network_policy.py
+++ b/backend/secuscan/network_policy.py
@@ -190,8 +190,12 @@ class NetworkPolicyEngine:
                 if parsed.scheme in {"http", "https", "ws", "wss"}:
                     if parsed.hostname:
                         target_host = parsed.hostname
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug(
+                    "Failed to parse URL while normalizing network policy target '%s': %s",
+                    original_dest_ip,
+                    exc,
+                )
 
         if ":" in target_host:
             if target_host.startswith("["):
@@ -357,8 +361,12 @@ class NetworkPolicyEngine:
                 parsed = urlparse(target_host)
                 if parsed.hostname:
                     target_host = parsed.hostname
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug(
+                    "Failed to parse egress target '%s' as URL: %s",
+                    host,
+                    exc,
+                )
 
         try:
             ip = ipaddress.ip_address(target_host)

--- a/testing/backend/unit/test_network_policy.py
+++ b/testing/backend/unit/test_network_policy.py
@@ -366,3 +366,25 @@ class TestDefaultDenylistSSRFProtection:
         assert "fc00::/7" in denylist
         assert "fe80::/10" in denylist
         assert "::1/128" in denylist
+
+def test_check_access_logs_url_parse_failure(caplog, tmp_path):
+    engine = NetworkPolicyEngine(audit_log_path=str(tmp_path / "audit.log"))
+
+    with patch("urllib.parse.urlparse", side_effect=RuntimeError("boom")):
+        with caplog.at_level("DEBUG"):
+            engine.check_access(
+                dest_ip="http://example.com",
+                plugin_id="test",
+            )
+
+    assert "Failed to parse URL while normalizing network policy target" in caplog.text
+
+
+def test_validate_egress_target_logs_url_parse_failure(caplog, tmp_path):
+    engine = NetworkPolicyEngine(audit_log_path=str(tmp_path / "audit.log"))
+
+    with patch("backend.secuscan.network_policy.urlparse", side_effect=RuntimeError("boom")):
+        with caplog.at_level("DEBUG"):
+            engine.validate_egress_target("http://example.com")
+
+    assert "Failed to parse egress target" in caplog.text


### PR DESCRIPTION
## Description
- Replaced silent URL parsing exception handlers with contextual debug logging in the network policy engine.
- Added regression tests covering URL parsing failures in both `check_access()` and `validate_egress_target()`.
- Preserved existing fail-closed behavior while improving observability for troubleshooting.

## Related Issues
Closes #1446 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Successfully verified by running:

```bash
ruff check backend testing
```

**Result:**  All checks passed.

```bash
pytest testing/backend/unit/test_network_policy.py -v
```

**Result:**  All 25 tests passed.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
