### PR TITLE
ci: ignore local virtualenv directories consistently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,11 @@ wheels/
 MANIFEST
 
 # Virtual Environment
+.venv/
+.venv-codex/
 venv/
 env/
 ENV/
-.venv
 venv_tests/
 test_env/
 


### PR DESCRIPTION
## Description
- Add `.venv-codex/` to `.gitignore` so local Codex virtual environment folders are ignored.
- Normalize the existing `.venv` entry to `.venv/` for consistent directory ignore patterns.

## Related Issues
Closes #1452

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- Verified that `.gitignore` includes ignore rules for `.venv/`, `venv/`, and `.venv-codex/`.
- Confirmed the diff only contains the intended `.gitignore` changes.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.