### PR TITLE
test(backend): add parser unit tests for code_analyzer plugin #1423

### DIFF
--- a/testing/backend/unit/test_code_analyzer_parser.py
+++ b/testing/backend/unit/test_code_analyzer_parser.py
@@ -1,0 +1,102 @@
+import json
+from plugins.code_analyzer.parser import parse
+
+
+def test_code_analyzer_parser_normal_output():
+    # A sample output representing a normal Bandit JSON output
+    normal_output = json.dumps({
+        "results": [
+            {
+                "code": "import pickle\npickle.loads(user_input)",
+                "filename": "server.py",
+                "issue_confidence": "HIGH",
+                "issue_severity": "HIGH",
+                "issue_text": "Deserialize untrusted data using pickle",
+                "line_number": 12,
+                "line_range": [12],
+                "more_info": "https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b301-pickle",
+                "test_id": "B301",
+                "test_name": "blacklist"
+            },
+            {
+                "code": "print('Hello')",
+                "filename": "hello.py",
+                "issue_confidence": "LOW",
+                "issue_severity": "LOW",
+                "issue_text": "Some minor warning",
+                "line_number": 5,
+                "line_range": [5],
+                "more_info": "https://bandit.readthedocs.io/some-warning",
+                "test_id": "B100",
+                "test_name": "minor"
+            }
+        ]
+    })
+
+    result = parse(normal_output)
+
+    assert result["count"] == 2
+    assert len(result["findings"]) == 2
+
+    # Verify first finding
+    f1 = result["findings"][0]
+    assert f1["title"] == "Bandit issue: Deserialize untrusted data using pickle in server.py"
+    assert f1["category"] == "Code Security"
+    assert f1["severity"] == "high"
+    assert "Severity: high, Confidence: high." in f1["description"]
+    assert "Found in server.py at line 12." in f1["description"]
+    assert f1["remediation"] == "Review the affected code and follow secure coding practices."
+    assert f1["metadata"]["issue_text"] == "Deserialize untrusted data using pickle"
+    assert f1["metadata"]["file"] == "server.py"
+    assert f1["metadata"]["line"] == 12
+    assert f1["metadata"]["test_id"] == "B301"
+    assert f1["metadata"]["more_info"] == "https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b301-pickle"
+
+    # Verify second finding
+    f2 = result["findings"][1]
+    assert f2["title"] == "Bandit issue: Some minor warning in hello.py"
+    assert f2["severity"] == "low"
+    assert "Confidence: low" in f2["description"]
+
+
+def test_code_analyzer_parser_empty_output():
+    # Empty string should not crash and should return empty results
+    result = parse("")
+    assert result == {"findings": [], "count": 0}
+
+
+def test_code_analyzer_parser_malformed_json():
+    # Malformed JSON should not crash and should return empty results
+    result = parse("{ malformed json }")
+    assert result == {"findings": [], "count": 0}
+
+
+def test_code_analyzer_parser_missing_results_key():
+    # Valid JSON but missing "results" key
+    result = parse("{}")
+    assert result == {"findings": [], "count": 0}
+
+
+def test_code_analyzer_parser_missing_fields_in_results():
+    # "results" list contains objects with missing fields
+    partial_output = json.dumps({
+        "results": [
+            {
+                # missing filename, line_number, issue_severity, issue_confidence, test_id, more_info
+                "issue_text": "Insecure function call"
+            }
+        ]
+    })
+
+    result = parse(partial_output)
+
+    assert result["count"] == 1
+    assert len(result["findings"]) == 1
+
+    finding = result["findings"][0]
+    assert finding["title"] == "Bandit issue: Insecure function call in Unknown"
+    assert finding["severity"] == "low"
+    assert "Confidence: low" in finding["description"]
+    assert "Found in Unknown at line 0." in finding["description"]
+    assert finding["metadata"]["test_id"] == "unknown"
+    assert finding["metadata"]["more_info"] == ""


### PR DESCRIPTION
Closes #1423


## Description
This PR introduces focused unit tests for the `code_analyzer` plugin's output parser to ensure robust, regression-free behavior. 

The test scenarios covered in `testing/backend/unit/test_code_analyzer_parser.py` include:
- **`test_code_analyzer_parser_normal_output`**: Validates the extraction of standard Bandit JSON output fields (`title`, `category`, `severity`, `description`, `remediation`, and `metadata` containing `issue_text`, `file`, `line`, `test_id`, and `more_info`).
- **`test_code_analyzer_parser_empty_output`**: Ensures the parser processes empty strings without throwing exceptions.
- **`test_code_analyzer_parser_malformed_json`**: Verifies graceful handling of invalid/malformed JSON inputs.
- **`test_code_analyzer_parser_missing_results_key`**: Ensures valid JSON structures lacking the `"results"` list return empty results cleanly.
- **`test_code_analyzer_parser_missing_fields_in_results`**: Confirms that default fallback values (e.g. `"Unknown"`, `0`, `"low"`, `"unknown"`) are correctly applied when nested properties in the results array are absent.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
1. Ran backend unit tests:
   ```bash
   python -m pytest testing/backend/unit/test_code_analyzer_parser.py
   
   Output: 5 passed, 1 warning in 0.54s

2. Checked the file code-style compliance using Ruff:
    ```bash
    python -m ruff check testing/backend/unit/test_code_analyzer_parser.py
  
    Output: All checks passed!

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
