### PR TITLE
fix : replace silent executor cleanup exception with debug log

### DIFF
--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -74,7 +74,8 @@ async def _terminate_process_group(pid: int, task_id: str, grace_seconds: int = 
         await asyncio.sleep(0.1)
         try:
             os.killpg(pgid, 0)
-        except (ProcessLookupError, PermissionError):
+        except (ProcessLookupError, PermissionError) as exc:
+            logger.debug("pgid %d already exited during grace poll: %s", pgid, exc)
             return
 
     try:


### PR DESCRIPTION
Closes #1445.

Summary of What Has Been Done:
Replaced a silent `except (ProcessLookupError, PermissionError):` block in the `_cleanup_process_group` function of `backend/secuscan/executor.py` with a debug-level log message, consistent with the existing logging pattern used throughout the same function.

Changes Made:
- In `backend/secuscan/executor.py` (around line 77), added `logger.debug("pgid %d already exited during grace poll: %s", pgid, exc)` to the silent except block, matching the debug logging already used for the SIGTERM and getpgid exception paths.

Impact it Made:
- Improves debuggability when process cleanup encounters race conditions
- Aligns with the structured logging policy established in recent executor improvements
- No functional change to behavior; only adds observability

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.