### PR TITLE
test : added toolCheatSheets content schema coverage

### DIFF
--- a/frontend/testing/unit/schema/toolCheatSheets.schema.test.ts
+++ b/frontend/testing/unit/schema/toolCheatSheets.schema.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Schema coverage for src/data/toolCheatSheets.ts (issue #1417).
+ *
+ * These tests verify that the cheat-sheet data conforms to its TypeScript
+ * interface contract: every tool entry has the required fields, each flag
+ * has a non-empty flag and description, and the ethical tip is present.
+ */
+
+import { describe, it, expect } from 'vitest'
+import toolCheatSheets, { type CheatSheet } from '../../../src/data/toolCheatSheets'
+
+const SCHEMA_FIELDS: Array<keyof CheatSheet> = [
+    'toolId',
+    'toolName',
+    'overview',
+    'flags',
+    'ethicalTip',
+]
+
+describe('toolCheatSheets — schema contract', () => {
+    it('exports at least one entry', () => {
+        expect(Object.keys(toolCheatSheets).length).toBeGreaterThan(0)
+    })
+
+    it('every entry has all required top-level fields', () => {
+        for (const [toolId, sheet] of Object.entries(toolCheatSheets)) {
+            for (const field of SCHEMA_FIELDS) {
+                expect(sheet).toHaveProperty(field)
+            }
+            // toolId in data should match the Record key
+            expect(sheet.toolId).toBe(toolId)
+        }
+    })
+
+    it('every toolId is a non-empty string', () => {
+        for (const sheet of Object.values(toolCheatSheets)) {
+            expect(typeof sheet.toolId).toBe('string')
+            expect(sheet.toolId.length).toBeGreaterThan(0)
+        }
+    })
+
+    it('every toolName is a non-empty string', () => {
+        for (const sheet of Object.values(toolCheatSheets)) {
+            expect(typeof sheet.toolName).toBe('string')
+            expect(sheet.toolName.length).toBeGreaterThan(0)
+        }
+    })
+
+    it('every overview is a non-empty string', () => {
+        for (const sheet of Object.values(toolCheatSheets)) {
+            expect(typeof sheet.overview).toBe('string')
+            expect(sheet.overview.length).toBeGreaterThan(0)
+        }
+    })
+
+    it('flags is always a non-empty array', () => {
+        for (const sheet of Object.values(toolCheatSheets)) {
+            expect(Array.isArray(sheet.flags)).toBe(true)
+            expect(sheet.flags.length).toBeGreaterThan(0)
+        }
+    })
+
+    it('every flag has a non-empty flag string and description', () => {
+        for (const sheet of Object.values(toolCheatSheets)) {
+            for (const f of sheet.flags) {
+                expect(typeof f.flag).toBe('string')
+                expect(f.flag.length).toBeGreaterThan(0)
+                expect(typeof f.description).toBe('string')
+                expect(f.description.length).toBeGreaterThan(0)
+            }
+        }
+    })
+
+    it('no flag objects are empty', () => {
+        for (const sheet of Object.values(toolCheatSheets)) {
+            for (const f of sheet.flags) {
+                expect(Object.keys(f).sort()).toEqual(['description', 'flag'])
+            }
+        }
+    })
+
+    it('every ethicalTip is a non-empty string', () => {
+        for (const sheet of Object.values(toolCheatSheets)) {
+            expect(typeof sheet.ethicalTip).toBe('string')
+            expect(sheet.ethicalTip.length).toBeGreaterThan(0)
+        }
+    })
+
+    it('nmap entry is present and has expected shape', () => {
+        const nmap = toolCheatSheets['nmap']
+        expect(nmap).toBeDefined()
+        expect(nmap.toolName).toBe('Nmap')
+        expect(nmap.flags.some(f => f.flag === '-sn')).toBe(true)
+        expect(nmap.flags.some(f => f.flag === '-sV')).toBe(true)
+    })
+})


### PR DESCRIPTION
Closes #1417.

Summary of What Has Been Done:
Added `testing/unit/schema/toolCheatSheets.schema.test.ts` covering the TypeScript schema contract of `src/data/toolCheatSheets.ts`. The tests verify that every cheat-sheet entry has all required fields (toolId, toolName, overview, flags, ethicalTip), that all flag objects have non-empty flag and description strings, and that the nmap entry has the expected shape.

Changes Made:
- New file: `frontend/testing/unit/schema/toolCheatSheets.schema.test.ts` (10 tests)
- Tests cover: required field presence, non-empty strings, nmap shape validation, flag object contract

Impact it Made:
- Guarantees schema integrity for the tool cheat-sheets data catalog
- Catches missing fields or malformed entries before they reach production
- All 10 tests pass

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.