### PR TITLE
feat(zap_scanner): replace placeholder connector with ZAP baseline command

### DIFF
--- a/plugins/zap_scanner/metadata.json
+++ b/plugins/zap_scanner/metadata.json
@@ -16,13 +16,18 @@
   "supports_session_reuse": true,
   "engine": {
     "type": "cli",
-    "binary": "python3"
+    "binary": "docker"
   },
   "command_template": [
-    "python3",
-    "-c",
-    "import sys;print('ZAP connector placeholder scan');print('target='+sys.argv[1]);print('mode=dast')",
-    "{target}"
+    "docker",
+    "run",
+    "--rm",
+    "ghcr.io/zaproxy/zaproxy:stable",
+    "zap-baseline.py",
+    "-t",
+    "{target}",
+    "-m",
+    "5"
   ],
   "fields": [
     {
@@ -62,10 +67,10 @@
   ],
   "dependencies": {
     "binaries": [
-      "python3"
+      "docker"
     ],
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "6546eca4549d40f188c84e9be46b7e992aa6a025d25a9e7ba1e2420387108819"
+  "checksum": "4d7cd9e4bed793703811204fd22a5e0b511d8880750f07a593301a7eae5732a0"
 }

--- a/plugins/zap_scanner/parser.py
+++ b/plugins/zap_scanner/parser.py
@@ -3,15 +3,22 @@ from typing import Any, Dict, List
 
 def parse(output: str) -> Dict[str, Any]:
     lines = [line.strip() for line in output.splitlines() if line.strip()]
+
+    alert_lines = [
+        line
+        for line in lines
+        if line.startswith("WARN-NEW:") or line.startswith("FAIL-NEW:")
+    ]
+
     findings: List[Dict[str, Any]] = []
 
-    for line in lines[:300]:
-        severity = "info"
-        low_line = line.lower()
-        if any(keyword in low_line for keyword in ["open", "found", "vuln", "warning", "detected", "exposed"]):
-            severity = "low"
-        if any(keyword in low_line for keyword in ["critical", "exploit", "injection", "compromised"]):
+    for line in alert_lines[:300]:
+        if line.startswith("FAIL-NEW:"):
             severity = "high"
+        elif line.startswith("WARN-NEW:"):
+            severity = "low"
+        else:
+            severity = "info"
 
         findings.append(
             {
@@ -27,5 +34,5 @@ def parse(output: str) -> Dict[str, Any]:
     return {
         "findings": findings,
         "count": len(findings),
-        "items": lines[:300],
+        "items": alert_lines[:300],
     }

--- a/testing/backend/unit/fixtures/zap_scanner/sample_output.txt
+++ b/testing/backend/unit/fixtures/zap_scanner/sample_output.txt
@@ -1,3 +1,4 @@
-ZAP connector placeholder scan
-target=https://secuscan.in
-mode=dast
+PASS: Passive scan completed
+WARN-NEW: X-Frame-Options Header Not Set [10020]
+FAIL-NEW: SQL Injection [40018]
+WARN-NEW: Content Security Policy Header Not Set [10038]

--- a/testing/backend/unit/test_zap_scanner_plugin.py
+++ b/testing/backend/unit/test_zap_scanner_plugin.py
@@ -58,10 +58,13 @@ def test_zap_scanner_build_command_renders_representative_target(plugin_manager)
     )
 
     assert command is not None
-    assert command[0] == "python3"
-    assert command[1] == "-c"
+    assert command[0] == "docker"
+    assert command[1] == "run"
+    assert "--rm" in command
+    assert "ghcr.io/zaproxy/zaproxy:stable" in command
+    assert "zap-baseline.py" in command
+    assert "-t" in command
     assert target in command
-    assert "ZAP connector placeholder scan" in command[2]
 
 
 def test_zap_scanner_parser_fixture_produces_stable_findings(plugin_manager):
@@ -73,18 +76,17 @@ def test_zap_scanner_parser_fixture_produces_stable_findings(plugin_manager):
     assert parsed["count"] == 3
     assert len(parsed["findings"]) == 3
 
-    assert parsed["items"] == [
-        "ZAP connector placeholder scan",
-        "target=https://secuscan.in",
-        "mode=dast",
-    ]
-
     first = parsed["findings"][0]
-
     assert first["title"] == "Recon/Scan Observation"
-    assert first["category"] == "Security Scan"
-    assert first["severity"] == "info"
-    assert first["metadata"]["raw"] == "ZAP connector placeholder scan"
+    assert first["severity"] == "low"
+    assert "X-Frame-Options" in first["description"]
+
+    second = parsed["findings"][1]
+    assert second["severity"] == "high"
+    assert "SQL Injection" in second["description"]
+
+    third = parsed["findings"][2]
+    assert third["severity"] == "low"
 
 
 def test_zap_scanner_parser_empty_output_is_deterministic(plugin_manager):


### PR DESCRIPTION
## Description
This PR replaces the placeholder Python command used by the ZAP plugin with a Docker-based OWASP ZAP baseline command and updates the parser/tests to work with representative ZAP baseline output.

### Changes

- Replaced placeholder command with Docker-based ZAP baseline execution.
- Updated plugin dependency from `python3` to `docker`.
- Improved parser to process `WARN-NEW` and `FAIL-NEW` alerts while ignoring non-alert status lines.
- Updated fixture to use representative ZAP baseline output.
- Updated parser and command generation tests.

## Related Issues
Closes #1418 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
```bash
pytest testing/backend/unit/test_zap_scanner_plugin.py -v
```

**Result:** 5 tests passed.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
