### PR TITLE
test: authenticate settings e2e via session check

### DIFF
--- a/frontend/testing/e2e/settings-persistence.spec.ts
+++ b/frontend/testing/e2e/settings-persistence.spec.ts
@@ -1,16 +1,27 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+async function mockAuthenticatedSession(page: Page) {
+  await page.route("**/api/v1/auth/session/check", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ authenticated: true }),
+    })
+  );
+
+  await page.route("**/api/v1/notifications/rules", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ rules: [], total: 0 }),
+    })
+  );
+}
 
 test.describe("Settings persistence", () => {
 
   test("theme persists after reload", async ({ page }) => {
-    await page.goto("/");
-
-    await page.evaluate(() => {
-      localStorage.setItem(
-        "secuscan_api_key",
-        "6abeafd82cdb0eebea98dc3817b0bb5f9f8773f60402bccad9eaad7870ae8f58"
-      );
-    });
+    await mockAuthenticatedSession(page);
 
     await page.goto("/settings");
 
@@ -32,11 +43,7 @@ test.describe("Settings persistence", () => {
   });
 
   test("theme reset path is available", async ({ page }) => {
-    await page.goto("/");
-
-    await page.evaluate(() => {
-      localStorage.setItem("secuscan_api_key",  "6abeafd82cdb0eebea98dc3817b0bb5f9f8773f60402bccad9eaad7870ae8f58");
-    });
+    await mockAuthenticatedSession(page);
 
     await page.goto("/settings");
 


### PR DESCRIPTION
## Summary

- replace obsolete `secuscan_api_key` localStorage seeding in the Settings Playwright spec
- mock the current `/auth/session/check` browser auth flow for settings-focused tests
- stub notification rules during these tests so Settings can mount without backend data

## Why

The frontend no longer authenticates from a persisted localStorage API key. These tests should set up the same session-check state that the app now reads on startup.

Fixes #1550

## Validation

- `npm run e2e -- testing/e2e/settings-persistence.spec.ts`