### PR TITLE
fix: include credentials on task streams

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -572,7 +572,7 @@ export function cancelTask(taskId: string) {
 
 export function streamTask(taskId: string, onEvent: (ev: MessageEvent) => void) {
   const url = `${API_BASE}/task/${taskId}/stream`
-  const es = new EventSource(url)
+  const es = new EventSource(url, { withCredentials: true })
   es.onmessage = onEvent
   es.onerror = () => {}
   return es

--- a/frontend/src/hooks/useTaskSubscription.ts
+++ b/frontend/src/hooks/useTaskSubscription.ts
@@ -103,7 +103,7 @@ export function useTaskSubscription({
     }
 
     const url = `${API_BASE}/task/${taskId}/stream`
-    const es = new EventSource(url)
+    const es = new EventSource(url, { withCredentials: true })
     esRef.current = es
 
     es.addEventListener('status', (e: MessageEvent) => {

--- a/frontend/testing/unit/hooks/useTaskSubscription.test.ts
+++ b/frontend/testing/unit/hooks/useTaskSubscription.test.ts
@@ -16,9 +16,10 @@ class MockEventSource {
   onerror: ((err: Event) => void) | null = null
   listeners: Map<string, (e: MessageEvent) => void> = new Map()
   url: string
+  options?: EventSourceInit
   readyState = 0
   closeCount = 0
-  constructor(url: string) { this.url = url; MockEventSource.instances.push(this) }
+  constructor(url: string, options?: EventSourceInit) { this.url = url; this.options = options; MockEventSource.instances.push(this) }
   addEventListener(event: string, handler: (e: MessageEvent) => void) { this.listeners.set(event, handler) }
   close() { this.closeCount++; const idx = MockEventSource.instances.indexOf(this); if (idx !== -1) MockEventSource.instances.splice(idx, 1) }
   dispatchEvent(event: string, data: string) { const h = this.listeners.get(event); if (h) h(new MessageEvent(event, { data })) }
@@ -57,6 +58,12 @@ describe('useTaskSubscription', () => {
     const es = getES()
     expect(es).toBeTruthy()
     expect(es!.url).toContain('/task/task-1/stream')
+  })
+
+  it('includes credentials on the SSE connection', async () => {
+    renderHook({ taskId: 'task-1' })
+    await flush()
+    expect(getES()!.options).toEqual({ withCredentials: true })
   })
 
   it('calls onStatus on status event', async () => {


### PR DESCRIPTION
## Summary

- pass `withCredentials: true` when creating task EventSource streams
- apply the same behavior in both the API helper and task subscription hook
- extend the hook unit test mock to assert credentialed SSE construction

## Why

The browser auth flow now uses a signed HttpOnly session cookie. Cross-origin task streams need to include credentials so the protected `/task/{task_id}/stream` route can authenticate consistently with normal API requests.

Fixes #1551

## Validation

- `npm test -- testing/unit/hooks/useTaskSubscription.test.ts`
- `npm run typecheck`