### PR TITLE
fix: log out during settings purge

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -313,10 +313,12 @@ export default function Settings() {
             title: "NUCLEAR PURGE",
             message: "CRITICAL: THIS WILL PURGE ALL HISTORY AND ASSETS. PROCEED?",
             type: "danger",
-            onConfirm: () => {
+            onConfirm: async () => {
                 Object.keys(localStorage)
                     .filter(key => key.startsWith('secuscan') || key === 'sidebar-expanded')
                     .forEach(key => localStorage.removeItem(key))
+                clearStoredApiKey()
+                await logoutSession()
                 window.location.reload()
                 setModalState(prev => ({ ...prev, isOpen: false }))
             }

--- a/frontend/testing/unit/pages/SettingsSaveReset.test.tsx
+++ b/frontend/testing/unit/pages/SettingsSaveReset.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Settings from '../../../src/pages/Settings'
 import { ThemeProvider } from '../../../src/components/ThemeContext'
@@ -43,6 +43,7 @@ describe('Settings save/reset behavior', () => {
   beforeEach(() => {
     window.localStorage.removeItem('secuscan-config')
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
   it('saves the current config to localStorage (secuscan-config)', async () => {
     const user = userEvent.setup()
@@ -72,8 +73,12 @@ describe('Settings save/reset behavior', () => {
     expect(concurrentOps.value).toBe('8')
   })
   it('nuclear purge removes only secuscan-owned keys and preserves unrelated keys', async () => {
-  // Set up SecuScan keys
-  // Set up SecuScan keys
+  const fetchSpy = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ status: 'logged_out' }),
+  })
+  vi.stubGlobal('fetch', fetchSpy)
+
   window.localStorage.setItem('secuscan-config', JSON.stringify(DEFAULT_CONFIG))
   window.localStorage.setItem('secuscan_api_key', 'test-api-key')
   window.localStorage.setItem('secuscan-saved-views', JSON.stringify([]))
@@ -105,5 +110,15 @@ describe('Settings save/reset behavior', () => {
 
   // Unrelated key should still be there
   expect(window.localStorage.getItem('some-other-app-key')).toBe('should-not-be-deleted')
+
+  await waitFor(() => {
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/auth/session/logout'),
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+      }),
+    )
+  })
 })
 })


### PR DESCRIPTION
## Summary

- clear the in-memory API key during the Settings purge flow
- call `/auth/session/logout` before reloading so the HttpOnly session cookie is cleared
- extend the existing purge unit test to assert the logout request

## Why

The purge action removes local browser state, but the current auth flow also uses an HttpOnly session cookie. Without logging out, a reload can still pass `/auth/session/check` and leave the app authenticated.

Fixes #1552

## Validation

- `npm test -- testing/unit/pages/SettingsSaveReset.test.tsx`
- `npm run typecheck`

Note: the focused jsdom test emits the existing `Not implemented: navigation to another Document` warning when `window.location.reload()` is exercised, but the suite passes.