### PR TITLE
test : added null-byte and edge case tests for JSONFormatter

### DIFF
--- a/testing/backend/unit/test_logging_utils.py
+++ b/testing/backend/unit/test_logging_utils.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 
 from backend.secuscan.logging_utils import RequestIDFilter, JSONFormatter
 
@@ -160,3 +161,89 @@ def test_json_formatter_no_exception_key_when_no_exc_info():
 
     assert "exception" not in result
     assert result["message"] == "normal log"
+
+
+def test_json_formatter_handles_null_bytes_in_message():
+    """A message containing null bytes should not cause JSON serialization to fail."""
+    import json
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="token=abc123" + chr(0) + "extra",
+        args=(),
+        exc_info=None,
+    )
+    formatter = JSONFormatter()
+    result_str = formatter.format(record)
+    # Should not raise and should produce valid JSON
+    result = json.loads(result_str)
+    assert isinstance(result, dict)
+    assert "timestamp" in result
+    assert "level" in result
+
+
+def test_json_formatter_handles_non_string_message():
+    """A record whose getMessage() would return a non-string value should not crash."""
+    import json
+    # Create a record with a dict msg and args that when interpolated produce a non-string
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="%(key)s",
+        args=({"key": "value"},),
+        exc_info=None,
+    )
+    formatter = JSONFormatter()
+    # Should not raise
+    result_str = formatter.format(record)
+    result = json.loads(result_str)
+    assert isinstance(result, dict)
+
+
+def test_json_formatter_combines_exc_info_and_custom_request_id():
+    """Both exception info and a custom request_id should appear in the output."""
+    import json
+    try:
+        raise ValueError("test error")
+    except ValueError:
+        exc_info = sys.exc_info()
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="error with context",
+        args=(),
+        exc_info=exc_info,
+    )
+    # Manually set request_id on the record to simulate RequestIDFilter behavior
+    record.request_id = "req-123-custom-id"
+    formatter = JSONFormatter()
+    result = json.loads(formatter.format(record))
+    assert "exception" in result
+    assert "ValueError" in result["exception"]
+    assert result["request_id"] == "req-123-custom-id"
+
+
+def test_json_formatter_handles_very_long_message():
+    """A 1MB+ message string should be handled without crashing."""
+    import json
+    long_msg = "A" * (1024 * 1024)  # 1MB
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=long_msg,
+        args=(),
+        exc_info=None,
+    )
+    formatter = JSONFormatter()
+    result_str = formatter.format(record)
+    result = json.loads(result_str)
+    assert result["message"] == long_msg
+    assert len(result["message"]) == 1024 * 1024


### PR DESCRIPTION
Closes #1577.

Summary of What Has Been Done:
Added 4 new test functions to testing/backend/unit/test_logging_utils.py:
1. test_json_formatter_handles_null_bytes_in_message: Verifies JSONFormatter does not crash when the log message contains null bytes (\\x00)
2. test_json_formatter_handles_non_string_message: Verifies the formatter handles a LogRecord where getMessage() returns a non-standard value
3. test_json_formatter_combines_exc_info_and_custom_request_id: Verifies both exception info and custom request_id appear together in the JSON output
4. test_json_formatter_handles_very_long_message: Verifies a 1MB+ message string is handled correctly without crashing

Changes Made:
- Added import sys at the top of test_logging_utils.py
- Added 4 test functions using logging.LogRecord directly to control message content
- All tests use the real JSONFormatter from backend.secuscan.logging_utils

Impact it Made:
- Prevents logging pipeline crashes from malformed log messages
- Ensures the formatter never leaks unhandled exceptions into production logs
- Improves robustness of the structured logging system

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.