### PR TITLE
Type Framer Motion spring transitions without as-any casts (#1409)

### DIFF
--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion, AnimatePresence, type Variants } from "framer-motion";
 import { API_BASE, deleteTask, clearAllTasks, bulkDeleteTasks, startTask, ExecutionContext } from "../api";
 import { routePath } from "../routes";
 import {
@@ -38,23 +38,23 @@ const statusFilters = [
   { value: "cancelled", label: "MANUAL_ABORT" },
 ];
 
-const containerVariants = {
+const containerVariants: Variants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
     transition: { staggerChildren: 0.1 },
   },
-} as const;
+};
 
-const itemVariants = {
+const itemVariants: Variants = {
   hidden: { opacity: 0, scale: 0.95, y: 20 },
   visible: {
     opacity: 1,
     scale: 1,
     y: 0,
-    transition: { type: "spring", stiffness: 200, damping: 20 } as any,
+    transition: { type: "spring", stiffness: 200, damping: 20 },
   },
-} as const;
+};
 
 export default function Scans() {
   const navigate = useNavigate();

--- a/frontend/src/pages/Toolkit.tsx
+++ b/frontend/src/pages/Toolkit.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence, type Variants } from 'framer-motion'
 import { listPlugins, PluginListItem } from '../api'
 import { scanTools } from '../data/scanTools'
 import { routePath } from '../routes'
@@ -40,7 +40,7 @@ const LEGACY_TAB_LABELS: Record<string, string> = {
   robots: 'Robots',
 }
 
-const containerVariants = {
+const containerVariants: Variants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
@@ -48,13 +48,13 @@ const containerVariants = {
   },
 }
 
-const itemVariants = {
+const itemVariants: Variants = {
   hidden: { opacity: 0, scale: 0.95, y: 20 },
   visible: {
     opacity: 1,
     scale: 1,
     y: 0,
-    transition: { type: 'spring', stiffness: 200, damping: 20 } as any,
+    transition: { type: 'spring', stiffness: 200, damping: 20 },
   },
 }
 
@@ -96,7 +96,7 @@ function getToolAccessibilityLabel(tool: CatalogTool): string {
 
 function mapPluginCategoryToLegacyTab(category: string, pluginId?: string): UITab {
   const pinnedTool = scanTools.find(t => t.id === pluginId);
-  
+
   if (pinnedTool) {
     return pinnedTool.category as UITab;
   }
@@ -124,7 +124,7 @@ function mapPluginCategoryToLegacyTab(category: string, pluginId?: string): UITa
 function mapPluginToCatalogTool(plugin: PluginListItem): CatalogTool {
   const normalizedCategory = normalizeCategoryId(plugin.category)
   const pinnedTool = scanTools.find(t => t.id === plugin.id);
-  
+
   return {
     id: plugin.id,
     name: pinnedTool ? pinnedTool.name : plugin.name,


### PR DESCRIPTION
Closes  #1409 

## Changes
- `Scans.tsx` and `Toolkit.tsx`: imported `type Variants` from `framer-motion`,  annotated `itemVariants` as `Variants`, removed the `as any` cast on the transition object and the redundant `as const`.

## Checklist
- Both `as any` casts removed
- Correct Framer Motion typing used
- Transition values unchanged — animation behavior unaffected