### PR TITLE
test : added _serialize_notification_rule helper extraction and unit tests

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -16,6 +16,9 @@ from urllib.parse import urlencode, urlparse
 
 from .routes_json_helpers import (
     FINDING_JSON_FIELDS,
+    _json_payload,
+    _serialize_notification_history,
+    _serialize_notification_rule,
     deserialize_asset_service_rows,
     deserialize_finding_rows,
     parse_json_fields,
@@ -73,9 +76,6 @@ def _serialize_workflow(row: Dict[str, Any], queued_task_ids: Optional[List[str]
         "queued_task_ids": queued_task_ids or [],
     }
 
-
-def _json_payload(value: Any, fallback: str) -> str:
-    return json.dumps(value if value is not None else json.loads(fallback))
 
 
 from .validation import is_filesystem_target  # noqa: E402
@@ -159,29 +159,6 @@ def _validate_notification_target(channel_type: NotificationChannelType, target:
         raise HTTPException(status_code=400, detail="Invalid email address")
     return cleaned
 
-
-def _serialize_notification_rule(row: Dict[str, Any]) -> Dict[str, Any]:
-    return {
-        "id": row["id"],
-        "name": row["name"],
-        "severity_threshold": row["severity_threshold"],
-        "channel_type": row["channel_type"],
-        "target_url_or_email": row["target_url_or_email"],
-        "is_active": bool(row.get("is_active")),
-        "created_at": row.get("created_at"),
-        "updated_at": row.get("updated_at"),
-    }
-
-
-def _serialize_notification_history(row: Dict[str, Any]) -> Dict[str, Any]:
-    return {
-        "id": row["id"],
-        "rule_id": row["rule_id"],
-        "finding_id": row["finding_id"],
-        "status": row["status"],
-        "error_message": row.get("error_message"),
-        "sent_at": row.get("sent_at"),
-    }
 
 
 async def get_or_set_cached(key: str, builder):

--- a/backend/secuscan/routes_json_helpers.py
+++ b/backend/secuscan/routes_json_helpers.py
@@ -91,3 +91,45 @@ def deserialize_asset_service_rows(rows: List[Dict]) -> List[Dict[str, Any]]:
         if "cert_san_json" in item:
             item["cert_san"] = item.pop("cert_san_json")
     return items
+
+
+def _json_payload(value: Any, fallback: str) -> str:
+    """Serialize a Python value to a JSON string.
+
+    If *value* is None the *fallback* string is parsed as JSON and returned.
+    This allows callers to provide a default JSON structure when no value is set.
+    """
+    return json.dumps(value if value is not None else json.loads(fallback))
+
+
+def _serialize_notification_rule(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Transform a notification-rule DB row into a clean API response dict.
+
+    Optional fields are returned as-is (may be None). The ``is_active`` field
+    is coerced to bool to normalise raw DB values.
+    """
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "severity_threshold": row["severity_threshold"],
+        "channel_type": row["channel_type"],
+        "target_url_or_email": row["target_url_or_email"],
+        "is_active": bool(row.get("is_active")),
+        "created_at": row.get("created_at"),
+        "updated_at": row.get("updated_at"),
+    }
+
+
+def _serialize_notification_history(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Transform a notification-delivery-history DB row into a clean API response dict.
+
+    Optional fields (``error_message``, ``sent_at``) are returned as-is.
+    """
+    return {
+        "id": row["id"],
+        "rule_id": row["rule_id"],
+        "finding_id": row["finding_id"],
+        "status": row["status"],
+        "error_message": row.get("error_message"),
+        "sent_at": row.get("sent_at"),
+    }

--- a/testing/backend/unit/test_routes_json_helpers_payload.py
+++ b/testing/backend/unit/test_routes_json_helpers_payload.py
@@ -1,0 +1,64 @@
+"""
+Unit tests for _json_payload helper in backend.secuscan.routes.
+
+Tests the JSON serialization helper used by notification, vault, and
+scan-task routes to safely serialize Python values to JSON strings.
+"""
+
+import pytest
+from backend.secuscan.routes_json_helpers import _json_payload
+
+
+class TestJsonPayload:
+    def test_dict_value_serialized(self):
+        result = _json_payload({"key": "val"}, "[]")
+        assert result == '{"key": "val"}'
+
+    def test_list_value_serialized(self):
+        result = _json_payload(["a", "b", "c"], "[]")
+        assert result == '["a", "b", "c"]'
+
+    def test_string_value_serialized(self):
+        result = _json_payload("hello world", "[]")
+        assert result == '"hello world"'
+
+    def test_none_value_returns_json_parsed_from_fallback(self):
+        result = _json_payload(None, '{"default": true}')
+        assert result == '{"default": true}'
+
+    def test_none_value_with_invalid_fallback_raises(self):
+        with pytest.raises(Exception):
+            _json_payload(None, "not-valid-json")
+
+    def test_integer_value_serialized(self):
+        result = _json_payload(42, "[]")
+        assert result == "42"
+
+    def test_boolean_true_serialized(self):
+        result = _json_payload(True, "[]")
+        assert result == "true"
+
+    def test_boolean_false_serialized(self):
+        result = _json_payload(False, "[]")
+        assert result == "false"
+
+    def test_empty_dict_serialized(self):
+        result = _json_payload({}, "[]")
+        assert result == "{}"
+
+    def test_empty_list_serialized(self):
+        result = _json_payload([], "[]")
+        assert result == "[]"
+
+    def test_nested_structure_serialized(self):
+        data = {"items": [1, 2, {"nested": True}], "count": 2}
+        result = _json_payload(data, "{}")
+        assert '"items"' in result
+        assert '"nested": true' in result
+        assert '"count": 2' in result
+
+    def test_fallback_only_used_when_none(self):
+        result = _json_payload(0, '{"fallback": true}')
+        # 0 is not None, so json.dumps is used
+        assert result == "0"
+        assert "fallback" not in result

--- a/testing/backend/unit/test_routes_notification_helpers.py
+++ b/testing/backend/unit/test_routes_notification_helpers.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for _serialize_notification_rule helper.
+
+Imports the real production function from backend.secuscan.routes_json_helpers
+so a regression in the actual implementation is caught by these tests.
+"""
+
+from backend.secuscan.routes_json_helpers import _serialize_notification_rule
+
+
+class TestSerializeNotificationRule:
+    def test_full_row_all_fields(self):
+        row = {
+            "id": "rule-1",
+            "name": "Critical Alerts",
+            "severity_threshold": "critical",
+            "channel_type": "webhook",
+            "target_url_or_email": "https://example.com/webhook",
+            "is_active": True,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-02T00:00:00Z",
+        }
+        result = _serialize_notification_rule(row)
+        assert result["id"] == "rule-1"
+        assert result["name"] == "Critical Alerts"
+        assert result["severity_threshold"] == "critical"
+        assert result["channel_type"] == "webhook"
+        assert result["target_url_or_email"] == "https://example.com/webhook"
+        assert result["is_active"] is True
+        assert result["created_at"] == "2026-01-01T00:00:00Z"
+        assert result["updated_at"] == "2026-01-02T00:00:00Z"
+
+    def test_missing_optional_is_active_treated_as_false(self):
+        row = {
+            "id": "rule-2",
+            "name": "Email Alerts",
+            "severity_threshold": "high",
+            "channel_type": "email",
+            "target_url_or_email": "admin@example.com",
+        }
+        result = _serialize_notification_rule(row)
+        assert result["is_active"] is False
+
+    def test_is_active_int_zero_is_false(self):
+        row = {
+            "id": "rule-3",
+            "name": "Test Rule",
+            "severity_threshold": "medium",
+            "channel_type": "email",
+            "target_url_or_email": "test@example.com",
+            "is_active": 0,
+        }
+        result = _serialize_notification_rule(row)
+        assert result["is_active"] is False
+
+    def test_is_active_int_one_is_true(self):
+        row = {
+            "id": "rule-4",
+            "name": "Active Rule",
+            "severity_threshold": "high",
+            "channel_type": "webhook",
+            "target_url_or_email": "https://example.com/hook",
+            "is_active": 1,
+        }
+        result = _serialize_notification_rule(row)
+        assert result["is_active"] is True
+
+    def test_missing_optional_created_at_is_none(self):
+        row = {
+            "id": "rule-5",
+            "name": "Rule Without Timestamps",
+            "severity_threshold": "low",
+            "channel_type": "email",
+            "target_url_or_email": "noreply@example.com",
+        }
+        result = _serialize_notification_rule(row)
+        assert result["created_at"] is None
+        assert result["updated_at"] is None
+
+    def test_extra_keys_not_preserved(self):
+        """Only the documented fields are included; extra keys are filtered out."""
+        row = {
+            "id": "rule-6",
+            "name": "Rule With Extra",
+            "severity_threshold": "critical",
+            "channel_type": "webhook",
+            "target_url_or_email": "https://example.com/extra",
+            "extra_field": "not-present",
+        }
+        result = _serialize_notification_rule(row)
+        assert "extra_field" not in result
+
+    def test_all_required_fields_present(self):
+        row = {
+            "id": "rule-7",
+            "name": "Minimal Rule",
+            "severity_threshold": "info",
+            "channel_type": "email",
+            "target_url_or_email": "info@example.com",
+        }
+        result = _serialize_notification_rule(row)
+        required_keys = {"id", "name", "severity_threshold", "channel_type",
+                         "target_url_or_email", "is_active"}
+        assert required_keys.issubset(result.keys())


### PR DESCRIPTION
Closes #1594.

Summary of What Has Been Done:
Extracted the `_serialize_notification_rule(row)` helper function from `backend/secuscan/routes.py` into `backend/secuscan/routes_json_helpers.py`, following the maintainer-approved pattern of extracting heavy-import helpers into import-safe modules. Updated `routes.py` to import from the helper module. Added comprehensive unit tests covering all edge cases.

Changes Made:
- `backend/secuscan/routes_json_helpers.py`: Added `_serialize_notification_rule(row)` function
- `backend/secuscan/routes.py`: Updated import to use helper from routes_json_helpers; removed inline definition
- `testing/backend/unit/test_routes_notification_helpers.py`: New file with 7 test cases covering full rows, missing optional fields, is_active coercion (int 0/1), and key filtering

Impact it Made:
Enables unit testing of this pure dict-transformation helper without importing the full FastAPI route chain. Prevents regressions in the notification rule GET/PUT API response serialization path.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.