### PR TITLE
test: add _recency_detail edge case unit tests

### DIFF
--- a/testing/backend/unit/test_risk_scoring_recency_detail.py
+++ b/testing/backend/unit/test_risk_scoring_recency_detail.py
@@ -1,0 +1,70 @@
+"""
+Unit tests for backend/secuscan/risk_scoring.py's _recency_detail helper.
+
+Tests the human-readable recency explanation generator. This is a pure
+function, so these tests run with --noconftest (no FastAPI dependencies
+needed) since risk_scoring.py only depends on stdlib.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.secuscan.risk_scoring import _recency_detail
+
+
+class TestRecencyDetail:
+    def test_none_discovered_at_returns_moderate_recency_message(self):
+        """When discovered_at is None, a moderate-recency fallback message is returned."""
+        result = _recency_detail(None, 5.0)
+        assert result == "No discovery date — assumed moderate recency"
+
+    def test_future_date_returns_very_recent_message(self):
+        """A discovered_at timestamp in the future is treated as very recent."""
+        future = datetime.now(timezone.utc) + timedelta(days=3)
+        result = _recency_detail(future, 10.0)
+        assert result == "Discovered in the future — treated as very recent"
+
+    def test_today_returns_maximum_recency_message(self):
+        """A discovered_at timestamp from today (0 days ago) returns the max-score message."""
+        now = datetime.now(timezone.utc)
+        result = _recency_detail(now, 10.0)
+        assert result == "Discovered today — maximum recency score"
+
+    def test_yesterday_returns_singular_day_message(self):
+        """Exactly 1 day ago uses singular 'day' wording with the recency score."""
+        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+        result = _recency_detail(yesterday, 7.5)
+        assert result == "Discovered 1 day ago — recency score 7.5/10"
+
+    def test_multiple_days_ago_returns_plural_days_message(self):
+        """More than 1 day ago uses plural 'days' wording with the recency score."""
+        ten_days_ago = datetime.now(timezone.utc) - timedelta(days=10)
+        result = _recency_detail(ten_days_ago, 5.0)
+        assert result == "Discovered 10 days ago — recency score 5.0/10"
+
+    def test_many_days_ago_returns_plural_days_message(self):
+        """A much older date (well past a year) still uses the plural days format."""
+        long_ago = datetime.now(timezone.utc) - timedelta(days=400)
+        result = _recency_detail(long_ago, 1.0)
+        assert result == "Discovered 400 days ago — recency score 1.0/10"
+
+    def test_naive_datetime_is_treated_as_utc(self):
+        """A naive (non-tz-aware) datetime is assumed UTC and handled without error."""
+        naive_yesterday = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1)
+        result = _recency_detail(naive_yesterday, 7.5)
+        assert result == "Discovered 1 day ago — recency score 7.5/10"
+
+    def test_non_utc_timezone_is_normalized_correctly(self):
+        """A tz-aware datetime in a non-UTC timezone is normalized before day-diffing."""
+        ist = timezone(timedelta(hours=5, minutes=30))
+        # 1 day ago in IST should still resolve to ~1 day ago once normalized to UTC.
+        one_day_ago_ist = datetime.now(ist) - timedelta(days=1)
+        result = _recency_detail(one_day_ago_ist, 7.5)
+        assert result == "Discovered 1 day ago — recency score 7.5/10"
+
+    def test_recency_score_is_formatted_to_one_decimal_place(self):
+        """The rv value passed in is always rendered with exactly one decimal place."""
+        two_days_ago = datetime.now(timezone.utc) - timedelta(days=2)
+        result = _recency_detail(two_days_ago, 5)
+        assert result == "Discovered 2 days ago — recency score 5.0/10"


### PR DESCRIPTION
## Description
Adds unit tests for the `_recency_detail` helper in `backend/secuscan/risk_scoring.py`, which generates human-readable recency explanations from a discovery datetime and recency score. This function previously had no dedicated test coverage.

New file: `testing/backend/unit/test_risk_scoring_recency_detail.py`

Covers the edge cases listed in the issue:
- `discovered_at` is `None`
- Future date (days < 0)
- Today (days == 0)
- Yesterday (days == 1, singular wording)
- Multiple days ago (days > 1, plural wording)
- A much older date (400+ days, still plural wording)
- Naive (non-tz-aware) datetime, assumed UTC
- Non-UTC timezone normalization (tested with IST, UTC+5:30)
- Recency score formatting (always one decimal place)

## Related Issues
Closes #1525

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Ran the new test file directly with pytest:
python -m pytest testing/backend/unit/test_risk_scoring_recency_detail.py --noconftest -v
All 9 tests pass. `--noconftest` is used since `risk_scoring.py` only depends on stdlib, no FastAPI dependencies needed (matches the pattern requested in the issue).

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.