### PR TITLE
test : added unit tests for ScanPhase and PluginImplementationStatus enums

### DIFF
--- a/testing/backend/unit/test_models.py
+++ b/testing/backend/unit/test_models.py
@@ -38,6 +38,11 @@ from backend.secuscan.models import (
     HealthResponse,
     SafetyLevel,
     PluginListResponse,
+    NotificationRuleResponse,
+    NotificationDeliveryStatus,
+    NotificationHistoryResponse,
+    ScanPhase,
+    PluginImplementationStatus,
 )
 
 
@@ -431,7 +436,7 @@ def test_safety_level_invalid_raises():
         SafetyLevel("unknown")
 
 # ---------------------------------------------------------------------------
-# PluginListResponse model
+
 # ---------------------------------------------------------------------------
 
 
@@ -482,3 +487,49 @@ class TestPluginListResponse:
         """total accepts any non-negative integer."""
         resp = PluginListResponse(plugins=[], total=999)
         assert resp.total == 999
+
+
+# ---------------------------------------------------------------------------
+# ScanPhase enum
+# ---------------------------------------------------------------------------
+
+
+def test_scan_phase_all_values():
+    """All five ScanPhase values are accepted."""
+    for name in ["queued", "running_command", "parsing", "reporting", "finished"]:
+        phase = ScanPhase(name)
+        assert phase.value == name
+
+
+def test_scan_phase_invalid_raises():
+    """An invalid ScanPhase value raises ValueError."""
+    with pytest.raises(ValueError):
+        ScanPhase("unknown_phase")
+
+
+def test_scan_phase_from_value():
+    """ScanPhase can be constructed from a known value."""
+    assert ScanPhase("parsing") == ScanPhase.PARSING
+
+
+# ---------------------------------------------------------------------------
+# PluginImplementationStatus enum
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_implementation_status_all_values():
+    """All three PluginImplementationStatus values are accepted."""
+    for name in ["native", "integrated", "placeholder"]:
+        status = PluginImplementationStatus(name)
+        assert status.value == name
+
+
+def test_plugin_implementation_status_invalid_raises():
+    """An invalid PluginImplementationStatus value raises ValueError."""
+    with pytest.raises(ValueError):
+        PluginImplementationStatus("experimental")
+
+
+def test_plugin_implementation_status_from_value():
+    """PluginImplementationStatus can be constructed from a known value."""
+    assert PluginImplementationStatus("native") == PluginImplementationStatus.NATIVE


### PR DESCRIPTION
Closes #1606.

Summary of What Has Been Done:
Added unit tests for the ScanPhase and PluginImplementationStatus Pydantic enums in backend/secuscan/models.py. Extended testing/backend/unit/test_models.py with 6 focused tests.

Changes Made:
- Added ScanPhase and PluginImplementationStatus to test_models.py imports
- test_scan_phase_all_values: verifies all 5 values (queued, running_command, parsing, reporting, finished)
- test_scan_phase_invalid_raises: verifies invalid value raises ValueError
- test_scan_phase_from_value: verifies value-based construction
- test_plugin_implementation_status_all_values: verifies all 3 values (native, integrated, placeholder)
- test_plugin_implementation_status_invalid_raises: verifies invalid value raises ValueError
- test_plugin_implementation_status_from_value: verifies value-based construction

Impact it Made:
Maintainability: ensures enum validation rejects invalid values at model boundaries.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.