### PR TITLE
test: add CORS security tests for wildcard origin and credentials

### DIFF
--- a/testing/backend/integration/test_cors.py
+++ b/testing/backend/integration/test_cors.py
@@ -27,3 +27,43 @@ def test_cors_preflight_allows_preview_origin(test_client):
 
     assert response.status_code == 200
     assert response.headers.get("access-control-allow-origin") == origin
+
+
+def test_cors_security_no_wildcard_with_credentials(test_client):
+    """Access-Control-Allow-Origin must never be * when credentials are enabled."""
+    routes = ["/api/v1/health", "/api/v1/tasks", "/api/v1/findings"]
+    for route in routes:
+        response = test_client.options(
+            route,
+            headers={
+                "Origin": "http://localhost:5173",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        origin_header = response.headers.get("access-control-allow-origin", "")
+        assert origin_header != "*", f"Route {route} returned wildcard with credentials enabled"
+
+
+def test_cors_rejects_non_whitelisted_origin(test_client):
+    """Non-whitelisted origins must not have their origin echoed as CORS header."""
+    origin = "https://untrusted-origin.com"
+    response = test_client.options(
+        "/api/v1/health",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    cors_origin = response.headers.get("access-control-allow-origin")
+    assert cors_origin != origin
+
+
+def test_cors_actual_request_has_credentials(test_client):
+    """Actual (non-preflight) requests should also carry CORS headers."""
+    origin = "http://localhost:5173"
+    response = test_client.get(
+        "/api/v1/health",
+        headers={"Origin": origin},
+    )
+    assert response.headers.get("access-control-allow-origin") == origin
+    assert response.headers.get("access-control-allow-credentials") == "true"


### PR DESCRIPTION
## Summary
Adds security tests verifying the CORS fix for wildcard origins with credentials (points 1–3 of the issue are already satisfied in the current codebase).

## Changes
- **Add CORS security tests** (`testing/backend/integration/test_cors.py`):
  - `test_cors_security_no_wildcard_with_credentials` — verifies `Access-Control-Allow-Origin` is never `*` when credentials are enabled, checked across multiple routes
  - `test_cors_rejects_non_whitelisted_origin` — ensures untrusted origins are not echoed back
  - `test_cors_actual_request_has_credentials` — confirms actual (non-preflight) requests carry proper CORS headers for whitelisted origins

## Checklist
- [x] 1. Replace `allow_origins=["*"]` with a specific allowlist — **already done in main.py**
- [x] 2. Keep `allow_credentials=True` only when origins are explicit — **already done in main.py**
- [x] 3. Remove `options_handler` — **already removed**
- [x] 4. Add security tests — **added in this PR**

Closes #1586