### PR TITLE
fix: replace fail-open with in-memory fallback in rate limiter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check formatting hygiene on changed files
-        run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1
-          git diff --check "origin/${{ github.base_ref }}"...HEAD
+        run: git diff --check "${{ github.event.pull_request.base.sha }}"...HEAD
 
   issue-template-label-validation:
     runs-on: ubuntu-latest

--- a/backend/secuscan/rate_limiter.py
+++ b/backend/secuscan/rate_limiter.py
@@ -7,17 +7,23 @@ Algorithm: Sliding window counter using Redis INCR + EXPIRE.
 - Per-IP counters stored as Redis keys with TTL.
 - Two-tier limits: per-minute (burst protection) and per-hour (sustained limit).
 - Returns HTTP 429 with Retry-After header when limits are exceeded.
-- When Redis is unavailable, fails OPEN (allows request) and logs a warning,
-  so a Redis outage does not take down the scan service entirely.
+- When Redis is unavailable, falls back to in-memory rate limiting and logs
+  an ERROR, so a Redis outage does not take down the scan service entirely.
 
 Key schema:
   rate_limit:scan:{ip}:minute:{window_start_minute}  → request count
   rate_limit:scan:{ip}:hour:{window_start_hour}      → request count
+
+Fallback:
+  In-memory dictionary is used when Redis is unreachable to maintain
+  rate limiting coverage. A circuit breaker periodically attempts to
+  reconnect to Redis.
 """
 
 import logging
 import time
-from typing import Optional
+from collections import defaultdict
+from typing import Dict, List, Optional
 
 import redis.asyncio as aioredis
 from fastapi import HTTPException, Request, status
@@ -52,6 +58,8 @@ class ScanRateLimiter:
         self._rate_window = rate_window  # e.g. per 60 seconds
         self._burst_limit = burst_limit  # e.g. 10 requests
         self._burst_window = burst_window  # e.g. per 3600 seconds
+        self._redis_failed = False
+        self._fallback_history: Dict[str, List[float]] = defaultdict(list)
 
     def _get_client_ip(self, request: Request) -> str:
         """
@@ -69,11 +77,67 @@ class ScanRateLimiter:
         """Build a namespaced Redis key for this IP and time window."""
         return f"rate_limit:scan:{ip}:{window_type}:{window_value}"
 
+    async def _check_fallback(self, request: Request) -> None:
+        """In-memory fallback rate limit check used when Redis is down."""
+        ip = self._get_client_ip(request)
+        now = time.time()
+
+        minute_window = int(now // self._rate_window)
+        hour_window = int(now // self._burst_window)
+
+        bucket_min = f"{ip}:minute:{minute_window}"
+        bucket_hr = f"{ip}:hour:{hour_window}"
+
+        # Clean stale entries
+        cutoff = now - max(self._rate_window, self._burst_window)
+        for key in list(self._fallback_history.keys()):
+            self._fallback_history[key] = [
+                ts for ts in self._fallback_history[key] if ts > cutoff
+            ]
+
+        # Check per-minute limit
+        minute_count = len(self._fallback_history[bucket_min]) + 1
+        if minute_count > self._rate_limit:
+            retry_after = self._rate_window - (int(now) % self._rate_window)
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail={
+                    "error": "rate_limit_exceeded",
+                    "message": (
+                        f"Scan rate limit exceeded: maximum {self._rate_limit} "
+                        f"requests per {self._rate_window} seconds."
+                    ),
+                    "retry_after": retry_after,
+                },
+                headers={"Retry-After": str(retry_after)},
+            )
+
+        # Check per-hour limit
+        hour_count = len(self._fallback_history[bucket_hr]) + 1
+        if hour_count > self._burst_limit:
+            retry_after = self._burst_window - (int(now) % self._burst_window)
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail={
+                    "error": "burst_limit_exceeded",
+                    "message": (
+                        f"Hourly scan limit exceeded: maximum {self._burst_limit} "
+                        f"requests per hour."
+                    ),
+                    "retry_after": retry_after,
+                },
+                headers={"Retry-After": str(retry_after)},
+            )
+
+        # Record the request
+        self._fallback_history[bucket_min].append(now)
+        self._fallback_history[bucket_hr].append(now)
+
     async def check(self, request: Request) -> None:
         """
         Check rate limits for the incoming request.
         Raises HTTP 429 if either the per-minute or per-hour limit is exceeded.
-        Does nothing (allows request) if Redis is unavailable.
+        Falls back to in-memory rate limiting if Redis is unavailable.
 
         Args:
             request: The incoming FastAPI request object.
@@ -85,16 +149,28 @@ class ScanRateLimiter:
         if self._rate_limit == 0:
             return
 
-        # If Redis is not configured, fail open with a warning
+        # If Redis is not configured, use in-memory fallback
         if self._redis is None:
             logger.warning(
-                "ScanRateLimiter: Redis client is None — rate limiting is DISABLED. "
-                "Configure REDIS_URL to enable rate limiting."
+                "ScanRateLimiter: Redis client is None — using in-memory fallback. "
+                "Configure REDIS_URL to enable Redis-backed rate limiting."
             )
-            return
+            return await self._check_fallback(request)
 
         ip = self._get_client_ip(request)
         now = int(time.time())
+
+        # If Redis previously failed, try to reconnect (circuit breaker)
+        if self._redis_failed:
+            try:
+                await self._redis.ping()
+                self._redis_failed = False
+                logger.info("ScanRateLimiter: Redis connection restored.")
+            except Exception:
+                logger.error(
+                    "ScanRateLimiter: Redis still unreachable, using in-memory fallback."
+                )
+                return await self._check_fallback(request)
 
         try:
             # ── Tier 1: Per-minute limit (burst protection) ──────────────────
@@ -163,10 +239,13 @@ class ScanRateLimiter:
             # Re-raise 429s — don't swallow them in the Redis error handler
             raise
         except Exception as exc:
-            # Redis connection error, timeout, etc. — fail open, log, continue
+            # Redis connection error, timeout, etc. — fail over, log, continue
+            self._redis_failed = True
             logger.error(
-                "ScanRateLimiter: Redis error, failing open: %s", exc, exc_info=True
+                "ScanRateLimiter: Redis error (%s), switching to in-memory fallback.",
+                exc,
             )
+            return await self._check_fallback(request)
 
 
 def make_scan_rate_limiter(

--- a/backend/secuscan/rate_limiter.py
+++ b/backend/secuscan/rate_limiter.py
@@ -61,6 +61,12 @@ class ScanRateLimiter:
         self._redis_failed = False
         self._fallback_history: Dict[str, List[float]] = defaultdict(list)
 
+    async def reset(self) -> None:
+        """Clear in-memory fallback state and reset circuit breaker."""
+
+        self._fallback_history.clear()
+        self._redis_failed = False
+
     def _get_client_ip(self, request: Request) -> str:
         """
         Extract the real client IP.

--- a/backend/secuscan/rate_limiter.py
+++ b/backend/secuscan/rate_limiter.py
@@ -100,6 +100,8 @@ class ScanRateLimiter:
             self._fallback_history[key] = [
                 ts for ts in self._fallback_history[key] if ts > cutoff
             ]
+            if not self._fallback_history[key]:
+                del self._fallback_history[key]
 
         # Check per-minute limit
         minute_count = len(self._fallback_history[bucket_min]) + 1

--- a/testing/backend/conftest.py
+++ b/testing/backend/conftest.py
@@ -40,6 +40,8 @@ def setup_test_environment(monkeypatch):
     # _execute_command but the policy check runs before that mock fires.
     # Tests that specifically test policy behaviour override this themselves.
     monkeypatch.setattr(settings, "enforce_network_policy", False)
+    # Disable scan rate limiter in tests to avoid 429 interference
+    monkeypatch.setattr(settings, "scan_rate_limit", 0)
 
     settings.ensure_directories()
 
@@ -68,6 +70,10 @@ def test_client(setup_test_environment):
             await reset_all_endpoint_limiters()
         except ImportError:
             pass
+        scan_limiter = getattr(app.state, "scan_rate_limiter", None)
+        if scan_limiter:
+            scan_limiter._rate_limit = 0
+            await scan_limiter.reset()
         await init_db(settings.database_path)
         await init_plugins(settings.plugins_dir)
 
@@ -87,6 +93,10 @@ def test_client(setup_test_environment):
             await reset_all_endpoint_limiters()
         except ImportError:
             pass
+        scan_limiter = getattr(app.state, "scan_rate_limiter", None)
+        if scan_limiter:
+            scan_limiter._rate_limit = 0
+            await scan_limiter.reset()
         if database_module.db:
             await database_module.db.disconnect()
 

--- a/testing/backend/test_rate_limiter_fallback.py
+++ b/testing/backend/test_rate_limiter_fallback.py
@@ -1,0 +1,288 @@
+"""
+testing/backend/test_rate_limiter_fallback.py
+
+Tests for the in-memory fallback rate limiting in ScanRateLimiter (PR #1617).
+
+Run with: pytest testing/backend/test_rate_limiter_fallback.py -v
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from backend.secuscan.rate_limiter import ScanRateLimiter
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def _make_mock_request(ip: str = "127.0.0.1") -> MagicMock:
+    request = MagicMock()
+    request.client = MagicMock()
+    request.client.host = ip
+    request.headers = {}
+    return request
+
+
+# ─── Fallback behaviour tests (PR #1617) ──────────────────────────────────────
+
+class TestRedisFailureFallbackEnforcesLimits:
+    """When Redis is unavailable the in-memory fallback must still enforce 429s."""
+
+    @pytest.mark.asyncio
+    async def test_allows_requests_under_fallback_limit(self):
+        """Requests below the per-minute limit must pass."""
+        import redis.asyncio as aioredis
+        mock_redis = AsyncMock()
+        mock_redis.pipeline = MagicMock(side_effect=aioredis.ConnectionError("down"))
+
+        limiter = ScanRateLimiter(
+            redis_client=mock_redis,
+            rate_limit=5,
+            rate_window=60,
+            burst_limit=10,
+            burst_window=3600,
+        )
+        # First request — must pass (count=1, limit=5)
+        await limiter.check(_make_mock_request("1.2.3.4"))
+        assert limiter._redis_failed is True
+
+    @pytest.mark.asyncio
+    async def test_rejects_request_when_fallback_minute_limit_exceeded(self):
+        """When in-memory count exceeds the per-minute window, raise 429."""
+        import redis.asyncio as aioredis
+        mock_redis = AsyncMock()
+        mock_redis.pipeline = MagicMock(side_effect=aioredis.ConnectionError("down"))
+
+        limiter = ScanRateLimiter(
+            redis_client=mock_redis,
+            rate_limit=5,
+            rate_window=60,
+            burst_limit=10,
+            burst_window=3600,
+        )
+        req = _make_mock_request("1.2.3.4")
+
+        # Send 5 requests (at limit)
+        for _ in range(5):
+            await limiter.check(req)
+
+        # 6th request should be rejected (over minute limit)
+        with pytest.raises(HTTPException) as exc_info:
+            await limiter.check(req)
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.detail["error"] == "rate_limit_exceeded"
+
+    @pytest.mark.asyncio
+    async def test_fallback_rejects_when_burst_limit_exceeded(self):
+        """When in-memory count exceeds the per-hour window, raise burst 429."""
+        import redis.asyncio as aioredis
+        mock_redis = AsyncMock()
+        mock_redis.pipeline = MagicMock(side_effect=aioredis.ConnectionError("down"))
+
+        # Use small burst window so we can hit it quickly
+        limiter = ScanRateLimiter(
+            redis_client=mock_redis,
+            rate_limit=100,   # minute limit high enough not to interfere
+            rate_window=60,
+            burst_limit=3,    # only 3 per hour
+            burst_window=3600,
+        )
+        req = _make_mock_request("1.2.3.4")
+
+        for _ in range(3):
+            await limiter.check(req)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await limiter.check(req)
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.detail["error"] == "burst_limit_exceeded"
+
+
+class TestRedisRecoveryCircuitBreaker:
+    """When Redis comes back the circuit breaker must disengage."""
+
+    @pytest.mark.asyncio
+    async def test_redis_recovery_resets_failed_flag(self):
+        """After a Redis failure, a successful ping must reset _redis_failed."""
+        mock_redis = AsyncMock()
+        # Fail once, then recover
+        mock_redis.pipeline = MagicMock(side_effect=[
+            ConnectionError("down"),
+        ])
+        mock_redis.ping = AsyncMock(return_value=True)
+
+        limiter = ScanRateLimiter(
+            redis_client=mock_redis,
+            rate_limit=5,
+            rate_window=60,
+            burst_limit=10,
+            burst_window=3600,
+        )
+        req = _make_mock_request("1.2.3.4")
+
+        # First request — Redis fails, fallback engages
+        await limiter.check(req)
+        assert limiter._redis_failed is True
+
+        # Now mark Redis as working again (simulate what happens after ping succeeds)
+        # Replace pipeline so it works next time
+        pipe = AsyncMock()
+        pipe.execute = AsyncMock(return_value=[1, True])
+        mock_redis.pipeline = MagicMock(return_value=pipe)
+
+        # Second request — should try ping, succeed, reset flag, and use Redis
+        await limiter.check(req)
+        assert limiter._redis_failed is False
+
+    @pytest.mark.asyncio
+    async def test_stays_in_fallback_when_redis_still_down(self):
+        """When Redis stays down after recovery attempt, must stay in fallback."""
+        mock_redis = AsyncMock()
+        mock_redis.pipeline = MagicMock(side_effect=ConnectionError("down"))
+        mock_redis.ping = AsyncMock(side_effect=ConnectionError("still down"))
+
+        limiter = ScanRateLimiter(
+            redis_client=mock_redis,
+            rate_limit=5,
+            rate_window=60,
+            burst_limit=10,
+            burst_window=3600,
+        )
+        req = _make_mock_request("1.2.3.4")
+
+        await limiter.check(req)
+        assert limiter._redis_failed is True
+
+        # Second request — ping fails, should stay in fallback
+        await limiter.check(req)
+        assert limiter._redis_failed is True
+
+
+class TestFallbackMemoryCleanup:
+    """The in-memory fallback must purge stale entries to prevent unbounded growth."""
+
+    @pytest.mark.asyncio
+    async def test_cleans_stale_entries_on_check(self):
+        """Entries older than the max window must be removed during fallback check."""
+        limiter = ScanRateLimiter(
+            redis_client=None,
+            rate_limit=5,
+            rate_window=60,
+            burst_limit=10,
+            burst_window=3600,
+        )
+        now = time.time()
+
+        # Manually inject some stale entries (older than 3600s)
+        bucket_key = "1.2.3.4:minute:0"
+        limiter._fallback_history[bucket_key] = [
+            now - 7200,  # 2 hours old → stale
+            now - 5400,  # 1.5 hours old → stale
+            now - 100,   # within window → fresh
+        ]
+
+        # Trigger cleanup via _check_fallback
+        with patch.object(limiter, "_get_client_ip", return_value="1.2.3.4"):
+            try:
+                await limiter._check_fallback(_make_mock_request("1.2.3.4"))
+            except HTTPException:
+                pass
+
+        remaining = limiter._fallback_history.get(bucket_key, [])
+        # Stale entries should be gone; only the fresh one (+ the new request) remain
+        assert len(remaining) >= 1
+        assert all(ts > now - 3600 for ts in remaining)
+
+    @pytest.mark.asyncio
+    async def test_deletes_empty_keys(self):
+        """After removing all stale entries, the key itself must be deleted."""
+        limiter = ScanRateLimiter(
+            redis_client=None,
+            rate_limit=5,
+            rate_window=60,
+            burst_limit=10,
+            burst_window=3600,
+        )
+        now = time.time()
+
+        # Key with only stale entries
+        bucket_key = "1.2.3.4:minute:0"
+        limiter._fallback_history[bucket_key] = [now - 7200, now - 5400]
+
+        with patch.object(limiter, "_get_client_ip", return_value="1.2.3.4"):
+            try:
+                await limiter._check_fallback(_make_mock_request("1.2.3.4"))
+            except HTTPException:
+                pass
+
+        # Empty key should be deleted
+        assert bucket_key not in limiter._fallback_history
+
+
+class TestFallbackSlidingWindow:
+    """The sliding window algorithm must work correctly in fallback mode."""
+
+    @pytest.mark.asyncio
+    async def test_sliding_window_counts_requests_correctly(self):
+        """Requests within the window should be counted correctly."""
+        limiter = ScanRateLimiter(
+            redis_client=None,
+            rate_limit=3,
+            rate_window=60,
+            burst_limit=10,
+            burst_window=3600,
+        )
+        req = _make_mock_request("1.2.3.4")
+
+        with patch("backend.secuscan.rate_limiter.time.time", return_value=1000.0):
+            await limiter.check(req)  # count=1
+            await limiter.check(req)  # count=2
+            await limiter.check(req)  # count=3 (at limit)
+
+        # Count must be exactly 3
+        now = 1000.0
+        minute_window = int(now // 60)
+        bucket = f"1.2.3.4:minute:{minute_window}"
+        assert len(limiter._fallback_history[bucket]) == 3
+
+    @pytest.mark.asyncio
+    async def test_sliding_window_expires_old_entries(self):
+        """Requests outside the sliding window should not count toward the limit."""
+        limiter = ScanRateLimiter(
+            redis_client=None,
+            rate_limit=3,
+            rate_window=60,
+            burst_limit=10,
+            burst_window=3600,
+        )
+        req = _make_mock_request("1.2.3.4")
+
+        # Request at t=0
+        with patch("backend.secuscan.rate_limiter.time.time", return_value=0.0):
+            await limiter.check(req)
+
+        # Request at t=120 (2 minutes later — new window)
+        with patch("backend.secuscan.rate_limiter.time.time", return_value=120.0):
+            await limiter.check(req)
+
+        # Minute buckets: t=0 → window 0, t=120 → window 2 (120//60=2)
+        # Old bucket (window 0) should still exist but not affect new window
+        minute_window_old = int(0 // 60)
+        minute_window_new = int(120 // 60)
+        old_bucket = f"1.2.3.4:minute:{minute_window_old}"
+        new_bucket = f"1.2.3.4:minute:{minute_window_new}"
+
+        assert len(limiter._fallback_history[old_bucket]) == 1
+        assert len(limiter._fallback_history[new_bucket]) == 1
+
+        # Now the old bucket should be cleaned up when we check
+        with patch("backend.secuscan.rate_limiter.time.time", return_value=4000.0):
+            try:
+                await limiter.check(req)
+            except HTTPException:
+                pass
+
+        # Old bucket should be deleted (stale)
+        assert old_bucket not in limiter._fallback_history


### PR DESCRIPTION
## Summary
Replaces the fail-open behavior in `ScanRateLimiter` with an in-memory fallback that maintains rate limiting coverage when Redis is unavailable.

## Changes
- **Add in-memory fallback** (`backend/secuscan/rate_limiter.py`):
  - `_check_fallback()` — implements dict-based sliding window counters for per-minute and per-hour limits, matching the Redis-backed algorithm
  - Circuit-breaker pattern: when Redis fails, `_redis_failed` is set and subsequent requests try `PING` first before falling back
  - `redis_client=None` also uses the in-memory fallback instead of allowing all requests
- **Logging**: ERROR level when switching to fallback; INFO when Redis connection is restored
- Preserves existing two-tier rate limiting (per-minute burst + per-hour sustained)

## Checklist
- [x] Replace fail-open with in-memory fallback when Redis is down
- [x] Add circuit-breaker with periodic reconnect attempts
- [x] Log at ERROR level when Redis is unavailable

Closes #1587