### PR TITLE
Add webhook notifications (Slack/Discord/generic) on scan completion

### DIFF
--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -178,6 +178,10 @@ class Settings(BaseSettings):
     # Slack Webhook Configuration
     slack_webhook_url: Optional[str] = None
 
+    # Public base URL used to build absolute links (e.g. report links) in
+    # outbound notifications. Leave blank to emit relative paths.
+    public_base_url: str = ""
+
     class Config:
         env_prefix = "SECUSCAN_"
         case_sensitive = False
@@ -241,3 +245,4 @@ class Settings(BaseSettings):
 
 # Global settings instance
 settings = Settings()
+

--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -245,4 +245,3 @@ class Settings(BaseSettings):
 
 # Global settings instance
 settings = Settings()
-

--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -347,6 +347,16 @@ ON credential_vault(owner_id);
                 sent_at TIMESTAMP NOT NULL DEFAULT (datetime('now'))
             );
 
+            -- Per-owner webhook fired on scan completion/failure (issue #1615).
+            -- Distinct from notification_rules, which fires per-finding above a
+            -- severity threshold; this fires once per scan regardless of severity.
+            CREATE TABLE IF NOT EXISTS scan_webhook_settings (
+                owner_id TEXT PRIMARY KEY,
+                webhook_url TEXT NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT (datetime('now')),
+                updated_at TIMESTAMP NOT NULL DEFAULT (datetime('now'))
+            );
+
             -- Tasks indexes (existing)
             CREATE INDEX IF NOT EXISTS idx_tasks_created ON tasks(created_at);
             CREATE INDEX IF NOT EXISTS idx_tasks_target ON tasks(target);
@@ -1074,3 +1084,4 @@ async def get_db() -> Database:
         raise RuntimeError("Database not initialized")
 
     return db
+

--- a/backend/secuscan/database.py
+++ b/backend/secuscan/database.py
@@ -1084,4 +1084,3 @@ async def get_db() -> Database:
         raise RuntimeError("Database not initialized")
 
     return db
-

--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -814,6 +814,7 @@ class TaskExecutor:
                 },
                 task_id=task_id,
             )
+            await self._dispatch_task_notifications(db, task_id)
 
         except Exception as e:
             logger.error(f"Task {task_id} failed: {e}", exc_info=True)
@@ -846,6 +847,7 @@ class TaskExecutor:
                 context={"task_id": task_id, "error": str(e)},
                 task_id=task_id
             )
+            await self._dispatch_task_notifications(db, task_id)
         finally:
             self.running_tasks.pop(task_id, None)
             self._process_pids.pop(task_id, None)
@@ -1872,9 +1874,15 @@ class TaskExecutor:
             if sent:
                 logger.info("Task %s: delivered %d notification(s)", task_id, sent)
 
-            # Send Slack Webhook notification for scan completion
+            # Send Slack Webhook notification for scan completion (legacy,
+            # single global webhook configured via env var).
             from .notification_service import process_slack_notification
             await process_slack_notification(db, task_id)
+
+            # Send the per-owner scan-completion webhook (Slack/Discord/
+            # generic JSON), configured from the Settings page (issue #1615).
+            from .notification_service import process_scan_completion_webhook
+            await process_scan_completion_webhook(db, task_id)
         except Exception as exc:
             logger.warning(
                 "Task %s: notification dispatch failed: %s",
@@ -1899,3 +1907,4 @@ class TaskExecutor:
 
 # Global executor instance
 executor = TaskExecutor()
+

--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -1907,4 +1907,3 @@ class TaskExecutor:
 
 # Global executor instance
 executor = TaskExecutor()
-

--- a/backend/secuscan/models.py
+++ b/backend/secuscan/models.py
@@ -326,6 +326,19 @@ class NotificationRuleUpdate(BaseModel):
     is_active: Optional[bool] = None
 
 
+class ScanWebhookSettingsRequest(BaseModel):
+    """Request payload for setting the scan-completion webhook URL."""
+    webhook_url: str = Field(..., max_length=2000)
+
+
+class ScanWebhookSettingsResponse(BaseModel):
+    """Stored scan-completion webhook setting returned by the API."""
+    webhook_url: Optional[str] = None
+    platform: Optional[str] = None
+    configured: bool = False
+    updated_at: Optional[datetime] = None
+
+
 class NotificationRuleResponse(BaseModel):
     """Stored notification rule returned by the API."""
     id: str
@@ -359,3 +372,4 @@ class NotificationDiagnosticsResponse(BaseModel):
 class BulkDeleteRequest(RootModel[Annotated[List[str], Field(max_length=MAX_BULK_DELETE)]]):
     """Accepts a JSON array of task IDs directly. Max 500 per request."""
     pass
+

--- a/backend/secuscan/models.py
+++ b/backend/secuscan/models.py
@@ -372,4 +372,3 @@ class NotificationDiagnosticsResponse(BaseModel):
 class BulkDeleteRequest(RootModel[Annotated[List[str], Field(max_length=MAX_BULK_DELETE)]]):
     """Accepts a JSON array of task IDs directly. Max 500 per request."""
     pass
-

--- a/backend/secuscan/notification_service.py
+++ b/backend/secuscan/notification_service.py
@@ -700,6 +700,223 @@ async def update_notification_rule(
     return updated
 
 
+def detect_webhook_platform(webhook_url: str) -> str:
+    """Classify a webhook URL as 'slack', 'discord', or 'generic'.
+
+    Slack and Discord incoming webhooks both accept a simple JSON body
+    (``{"text": ...}`` / ``{"content": ...}``) so both work out of the box
+    with no extra configuration; anything else falls back to a plain JSON
+    payload.
+    """
+    try:
+        hostname = (urlparse(webhook_url).hostname or "").lower()
+    except ValueError:
+        return "generic"
+
+    if hostname.endswith("slack.com"):
+        return "slack"
+    if hostname.endswith("discord.com") or hostname.endswith("discordapp.com"):
+        return "discord"
+    return "generic"
+
+
+async def _gather_scan_summary(db: Database, task_id: str) -> Optional[Dict[str, Any]]:
+    """Collect task status, severity counts, and a report link for a scan."""
+    task = await db.fetchone("SELECT * FROM tasks WHERE id = ?", (task_id,))
+    if not task:
+        return None
+
+    status = str(task.get("status") or "unknown").lower()
+    target = task.get("target") or "Unknown Target"
+    tool_name = task.get("tool_name") or task.get("plugin_id") or "Security Scan"
+
+    findings = await db.fetchall(
+        "SELECT severity FROM findings WHERE task_id = ?",
+        (task_id,),
+    )
+    severity_counts: Dict[str, int] = {}
+    for row in findings:
+        sev = str(row.get("severity") or "info").lower()
+        severity_counts[sev] = severity_counts.get(sev, 0) + 1
+
+    from .config import settings as _settings
+
+    base_url = str(getattr(_settings, "public_base_url", "") or "").rstrip("/")
+    report_link = f"{base_url}/task/{task_id}" if base_url else f"/task/{task_id}"
+
+    return {
+        "task_id": task_id,
+        "tool_name": tool_name,
+        "target": target,
+        "status": status,
+        "total_findings": len(findings),
+        "severity_counts": severity_counts,
+        "error_message": task.get("error_message"),
+        "report_link": report_link,
+    }
+
+
+def build_scan_completion_payload(platform: str, summary: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a webhook body for the given platform from a scan summary."""
+    status = str(summary["status"]).upper()
+    target = summary["target"]
+    total = summary["total_findings"]
+    counts = summary["severity_counts"]
+    report_link = summary["report_link"]
+    status_icon = "✅" if status == "COMPLETED" else "❌" if status == "FAILED" else "ℹ️"
+
+    severity_text = ", ".join(
+        f"{sev.capitalize()}: {counts.get(sev, 0)}"
+        for sev in ["critical", "high", "medium", "low", "info"]
+        if counts.get(sev, 0) > 0 or sev in ("critical", "high", "medium")
+    )
+
+    summary_line = (
+        f"{status_icon} SecuScan scan of {target} finished with status {status}. "
+        f"Findings: {total} ({severity_text}). Report: {report_link}"
+    )
+    if status == "FAILED" and summary.get("error_message"):
+        summary_line += f" | Error: {summary['error_message']}"
+
+    if platform == "slack":
+        return {
+            "text": summary_line,
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {"type": "plain_text", "text": f"{status_icon} SecuScan: Scan {status.capitalize()}", "emoji": True},
+                },
+                {
+                    "type": "section",
+                    "fields": [
+                        {"type": "mrkdwn", "text": f"*Target:*\n{target}"},
+                        {"type": "mrkdwn", "text": f"*Status:*\n{status}"},
+                        {"type": "mrkdwn", "text": f"*Total Findings:*\n{total}"},
+                        {"type": "mrkdwn", "text": f"*Severity Breakdown:*\n{severity_text or 'None'}"},
+                    ],
+                },
+                {"type": "section", "text": {"type": "mrkdwn", "text": f"*Report:*\n<{report_link}|View full report>"}},
+            ],
+        }
+
+    if platform == "discord":
+        return {
+            "content": summary_line,
+            "embeds": [
+                {
+                    "title": f"SecuScan: Scan {status.capitalize()}",
+                    "url": report_link if report_link.startswith("http") else None,
+                    "fields": [
+                        {"name": "Target", "value": str(target), "inline": True},
+                        {"name": "Status", "value": status, "inline": True},
+                        {"name": "Total Findings", "value": str(total), "inline": True},
+                        {"name": "Severity Breakdown", "value": severity_text or "None", "inline": False},
+                    ],
+                }
+            ],
+        }
+
+    # Generic JSON fallback for any other endpoint.
+    return {
+        "event": f"scan.{summary['status']}",
+        "task_id": summary["task_id"],
+        "tool_name": summary["tool_name"],
+        "target": target,
+        "status": summary["status"],
+        "total_findings": total,
+        "severity_counts": counts,
+        "error_message": summary.get("error_message"),
+        "report_link": report_link,
+    }
+
+
+async def get_scan_webhook_url(db: Database, owner_id: str) -> Optional[str]:
+    """Fetch the configured scan-completion webhook URL for an owner, if any."""
+    row = await db.fetchone(
+        "SELECT webhook_url FROM scan_webhook_settings WHERE owner_id = ?",
+        (owner_id,),
+    )
+    return row["webhook_url"] if row else None
+
+
+async def set_scan_webhook_url(db: Database, owner_id: str, webhook_url: str) -> Dict[str, Any]:
+    """Create or update the scan-completion webhook URL for an owner."""
+    await db.execute(
+        """
+        INSERT INTO scan_webhook_settings (owner_id, webhook_url)
+        VALUES (?, ?)
+        ON CONFLICT(owner_id) DO UPDATE SET
+            webhook_url = excluded.webhook_url,
+            updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now')
+        """,
+        (owner_id, webhook_url),
+    )
+    row = await db.fetchone(
+        "SELECT * FROM scan_webhook_settings WHERE owner_id = ?",
+        (owner_id,),
+    )
+    return dict(row) if row else {"owner_id": owner_id, "webhook_url": webhook_url}
+
+
+async def delete_scan_webhook_url(db: Database, owner_id: str) -> bool:
+    """Remove the scan-completion webhook URL for an owner. Returns True if a row was deleted."""
+    cursor = await db.execute(
+        "DELETE FROM scan_webhook_settings WHERE owner_id = ?",
+        (owner_id,),
+    )
+    return bool(cursor.rowcount)
+
+
+async def process_scan_completion_webhook(db: Database, task_id: str) -> None:
+    """Deliver the per-owner scan-completion webhook (Slack/Discord/generic).
+
+    Non-blocking with respect to scan execution: every failure path here is
+    caught and logged rather than raised, per issue #1615's acceptance
+    criteria that delivery problems must never surface as a scan error.
+    """
+    try:
+        task = await db.fetchone(
+            "SELECT owner_id FROM tasks WHERE id = ?",
+            (task_id,),
+        )
+        if not task:
+            return
+
+        owner_id = task.get("owner_id") or "default"
+        webhook_url = await get_scan_webhook_url(db, owner_id)
+        if not webhook_url:
+            return
+
+        summary = await _gather_scan_summary(db, task_id)
+        if not summary:
+            return
+
+        platform = detect_webhook_platform(webhook_url)
+        payload = build_scan_completion_payload(platform, summary)
+
+        ok, error = await send_webhook(webhook_url, payload)
+        if ok:
+            logger.info(
+                "Scan completion webhook (%s) for task %s sent successfully",
+                platform,
+                task_id,
+            )
+        else:
+            logger.warning(
+                "Failed to deliver scan completion webhook (%s) for task %s: %s",
+                platform,
+                task_id,
+                error,
+            )
+    except Exception as exc:
+        logger.error(
+            "Error sending scan completion webhook for task %s: %s",
+            task_id,
+            exc,
+            exc_info=True,
+        )
+
+
 async def process_slack_notification(db: Database, task_id: str) -> None:
     """Send a structured JSON payload and a clean block message to the configured Slack Webhook after scan completion."""
     from .config import settings
@@ -821,3 +1038,4 @@ async def process_slack_notification(db: Database, task_id: str) -> None:
             logger.warning("Failed to send Slack notification for task %s: %s", task_id, error)
     except Exception as exc:
         logger.error("Error sending Slack notification for task %s: %s", task_id, exc, exc_info=True)
+

--- a/backend/secuscan/notification_service.py
+++ b/backend/secuscan/notification_service.py
@@ -1038,4 +1038,3 @@ async def process_slack_notification(db: Database, task_id: str) -> None:
             logger.warning("Failed to send Slack notification for task %s: %s", task_id, error)
     except Exception as exc:
         logger.error("Error sending Slack notification for task %s: %s", task_id, exc, exc_info=True)
-

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -97,6 +97,7 @@ from .models import (
     NotificationChannelType, TaskStatus,
     ExecutionContext, WorkflowStep, ValidationMode, EvidenceLevel,
     NotificationDiagnosticsResponse,
+    ScanWebhookSettingsRequest, ScanWebhookSettingsResponse,
 )
 from .config import settings
 from .database import get_db
@@ -2367,6 +2368,54 @@ async def delete_notification_rule(rule_id: str, owner: str = Depends(get_curren
     return {"rule_id": rule_id, "deleted": True}
 
 
+@router.get("/settings/webhook")
+async def get_scan_webhook_settings(owner: str = Depends(get_current_owner)):
+    """Return the configured scan-completion webhook for the current owner.
+
+    Fires on scan completion/failure (issue #1615) — distinct from the
+    per-finding severity-threshold rules under /notifications/rules.
+    """
+    db = await get_db()
+    row = await db.fetchone(
+        "SELECT * FROM scan_webhook_settings WHERE owner_id = ?",
+        (owner,),
+    )
+    if not row:
+        return {"webhook_url": None, "platform": None, "configured": False, "updated_at": None}
+    webhook_url = row["webhook_url"]
+    return {
+        "webhook_url": webhook_url,
+        "platform": notification_service.detect_webhook_platform(webhook_url),
+        "configured": True,
+        "updated_at": row.get("updated_at"),
+    }
+
+
+@router.put("/settings/webhook")
+async def upsert_scan_webhook_settings(
+    payload: ScanWebhookSettingsRequest,
+    owner: str = Depends(get_current_owner),
+):
+    """Create or update the scan-completion webhook URL for the current owner."""
+    target = _validate_notification_target(NotificationChannelType.WEBHOOK, payload.webhook_url)
+    db = await get_db()
+    row = await notification_service.set_scan_webhook_url(db, owner, target)
+    return {
+        "webhook_url": row["webhook_url"],
+        "platform": notification_service.detect_webhook_platform(row["webhook_url"]),
+        "configured": True,
+        "updated_at": row.get("updated_at"),
+    }
+
+
+@router.delete("/settings/webhook")
+async def delete_scan_webhook_settings(owner: str = Depends(get_current_owner)):
+    """Remove the scan-completion webhook URL for the current owner."""
+    db = await get_db()
+    deleted = await notification_service.delete_scan_webhook_url(db, owner)
+    return {"deleted": deleted}
+
+
 @router.get("/notifications/history", dependencies=[Depends(read_heavy_limiter)])
 async def list_notification_history(
     rule_id: Optional[str] = None,
@@ -2713,3 +2762,4 @@ async def get_vault_diagnostics():
         "key_fingerprint": crypto.key_fingerprint,
         "fingerprint_algorithm": "sha256-trunc64",
     }
+

--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -2762,4 +2762,3 @@ async def get_vault_diagnostics():
         "key_fingerprint": crypto.key_fingerprint,
         "fingerprint_algorithm": "sha256-trunc64",
     }
-

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -499,6 +499,32 @@ export async function listNotificationHistory(params?: {
   }
 }
 
+// Per-owner webhook fired once on scan completion/failure (Slack, Discord, or
+// a generic JSON endpoint — auto-detected from the URL). Distinct from the
+// per-finding notification rules above.
+export interface ScanWebhookSettings {
+  webhook_url: string | null
+  platform: 'slack' | 'discord' | 'generic' | null
+  configured: boolean
+  updated_at: string | null
+}
+
+export async function getScanWebhookSettings(): Promise<ScanWebhookSettings> {
+  return request<ScanWebhookSettings>('/settings/webhook')
+}
+
+export async function setScanWebhookSettings(webhookUrl: string): Promise<ScanWebhookSettings> {
+  return request<ScanWebhookSettings>('/settings/webhook', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ webhook_url: webhookUrl }),
+  })
+}
+
+export async function deleteScanWebhookSettings(): Promise<{ deleted: boolean }> {
+  return request<{ deleted: boolean }>('/settings/webhook', { method: 'DELETE' })
+}
+
 export function getTasks(params?: URLSearchParams) {
   const suffix = params ? `?${params.toString()}` : ''
   return request(`/tasks${suffix}`)
@@ -779,3 +805,4 @@ export function getAssetServices() {
 export function getKnowledgebaseStatus() {
   return request('/knowledgebase/status')
 }
+

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -805,4 +805,3 @@ export function getAssetServices() {
 export function getKnowledgebaseStatus() {
   return request('/knowledgebase/status')
 }
-

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -7,15 +7,19 @@ import {
   clearStoredApiKey,
   createNotificationRule,
   deleteNotificationRule,
+  deleteScanWebhookSettings,
+  getScanWebhookSettings,
   getStoredApiKey,
   listNotificationHistory,
   listNotificationRules,
   logoutSession,
+  setScanWebhookSettings,
   updateNotificationRule,
   type NotificationChannelType,
   type NotificationHistoryRow,
   type NotificationRule,
   type NotificationSeverityThreshold,
+  type ScanWebhookSettings,
 } from '../api'
 import { ConfirmModal } from '../components/ConfirmModal'
 
@@ -81,6 +85,57 @@ export default function Settings() {
     })
 
     const [editRules, setEditRules] = useState<Record<string, Partial<NotificationRule>>>({})
+
+    const [scanWebhook, setScanWebhook] = useState<ScanWebhookSettings | null>(null)
+    const [scanWebhookLoading, setScanWebhookLoading] = useState(false)
+    const [scanWebhookInput, setScanWebhookInput] = useState('')
+    const [scanWebhookSaving, setScanWebhookSaving] = useState(false)
+
+    async function refreshScanWebhook() {
+        setScanWebhookLoading(true)
+        try {
+            const data = await getScanWebhookSettings()
+            setScanWebhook(data)
+            setScanWebhookInput(data.webhook_url ?? '')
+        } catch {
+            addToast('Failed to load scan completion webhook', 'error')
+        } finally {
+            setScanWebhookLoading(false)
+        }
+    }
+
+    async function saveScanWebhook() {
+        const trimmed = scanWebhookInput.trim()
+        if (!trimmed) {
+            addToast('Webhook URL is required', 'error')
+            return
+        }
+        setScanWebhookSaving(true)
+        try {
+            const data = await setScanWebhookSettings(trimmed)
+            setScanWebhook(data)
+            setScanWebhookInput(data.webhook_url ?? '')
+            addToast('Scan completion webhook saved', 'success')
+        } catch {
+            addToast('Failed to save scan completion webhook', 'error')
+        } finally {
+            setScanWebhookSaving(false)
+        }
+    }
+
+    async function removeScanWebhook() {
+        setScanWebhookSaving(true)
+        try {
+            await deleteScanWebhookSettings()
+            setScanWebhook({ webhook_url: null, platform: null, configured: false, updated_at: null })
+            setScanWebhookInput('')
+            addToast('Scan completion webhook removed', 'info')
+        } catch {
+            addToast('Failed to remove scan completion webhook', 'error')
+        } finally {
+            setScanWebhookSaving(false)
+        }
+    }
 
     async function refreshNotificationRules() {
         setNotificationRulesLoading(true)
@@ -272,6 +327,7 @@ export default function Settings() {
 
     useEffect(() => {
         refreshNotificationRules()
+        refreshScanWebhook()
     }, [])
 
     useEffect(() => {
@@ -466,6 +522,66 @@ export default function Settings() {
                                     ● NO_KEY_SET — API requests will return 401 until a key is saved
                                 </p>
                             )}
+                        </div>
+                    </section>
+
+                    <section className="space-y-8" aria-label="Scan completion webhook">
+                        <div className="flex items-center gap-4">
+                            <h3 className="text-xs font-black text-silver-bright uppercase tracking-[0.4em] italic">Scan_Completion_Webhook</h3>
+                            <div className="h-0.5 flex-1 bg-black/10"></div>
+                            <button
+                                type="button"
+                                onClick={refreshScanWebhook}
+                                className="px-4 py-2 bg-charcoal border-4 border-black text-[10px] font-black uppercase tracking-widest text-silver/60 hover:text-silver-bright hover:bg-black/40 transition-all"
+                                aria-label="Refresh scan completion webhook"
+                            >
+                                Refresh
+                            </button>
+                        </div>
+
+                        <div className="bg-charcoal border-4 border-black p-10 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] space-y-6">
+                            <div className="space-y-2">
+                                <p className="text-[10px] text-silver/40 uppercase font-bold italic leading-relaxed">
+                                    Fires once per scan when it completes or fails — includes target, status, findings by severity, and a report link.
+                                    Works out of the box with Slack and Discord incoming webhook URLs; any other URL receives a generic JSON payload.
+                                </p>
+                            </div>
+                            <div className="bg-charcoal-dark border-4 border-black p-6 space-y-4">
+                                <label className="text-[10px] font-black text-silver/50 uppercase tracking-widest">Webhook_URL</label>
+                                <input
+                                    value={scanWebhookInput}
+                                    onChange={(e) => setScanWebhookInput(e.target.value)}
+                                    className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-silver-bright font-bold focus:outline-none focus:border-rag-blue/50 transition-colors"
+                                    placeholder="https://hooks.slack.com/services/... or https://discord.com/api/webhooks/..."
+                                    aria-label="Scan completion webhook URL"
+                                    disabled={scanWebhookLoading}
+                                />
+                                {scanWebhook?.configured && (
+                                    <p className="text-[10px] font-mono text-rag-green uppercase tracking-widest">
+                                        ● ACTIVE — detected format: {scanWebhook.platform ?? 'generic'}
+                                    </p>
+                                )}
+                            </div>
+                            <div className="flex flex-col md:flex-row items-start md:items-center gap-4">
+                                <button
+                                    type="button"
+                                    onClick={saveScanWebhook}
+                                    disabled={scanWebhookSaving || scanWebhookLoading}
+                                    className="bg-rag-blue text-black px-10 py-4 text-[10px] font-black uppercase tracking-[0.35em] shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 disabled:opacity-50 disabled:cursor-not-allowed transition-all italic"
+                                >
+                                    {scanWebhook?.configured ? 'UPDATE_WEBHOOK' : 'SAVE_WEBHOOK'}
+                                </button>
+                                {scanWebhook?.configured && (
+                                    <button
+                                        type="button"
+                                        onClick={removeScanWebhook}
+                                        disabled={scanWebhookSaving || scanWebhookLoading}
+                                        className="px-10 py-4 bg-charcoal-dark border-4 border-black text-[10px] font-black uppercase tracking-[0.2em] text-silver/60 hover:text-rag-red hover:bg-black/40 disabled:opacity-50 disabled:cursor-not-allowed transition-all italic"
+                                    >
+                                        REMOVE
+                                    </button>
+                                )}
+                            </div>
                         </div>
                     </section>
 
@@ -957,3 +1073,5 @@ export default function Settings() {
         </div>
     )
 }
+
+

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1073,5 +1073,3 @@ export default function Settings() {
         </div>
     )
 }
-
-

--- a/frontend/testing/unit/pages/SettingsNotifications.test.tsx
+++ b/frontend/testing/unit/pages/SettingsNotifications.test.tsx
@@ -9,6 +9,9 @@ import {
   listNotificationRules,
   updateNotificationRule,
   listNotificationHistory,
+  getScanWebhookSettings,
+  setScanWebhookSettings,
+  deleteScanWebhookSettings,
 } from '../../../src/api'
 
 vi.mock('../../../src/api', async () => {
@@ -20,6 +23,9 @@ vi.mock('../../../src/api', async () => {
     updateNotificationRule: vi.fn(),
     deleteNotificationRule: vi.fn(),
     listNotificationHistory: vi.fn(),
+    getScanWebhookSettings: vi.fn(),
+    setScanWebhookSettings: vi.fn(),
+    deleteScanWebhookSettings: vi.fn(),
   }
 })
 
@@ -52,6 +58,14 @@ describe('Settings notifications rules panel', () => {
     vi.mocked(updateNotificationRule).mockResolvedValue({} as any)
     vi.mocked(deleteNotificationRule).mockResolvedValue({ rule_id: 'rule-1', deleted: true } as any)
     vi.mocked(listNotificationHistory).mockResolvedValue({ history: [], total: 0, limit: 10, offset: 0 } as any)
+    vi.mocked(getScanWebhookSettings).mockResolvedValue({
+      webhook_url: null,
+      platform: null,
+      configured: false,
+      updated_at: null,
+    } as any)
+    vi.mocked(setScanWebhookSettings).mockResolvedValue({} as any)
+    vi.mocked(deleteScanWebhookSettings).mockResolvedValue({ deleted: true } as any)
   })
 
   it('renders existing rules from API', async () => {
@@ -87,5 +101,43 @@ describe('Settings notifications rules panel', () => {
     await waitFor(() => {
       expect(updateNotificationRule).toHaveBeenCalledWith('rule-1', { is_active: false })
     })
+  })
+})
+
+describe('Settings scan completion webhook panel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(listNotificationRules).mockResolvedValue([])
+    vi.mocked(createNotificationRule).mockResolvedValue({} as any)
+    vi.mocked(updateNotificationRule).mockResolvedValue({} as any)
+    vi.mocked(deleteNotificationRule).mockResolvedValue({ rule_id: 'rule-1', deleted: true } as any)
+    vi.mocked(listNotificationHistory).mockResolvedValue({ history: [], total: 0, limit: 10, offset: 0 } as any)
+    vi.mocked(getScanWebhookSettings).mockResolvedValue({
+      webhook_url: null,
+      platform: null,
+      configured: false,
+      updated_at: null,
+    } as any)
+    vi.mocked(setScanWebhookSettings).mockResolvedValue({
+      webhook_url: 'https://hooks.slack.com/services/x',
+      platform: 'slack',
+      configured: true,
+      updated_at: '2026-01-01T00:00:00Z',
+    } as any)
+    vi.mocked(deleteScanWebhookSettings).mockResolvedValue({ deleted: true } as any)
+  })
+
+  it('saves a new scan completion webhook URL', async () => {
+    const user = userEvent.setup()
+    renderSettings()
+
+    const input = await screen.findByLabelText(/Scan completion webhook URL/i)
+    await user.type(input, 'https://hooks.slack.com/services/x')
+    await user.click(screen.getByRole('button', { name: /SAVE_WEBHOOK/i }))
+
+    await waitFor(() => {
+      expect(setScanWebhookSettings).toHaveBeenCalledWith('https://hooks.slack.com/services/x')
+    })
+    expect(await screen.findByText(/detected format: slack/i)).toBeInTheDocument()
   })
 })

--- a/testing/backend/integration/test_notification_routes.py
+++ b/testing/backend/integration/test_notification_routes.py
@@ -247,6 +247,55 @@ def test_notification_history_list_contract(test_client):
     assert filtered_data["history"][0]["status"] == "success"
 
 
+def test_scan_webhook_settings_crud_contract(test_client):
+    # Nothing configured initially.
+    get_response = test_client.get("/api/v1/settings/webhook")
+    assert get_response.status_code == 200
+    assert get_response.json() == {
+        "webhook_url": None,
+        "platform": None,
+        "configured": False,
+        "updated_at": None,
+    }
+
+    put_response = test_client.put(
+        "/api/v1/settings/webhook",
+        json={"webhook_url": "https://hooks.slack.com/services/T00/B00/xxx"},
+    )
+    assert put_response.status_code == 200
+    created = put_response.json()
+    assert created["webhook_url"] == "https://hooks.slack.com/services/T00/B00/xxx"
+    assert created["platform"] == "slack"
+    assert created["configured"] is True
+
+    get_after_put = test_client.get("/api/v1/settings/webhook")
+    assert get_after_put.status_code == 200
+    assert get_after_put.json()["webhook_url"] == "https://hooks.slack.com/services/T00/B00/xxx"
+
+    # Updating replaces the existing value (upsert, not append).
+    update_response = test_client.put(
+        "/api/v1/settings/webhook",
+        json={"webhook_url": "https://discord.com/api/webhooks/1/abc"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["platform"] == "discord"
+
+    delete_response = test_client.delete("/api/v1/settings/webhook")
+    assert delete_response.status_code == 200
+    assert delete_response.json()["deleted"] is True
+
+    get_after_delete = test_client.get("/api/v1/settings/webhook")
+    assert get_after_delete.json()["configured"] is False
+
+
+def test_scan_webhook_settings_rejects_invalid_url(test_client):
+    response = test_client.put(
+        "/api/v1/settings/webhook",
+        json={"webhook_url": "not-a-url"},
+    )
+    assert response.status_code == 400
+
+
 def test_admin_diagnostics_notifications(test_client, monkeypatch):
     from backend.secuscan.config import settings
 
@@ -269,3 +318,4 @@ def test_admin_diagnostics_notifications(test_client, monkeypatch):
     assert "backoff_factor_seconds" in data
     assert type(data["max_retries"]) is int
     assert type(data["webhook_timeout_seconds"]) is float
+

--- a/testing/backend/integration/test_notification_routes.py
+++ b/testing/backend/integration/test_notification_routes.py
@@ -318,4 +318,3 @@ def test_admin_diagnostics_notifications(test_client, monkeypatch):
     assert "backoff_factor_seconds" in data
     assert type(data["max_retries"]) is int
     assert type(data["webhook_timeout_seconds"]) is float
-

--- a/testing/backend/unit/test_notification_service.py
+++ b/testing/backend/unit/test_notification_service.py
@@ -19,8 +19,14 @@ from backend.secuscan.models import (
 from backend.secuscan.notification_service import (
     NotificationRuleConflictError,
     build_alert_payload,
+    build_scan_completion_payload,
+    delete_scan_webhook_url,
     deliver_via_rule,
+    detect_webhook_platform,
+    get_scan_webhook_url,
     process_finding_notifications,
+    process_scan_completion_webhook,
+    set_scan_webhook_url,
     severity_meets_threshold,
     update_notification_rule,
     was_already_delivered,
@@ -768,3 +774,154 @@ async def test_process_slack_notification_failed_task(test_db, monkeypatch):
     assert "blocks" in payload
     assert "Error Message" in payload["blocks"][2]["text"]["text"]
     assert "Connection refused" in payload["blocks"][2]["text"]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Scan-completion webhook (issue #1615): per-owner webhook settable from the
+# Settings page, fired for both completed and failed scans, with Slack,
+# Discord, and generic JSON payload formats.
+# ---------------------------------------------------------------------------
+
+
+def test_detect_webhook_platform():
+    assert detect_webhook_platform("https://hooks.slack.com/services/T00/B00/xxx") == "slack"
+    assert detect_webhook_platform("https://discord.com/api/webhooks/1/abc") == "discord"
+    assert detect_webhook_platform("https://discordapp.com/api/webhooks/1/abc") == "discord"
+    assert detect_webhook_platform("https://example.com/my-hook") == "generic"
+    assert detect_webhook_platform("not a url") == "generic"
+
+
+def test_build_scan_completion_payload_slack():
+    summary = {
+        "task_id": "t1",
+        "tool_name": "nmap",
+        "target": "127.0.0.1",
+        "status": "completed",
+        "total_findings": 3,
+        "severity_counts": {"critical": 1, "medium": 2},
+        "error_message": None,
+        "report_link": "/task/t1",
+    }
+    payload = build_scan_completion_payload("slack", summary)
+    assert "blocks" in payload
+    assert "text" in payload
+    assert "127.0.0.1" in payload["text"]
+
+
+def test_build_scan_completion_payload_discord():
+    summary = {
+        "task_id": "t1",
+        "tool_name": "nmap",
+        "target": "127.0.0.1",
+        "status": "failed",
+        "total_findings": 0,
+        "severity_counts": {},
+        "error_message": "Connection refused",
+        "report_link": "https://example.com/task/t1",
+    }
+    payload = build_scan_completion_payload("discord", summary)
+    assert "content" in payload
+    assert "Connection refused" in payload["content"]
+    assert payload["embeds"][0]["url"] == "https://example.com/task/t1"
+
+
+def test_build_scan_completion_payload_generic():
+    summary = {
+        "task_id": "t1",
+        "tool_name": "nmap",
+        "target": "127.0.0.1",
+        "status": "completed",
+        "total_findings": 2,
+        "severity_counts": {"high": 2},
+        "error_message": None,
+        "report_link": "/task/t1",
+    }
+    payload = build_scan_completion_payload("generic", summary)
+    assert payload["event"] == "scan.completed"
+    assert payload["target"] == "127.0.0.1"
+    assert payload["severity_counts"] == {"high": 2}
+    assert payload["report_link"] == "/task/t1"
+
+
+@pytest.mark.asyncio
+async def test_set_get_delete_scan_webhook_url(test_db):
+    assert await get_scan_webhook_url(test_db, "owner-1") is None
+
+    row = await set_scan_webhook_url(test_db, "owner-1", "https://hooks.slack.com/services/x")
+    assert row["webhook_url"] == "https://hooks.slack.com/services/x"
+    assert await get_scan_webhook_url(test_db, "owner-1") == "https://hooks.slack.com/services/x"
+
+    # Upsert overwrites the existing value for the same owner.
+    await set_scan_webhook_url(test_db, "owner-1", "https://discord.com/api/webhooks/1/a")
+    assert await get_scan_webhook_url(test_db, "owner-1") == "https://discord.com/api/webhooks/1/a"
+
+    deleted = await delete_scan_webhook_url(test_db, "owner-1")
+    assert deleted is True
+    assert await get_scan_webhook_url(test_db, "owner-1") is None
+
+
+@pytest.mark.asyncio
+async def test_process_scan_completion_webhook_no_url_configured(test_db):
+    """No webhook configured for the owner => nothing is sent, no error raised."""
+    task_id, _ = await _seed_finding(test_db, severity="high")
+
+    mock_send = AsyncMock(return_value=(True, None))
+    with patch("backend.secuscan.notification_service.send_webhook", mock_send):
+        await process_scan_completion_webhook(test_db, task_id)
+
+    mock_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_scan_completion_webhook_completed(test_db):
+    task_id, _ = await _seed_finding(test_db, severity="critical")
+    await set_scan_webhook_url(test_db, "default", "https://hooks.slack.com/services/x")
+
+    mock_send = AsyncMock(return_value=(True, None))
+    with patch("backend.secuscan.notification_service.send_webhook", mock_send):
+        await process_scan_completion_webhook(test_db, task_id)
+
+    assert mock_send.call_count == 1
+    target_url, payload = mock_send.call_args[0]
+    assert target_url == "https://hooks.slack.com/services/x"
+    assert "blocks" in payload  # Slack format auto-detected from the URL
+
+
+@pytest.mark.asyncio
+async def test_process_scan_completion_webhook_failed_scan_discord(test_db):
+    task_id = str(uuid.uuid4())
+    await test_db.execute(
+        """
+        INSERT INTO tasks (
+            id, plugin_id, tool_name, target, status, inputs_json, consent_granted, error_message
+        ) VALUES (?, 'nmap', 'nmap', '127.0.0.1', 'failed', '{}', 1, 'Connection refused')
+        """,
+        (task_id,),
+    )
+    await set_scan_webhook_url(test_db, "default", "https://discord.com/api/webhooks/1/abc")
+
+    mock_send = AsyncMock(return_value=(True, None))
+    with patch("backend.secuscan.notification_service.send_webhook", mock_send):
+        await process_scan_completion_webhook(test_db, task_id)
+
+    assert mock_send.call_count == 1
+    target_url, payload = mock_send.call_args[0]
+    assert target_url == "https://discord.com/api/webhooks/1/abc"
+    assert "content" in payload
+    assert "Connection refused" in payload["content"]
+
+
+@pytest.mark.asyncio
+async def test_process_scan_completion_webhook_delivery_failure_is_swallowed(test_db):
+    """A failed/unreachable webhook must not raise - it's only logged."""
+    task_id, _ = await _seed_finding(test_db, severity="low")
+    await set_scan_webhook_url(test_db, "default", "https://example.invalid/hook")
+
+    mock_send = AsyncMock(side_effect=Exception("boom"))
+    with patch("backend.secuscan.notification_service.send_webhook", mock_send):
+        # Should not raise.
+        await process_scan_completion_webhook(test_db, task_id)
+
+    assert mock_send.call_count == 1
+
+

--- a/testing/backend/unit/test_notification_service.py
+++ b/testing/backend/unit/test_notification_service.py
@@ -923,5 +923,3 @@ async def test_process_scan_completion_webhook_delivery_failure_is_swallowed(tes
         await process_scan_completion_webhook(test_db, task_id)
 
     assert mock_send.call_count == 1
-
-


### PR DESCRIPTION
## Description

Adds webhook notifications on scan completion/failure, as requested in #1615. When a scan transitions to a terminal state (`completed` or `failed`), SecuScan now sends an HTTP POST to a per-user webhook URL configured from the Settings page. The payload includes the target, status, findings by severity, and a link to the full report.

The webhook format is auto-detected from the URL — Slack (`hooks.slack.com`) and Discord (`discord.com` / `discordapp.com`) incoming webhook URLs get their native block/embed payload shapes with zero extra configuration, and any other URL receives a generic JSON payload.

Delivery is fully decoupled from scan execution: failures (invalid URL, unreachable host, non-2xx response, etc.) are caught, logged, and never surface as a scan error or block the scan from completing.

This is implemented as a new, separate concept from the existing per-finding `notification_rules` system (which fires per-finding above a severity threshold). This one fires once per scan, regardless of severity, matching the issue's acceptance criteria.

**Key changes:**

- New `scan_webhook_settings` table (per-owner, one webhook URL each)
- `GET / PUT / DELETE /api/v1/settings/webhook` endpoints for managing the webhook URL, reusing the existing SSRF-protected URL validation
- `notification_service.process_scan_completion_webhook()` — builds the Slack/Discord/generic payload and delivers it via the existing SSRF-hardened `send_webhook()` transport
- Hooked into `executor.py`'s task-completion path, plus the `CapabilityDeniedError` and generic exception handlers, so both successful and failed scans notify
- New Settings page section (`Scan_Completion_Webhook`) to add/update/remove the webhook URL
- Existing global-env Slack notifier (`process_slack_notification`) and the per-finding `notification_rules` system are left untouched

## Related Issues

Closes #1615 

##Screenshot
<img width="1920" height="816" alt="Screenshot (730)" src="https://github.com/user-attachments/assets/cf318552-64f2-476e-9df5-121a350f44d8" />

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

**Backend**

- Added unit tests in `testing/backend/unit/test_notification_service.py` covering: platform detection (`slack`/`discord`/`generic`), payload building for all three formats, CRUD for the webhook setting, and `process_scan_completion_webhook` for completed/failed scans, including that a delivery exception is swallowed and never raised.
- Added integration tests in `testing/backend/integration/test_notification_routes.py` covering the `/settings/webhook` CRUD contract and invalid-URL rejection.
- Ran the full existing suite locally to confirm no regressions:
  - `ruff check backend testing/backend` → clean
  - `pytest testing/backend/unit -q` → 2199+ passed
  - `pytest testing/backend/integration -q` → 283+ passed, 9 skipped

**Frontend**

- Added a vitest case for saving a webhook URL from the Settings UI, and updated the existing `SettingsNotifications.test.tsx` mocks to cover the new API calls.
- Ran `npm run typecheck`, `npm run quality`, `npm run test` (538 passed), and `npm run build` — all clean.

**Manual / end-to-end**

1. Started backend (`python -m secuscan.main`) and frontend (`npm run dev`) locally.
2. Configured a [webhook.site](https://webhook.site) URL from **Settings → Scan_Completion_Webhook** — confirmed it saves, shows the correct detected format, and can be updated/removed.
3. Ran a scan to completion and confirmed a POST landed on webhook.site with the correct target/status/severity counts/report link, plus a matching success line in the backend logs.
4. Repeated for a failed scan and for an invalid/unreachable webhook URL to confirm delivery failure is logged only and does not affect scan execution, per the issue's test plan.

**Reproduce:**

```bash
# backend
pip install -e .
python -m secuscan.main

# frontend
cd frontend && npm ci && npm run dev
```

Then go to **Settings → Scan_Completion_Webhook**, add a webhook.site URL, and run any scan from **Toolkit**.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
