### PR TITLE
fix: resolve Windows Git Bash setup and startup compatibility issues

### DIFF
--- a/frontend/start.sh
+++ b/frontend/start.sh
@@ -23,7 +23,7 @@ if curl -s http://127.0.0.1:8080/api/v1/health > /dev/null 2>&1; then
     echo "✅ Backend is running"
 else
     echo "⚠️  Warning: Backend is not responding at http://127.0.0.1:8080"
-    echo "   Please start the backend first: cd ../backend && python3 -m backend.main"
+    echo "   Please start the backend first: cd ../backend && python -m backend.main"
     echo ""
     read -p "Continue anyway? (y/N): " -n 1 -r
     echo

--- a/setup.sh
+++ b/setup.sh
@@ -41,6 +41,7 @@ find_compatible_python() {
 
     candidates+=(
         "python3"
+        "python"
         "/opt/homebrew/bin/python3"
         "/usr/local/bin/python3"
         "python3.13"
@@ -130,7 +131,20 @@ log_header "Backend Setup"
 # If a venv already exists, verify it was created with a compatible Python.
 # A stale venv built from Python 3.9 would otherwise bypass the version check above and silently re-use the wrong interpreter during pip install.
 if [ -d "venv" ]; then
-    VENV_PYTHON="venv/bin/python3"
+    if [ -d "venv/Scripts" ]; then
+        VENV_BIN="venv/Scripts"
+    else
+        VENV_BIN="venv/bin"
+    fi
+
+    if [ -x "$VENV_BIN/python3" ]; then
+        VENV_PYTHON="$VENV_BIN/python3"
+    elif [ -x "$VENV_BIN/python" ]; then
+        VENV_PYTHON="$VENV_BIN/python"
+    else
+        VENV_PYTHON="$VENV_BIN/python3"
+    fi
+
     if [ ! -x "$VENV_PYTHON" ] || \
        ! "$VENV_PYTHON" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1; then
         VENV_OLD_VER="$("$VENV_PYTHON" --version 2>/dev/null | cut -d' ' -f2 || echo 'unknown')"
@@ -147,8 +161,14 @@ if [ ! -d "venv" ]; then
     log_success "Virtual environment created."
 fi
 
+if [ -d "venv/Scripts" ]; then
+    VENV_BIN="venv/Scripts"
+else
+    VENV_BIN="venv/bin"
+fi
+
 # Activate venv for installation
-source venv/bin/activate
+source "$VENV_BIN/activate"
 log_info "Upgrading pip..."
 pip install --upgrade pip -q
 
@@ -219,7 +239,11 @@ echo "To start the development environment, you can run:"
 echo -e "  ${BOLD}./start.sh${NC}"
 echo ""
 echo "Or start them manually in separate terminals:"
-echo -e "  ${CYAN}Backend:${NC}  source venv/bin/activate && python3 -m uvicorn backend.secuscan.main:app --reload"
+if [ -d "venv/Scripts" ]; then
+    echo -e "  ${CYAN}Backend:${NC}  source venv/Scripts/activate && python -m uvicorn backend.secuscan.main:app --reload"
+else
+    echo -e "  ${CYAN}Backend:${NC}  source venv/bin/activate && python -m uvicorn backend.secuscan.main:app --reload"
+fi
 echo -e "  ${CYAN}Frontend:${NC} cd frontend && npm run dev"
 echo ""
 echo "Access the app at: ${BOLD}http://localhost:5173${NC}"

--- a/start.sh
+++ b/start.sh
@@ -26,8 +26,19 @@ echo ""
 # If ports remain occupied after startup fails, see README.md
 # Troubleshooting → Local Startup Troubleshooting.
 echo "🧹 Cleaning up existing processes on port 8000 and 5173..."
-lsof -ti :8000 | xargs kill -9 2>/dev/null || true
-lsof -ti :5173 | xargs kill -9 2>/dev/null || true
+if command -v lsof &>/dev/null; then
+  lsof -ti :8000 | xargs kill -9 2>/dev/null || true
+  lsof -ti :5173 | xargs kill -9 2>/dev/null || true
+elif command -v netstat &>/dev/null && command -v taskkill &>/dev/null; then
+  for port in 8000 5173; do
+    pids=$(netstat -ano | grep -i LISTENING | grep -E "[:.]$port[[:space:]]" | awk '{print $5}' | tr -d '\r' | sort -u || true)
+    for pid in $pids; do
+      if [ -n "$pid" ] && [[ "$pid" =~ ^[0-9]+$ ]]; then
+        taskkill //F //PID "$pid" &>/dev/null || true
+      fi
+    done
+  done
+fi
 sleep 1
 
 # ── Backend ────────────────────────────────────
@@ -45,13 +56,29 @@ if [ ! -d "$ROOT_DIR/frontend" ]; then
   exit 1
 fi
 
-if [ -d "venv" ]; then
-  source venv/bin/activate
+# Determine python command (must be Python 3.11+)
+PYTHON_CMD=""
+if command -v python3 &>/dev/null && python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' &>/dev/null; then
+  PYTHON_CMD="python3"
+elif command -v python &>/dev/null && python -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' &>/dev/null; then
+  PYTHON_CMD="python"
 else
-  echo "   Creating virtual environment..."
-  python3 -m venv venv
-  source venv/bin/activate
+  echo "ERROR: Python 3.11+ is required to start SecuScan." >&2
+  exit 1
 fi
+
+if [ ! -d "venv" ]; then
+  echo "   Creating virtual environment..."
+  $PYTHON_CMD -m venv venv
+fi
+
+if [ -d "venv/Scripts" ]; then
+  VENV_BIN="venv/Scripts"
+else
+  VENV_BIN="venv/bin"
+fi
+
+source "$VENV_BIN/activate"
 
 pip install -q --upgrade pip
 pip install -q -r backend/requirements.txt
@@ -59,7 +86,7 @@ pip install -q -r backend/requirements.txt
 mkdir -p "$ROOT_DIR/data" "$ROOT_DIR/logs"
 
 echo "🚀 Starting backend on http://127.0.0.1:8000"
-python3 -m uvicorn backend.secuscan.main:app \
+python -m uvicorn backend.secuscan.main:app \
   --host 127.0.0.1 \
   --port 8000 \
   --reload \

--- a/testing/test_python.sh
+++ b/testing/test_python.sh
@@ -9,6 +9,7 @@ cd "$ROOT_DIR"
 find_compatible_python() {
   local candidates=(
     "python3"
+    "python"
     "/opt/homebrew/bin/python3"
     "/usr/local/bin/python3"
     "python3.13"
@@ -34,7 +35,20 @@ find_compatible_python() {
 
 # If a venv already exists, check Python version compatibility
 if [ -d "$VENV_DIR" ]; then
-  VENV_PYTHON="$VENV_DIR/bin/python3"
+  if [ -d "$VENV_DIR/Scripts" ]; then
+    VENV_BIN_DIR="$VENV_DIR/Scripts"
+  else
+    VENV_BIN_DIR="$VENV_DIR/bin"
+  fi
+
+  if [ -x "$VENV_BIN_DIR/python3" ]; then
+    VENV_PYTHON="$VENV_BIN_DIR/python3"
+  elif [ -x "$VENV_BIN_DIR/python" ]; then
+    VENV_PYTHON="$VENV_BIN_DIR/python"
+  else
+    VENV_PYTHON="$VENV_BIN_DIR/python3"
+  fi
+
   if [ ! -x "$VENV_PYTHON" ] || \
      ! "$VENV_PYTHON" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1; then
     echo "Existing venv_tests is incompatible. Recreating..."
@@ -52,7 +66,13 @@ if [ ! -d "$VENV_DIR" ]; then
   "$PYTHON_BIN" -m venv "$VENV_DIR"
 fi
 
-source "$VENV_DIR/bin/activate"
+if [ -d "$VENV_DIR/Scripts" ]; then
+  VENV_BIN_DIR="$VENV_DIR/Scripts"
+else
+  VENV_BIN_DIR="$VENV_DIR/bin"
+fi
+
+source "$VENV_BIN_DIR/activate"
 if ! python -c "import pip" >/dev/null 2>&1; then
   python -m ensurepip --upgrade
 fi


### PR DESCRIPTION
### Summary
This PR resolves the compatibility issues encountered when setting up, running, and testing the SecuScan development environment natively on Windows via Git Bash (MINGW64).

Closes #1531

### Changes Done
1. **Dynamic Virtualenv Resolution (`setup.sh`, `start.sh`, `testing/test_python.sh`)**:
   - Added logic to dynamically check for both `venv/Scripts` (Windows) and `venv/bin` (Linux/macOS) layout.
   - Sourced the correct Unix-compatible shell `activate` script in Git Bash.
2. **Cross-Platform Port Cleanup (`start.sh`)**:
   - Replaced direct `lsof` calls with a fallback chain checking for `netstat` and `taskkill` on Windows.
   - Appended `|| true` to the pipeline commands to prevent `set -euo pipefail` from exiting when no processes are listening on ports 8000/5173.
3. **Portable Python Executable Invocation**:
   - Changed calls to run `python` instead of `python3` inside the virtual environment because Windows venvs only generate `python.exe`.
4. **Instruction Updates (`frontend/start.sh`)**:
   - Updated CLI advice to suggest using `python` instead of `python3`.

### Verification Details
- Verified that all scripts cleanly fallback and resolve correct virtual environment paths.
- Verified that Git Bash correctly runs the setup, dev server, and test suites natively on Windows.
