### PR TITLE
refactor(plugins): decompose build_command, load_plugins, and validat…

### DIFF
--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -33,6 +33,7 @@ class Settings(BaseSettings):
     raw_output_dir: str = str(PROJECT_ROOT / "data" / "raw")
     reports_dir: str = str(PROJECT_ROOT / "data" / "reports")
     plugins_dir: str = str(PROJECT_ROOT.parent / "plugins")
+    disabled_plugins: List[str] = []
     wordlists_dir: str = str(PROJECT_ROOT / "wordlists")
     knowledgebase_dir: str = str(PROJECT_ROOT / "data" / "knowledgebase")
 

--- a/backend/secuscan/parser_sandbox.py
+++ b/backend/secuscan/parser_sandbox.py
@@ -79,6 +79,7 @@ class ParserSandboxError(RuntimeError):
         self.reason = reason
         # Keep stderr private; callers must not surface this to API consumers.
         self._stderr_diagnostic: str = stderr
+        self.stderr_excerpt = stderr[:2000] if stderr else ""
         # User-facing message: reason only — no stderr content.
         super().__init__(f"Parser sandbox failed for '{plugin_id}' ({reason})")
 
@@ -262,7 +263,7 @@ def run_parser_in_sandbox(
             plugin_id,
             _sanitize_stderr(stderr_text),
         )
-        raise ParserSandboxError(plugin_id, f"timed out after {timeout_seconds}s")
+        raise ParserSandboxError(plugin_id, f"timed out after {timeout_seconds}s", stderr_text)
 
     if proc.returncode != 0:
         logger.error(
@@ -280,6 +281,7 @@ def run_parser_in_sandbox(
         raise ParserSandboxError(
             plugin_id,
             f"subprocess exited with code {proc.returncode}",
+            stderr_text,
         )
 
     stdout_bytes = b"".join(stdout_chunks)
@@ -302,6 +304,7 @@ def run_parser_in_sandbox(
         raise ParserSandboxError(
             plugin_id,
             f"parser returned non-JSON output: {exc}",
+            stderr_text,
         )
 
     if not isinstance(parsed, (dict, list)):

--- a/backend/secuscan/plugins.py
+++ b/backend/secuscan/plugins.py
@@ -103,6 +103,19 @@ class PluginManager:
         self.plugins_dir = Path(plugins_dir)
         self.plugins: Dict[str, PluginMetadata] = {}
 
+    def _scan_plugin_dirs(self) -> List[Path]:
+        """Scan the plugins directory for plugin directories."""
+        if not self.plugins_dir.exists():
+            logger.warning(f"Plugins directory does not exist: {self.plugins_dir}")
+            self.plugins_dir.mkdir(parents=True, exist_ok=True)
+            return []
+
+        dirs = []
+        for plugin_dir in self.plugins_dir.iterdir():
+            if plugin_dir.is_dir():
+                dirs.append(plugin_dir)
+        return dirs
+
     async def load_plugins(self) -> int:
         """
         Load all plugins from the plugins directory.
@@ -110,18 +123,10 @@ class PluginManager:
         Returns:
             Number of successfully loaded plugins
         """
-        if not self.plugins_dir.exists():
-            logger.warning(f"Plugins directory does not exist: {self.plugins_dir}")
-            self.plugins_dir.mkdir(parents=True, exist_ok=True)
-            return 0
-
+        plugin_dirs = self._scan_plugin_dirs()
         loaded = 0
 
-        # Scan for plugin directories
-        for plugin_dir in self.plugins_dir.iterdir():
-            if not plugin_dir.is_dir():
-                continue
-
+        for plugin_dir in plugin_dirs:
             metadata_file = plugin_dir / "metadata.json"
             if not metadata_file.exists():
                 logger.warning(f"No metadata.json found in {plugin_dir}")
@@ -160,6 +165,37 @@ class PluginManager:
 
         return PluginMetadata(**data)
 
+    def _validate_engine(self, engine: Dict[str, str], plugin_id: str) -> bool:
+        """Validate plugin engine configuration."""
+        engine_type = engine.get("type")
+        if engine_type not in ["cli", "python", "docker"]:
+            logger.error(f"Invalid engine type: {engine_type}")
+            return False
+
+        if engine_type == "cli":
+            binary = engine.get("binary")
+            if binary and not shutil.which(binary):
+                logger.warning(f"Binary not found in PATH: {binary}")
+        return True
+
+    def _validate_safety(self, safety: Dict[str, Any]) -> bool:
+        """Validate plugin safety configuration."""
+        safety_level = safety.get("level")
+        if safety_level not in ["safe", "intrusive", "exploit"]:
+            logger.error(f"Invalid safety level: {safety_level}")
+            return False
+        return True
+
+    def _validate_capabilities(self, capabilities: Optional[List[str]], plugin_id: str) -> bool:
+        """Validate declared capabilities against the known set."""
+        if capabilities is not None:
+            try:
+                validate_capability_list(capabilities, plugin_id)
+            except ValueError as exc:
+                logger.error("Invalid capabilities in plugin %s: %s", plugin_id, exc)
+                return False
+        return True
+
     async def _validate_plugin(self, plugin: PluginMetadata, plugin_dir: Path) -> bool:
         """
         Validate plugin metadata and dependencies.
@@ -176,36 +212,19 @@ class PluginManager:
             logger.error("Plugin missing required fields: id or name")
             return False
 
-        # Validate engine type
-        if plugin.engine.get("type") not in ["cli", "python", "docker"]:
-            logger.error(f"Invalid engine type: {plugin.engine.get('type')}")
+        if not self._validate_engine(plugin.engine, plugin.id):
             return False
-
-        # Check binary exists for CLI plugins
-        if plugin.engine.get("type") == "cli":
-            binary = plugin.engine.get("binary")
-            if binary and not shutil.which(binary):
-                logger.warning(f"Binary not found in PATH: {binary}")
-                # Don't fail - might be in a non-standard location or added later
 
         # Validate parser exists
         parser_file = plugin_dir / "parser.py"
         if plugin.output.get("parser") == "custom" and not parser_file.exists():
             logger.warning("Custom parser specified but parser.py not found")
 
-        # Validate safety level
-        safety_level = plugin.safety.get("level")
-        if safety_level not in ["safe", "intrusive", "exploit"]:
-            logger.error(f"Invalid safety level: {safety_level}")
+        if not self._validate_safety(plugin.safety):
             return False
 
-        # Validate declared capabilities against the known set
-        if plugin.capabilities is not None:
-            try:
-                validate_capability_list(plugin.capabilities, plugin.id)
-            except ValueError as exc:
-                logger.error("Invalid capabilities in plugin %s: %s", plugin.id, exc)
-                return False
+        if not self._validate_capabilities(plugin.capabilities, plugin.id):
+            return False
 
         if not self._verify_plugin_integrity(plugin, plugin_dir):
             return False
@@ -333,7 +352,7 @@ class PluginManager:
                     "description": plugin.description,
                     "category": plugin.category,
                     "safety_level": plugin.safety.get("level"),
-                    "enabled": True,
+                    "enabled": plugin.id not in settings.disabled_plugins,
                     "icon": plugin.icon,
                     "requires_consent": bool(plugin.safety.get("requires_consent", False)),
                     "consent_message": plugin.safety.get("consent_message"),
@@ -544,6 +563,54 @@ class PluginManager:
                 f"Field '{field_id}' value must not begin with '-': {value!r}"
             )
 
+    def _validate_integer_field(self, field_id: str, value: Any) -> None:
+        """Validate integer field value."""
+        try:
+            int(value)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"Field '{field_id}' expects an integer; got {value!r}"
+            )
+
+    def _validate_boolean_field(self, field_id: str, value: Any) -> None:
+        """Validate boolean field value."""
+        if isinstance(value, bool):
+            return
+        if isinstance(value, str) and value.lower() in ("true", "false", "1", "0"):
+            return
+        raise ValueError(
+            f"Field '{field_id}' expects a boolean; got {value!r}"
+        )
+
+    def _validate_select_field(self, field_id: str, value: Any, options: Optional[List[Dict[str, str]]]) -> None:
+        """Validate select field value against options."""
+        allowed = [opt.get("value") for opt in (options or [])]
+        if value not in allowed:
+            raise ValueError(
+                f"Field '{field_id}' value {value!r} is not in allowed "
+                f"values {allowed}"
+            )
+
+    def _validate_string_field(self, field_id: str, value: Any, validation: Dict[str, Any]) -> None:
+        """Validate string/text field value against patterns and presets."""
+        value_str = str(value)
+
+        # Pattern / validation_type validation from field metadata
+        validation_type = validation.get("validation_type")
+        if validation_type and validation_type in _VALIDATION_PRESETS:
+            preset = _VALIDATION_PRESETS[validation_type]
+            if not preset["pattern"].match(value_str):
+                msg = validation.get("message", preset["message"])
+                raise ValueError(f"Field '{field_id}': {msg}")
+        else:
+            pattern = validation.get("pattern")
+            if pattern and not re.match(pattern, value_str):
+                msg = validation.get("message", f"Value does not match pattern {pattern!r}")
+                raise ValueError(f"Field '{field_id}': {msg}")
+
+        # Reject argv-level flag injection
+        self._reject_injected_args(field_id, value_str)
+
     def _validate_inputs_against_schema(
         self, plugin: PluginMetadata, inputs: Dict[str, Any]
     ) -> None:
@@ -573,51 +640,56 @@ class PluginManager:
                 continue
 
             if field.type == PluginFieldType.INTEGER:
-                try:
-                    int(raw_value)
-                except (TypeError, ValueError):
-                    raise ValueError(
-                        f"Field '{field_id}' expects an integer; got {raw_value!r}"
-                    )
-                continue
+                self._validate_integer_field(field_id, raw_value)
 
-            if field.type == PluginFieldType.BOOLEAN:
-                if isinstance(raw_value, bool):
-                    continue
-                if isinstance(raw_value, str) and raw_value.lower() in ("true", "false", "1", "0"):
-                    continue
-                raise ValueError(
-                    f"Field '{field_id}' expects a boolean; got {raw_value!r}"
-                )
+            elif field.type == PluginFieldType.BOOLEAN:
+                self._validate_boolean_field(field_id, raw_value)
 
-            if field.type == PluginFieldType.SELECT:
-                allowed = [opt.get("value") for opt in (field.options or [])]
-                if raw_value not in allowed:
-                    raise ValueError(
-                        f"Field '{field_id}' value {raw_value!r} is not in allowed "
-                        f"values {allowed}"
-                    )
-                continue
+            elif field.type == PluginFieldType.SELECT:
+                self._validate_select_field(field_id, raw_value, field.options)
 
-            if field.type in (PluginFieldType.STRING, PluginFieldType.TEXT):
-                value_str = str(raw_value)
+            elif field.type in (PluginFieldType.STRING, PluginFieldType.TEXT):
+                self._validate_string_field(field_id, raw_value, field.validation or {})
 
-                # Pattern / validation_type validation from field metadata
-                validation = field.validation or {}
-                validation_type = validation.get("validation_type")
-                if validation_type and validation_type in _VALIDATION_PRESETS:
-                    preset = _VALIDATION_PRESETS[validation_type]
-                    if not preset["pattern"].match(value_str):
-                        msg = validation.get("message", preset["message"])
-                        raise ValueError(f"Field '{field_id}': {msg}")
-                else:
-                    pattern = validation.get("pattern")
-                    if pattern and not re.match(pattern, value_str):
-                        msg = validation.get("message", f"Value does not match pattern {pattern!r}")
-                        raise ValueError(f"Field '{field_id}': {msg}")
+    def _evaluate_conditional_token(self, token: str, inputs: Dict[str, Any]) -> List[str]:
+        """Evaluate conditional command template token (--if:)."""
+        parts = token.split(":")
+        if len(parts) < 4 or parts[2] != "then":
+            return []
 
-                # Reject argv-level flag injection
-                self._reject_injected_args(field_id, value_str)
+        condition_var = parts[1]
+
+        # Correctly identify then/else segments
+        try:
+            else_idx = parts.index("else")
+            then_parts = parts[3:else_idx]
+            else_parts = parts[else_idx + 1:]
+        except ValueError:
+            then_parts = parts[3:]
+            else_parts = []
+
+        condition = inputs.get(condition_var, False)
+        # For booleans or non-empty existence
+        if isinstance(condition, str) and condition.lower() == "false":
+            condition = False
+
+        active_parts = then_parts if condition else else_parts
+        rendered = []
+        for part in active_parts:
+            if interpolated := self._interpolate(part, inputs):
+                rendered.append(interpolated)
+        return rendered
+
+    def _render_command_tokens(self, command_template: List[str], inputs: Dict[str, Any]) -> List[str]:
+        """Render all tokens from command template using user inputs."""
+        command = []
+        for token in command_template:
+            if token.startswith("--if:"):
+                command.extend(self._evaluate_conditional_token(token, inputs))
+            else:
+                if interpolated := self._interpolate(token, inputs):
+                    command.append(interpolated)
+        return command
 
     def build_command(self, plugin_id: str, inputs: Dict) -> Optional[List[str]]:
         """
@@ -644,42 +716,7 @@ class PluginManager:
         # Validate before normalisation so SELECT checks run against raw user values
         self._validate_inputs_against_schema(plugin, inputs)
         inputs = self._normalize_inputs(plugin, inputs)
-        command = []
-
-        for token in plugin.command_template:
-            # Handle conditionals:
-            # --if:condition:then:value
-            # --if:condition:then:value:else:fallback
-            if token.startswith("--if:"):
-                parts = token.split(":")
-                if len(parts) >= 4 and parts[2] == "then":
-                    condition_var = parts[1]
-
-                    # Correctly identify then/else segments
-                    try:
-                        else_idx = parts.index("else")
-                        then_parts = parts[3:else_idx]
-                        else_parts = parts[else_idx+1:]
-                    except ValueError:
-                        then_parts = parts[3:]
-                        else_parts = []
-
-                    condition = inputs.get(condition_var, False)
-                    # For booleans or non-empty existence
-                    if isinstance(condition, str) and condition.lower() == "false":
-                        condition = False
-
-                    active_parts = then_parts if condition else else_parts
-
-                    for part in active_parts:
-                        if interpolated := self._interpolate(part, inputs):
-                            command.append(interpolated)
-                continue
-
-            if interpolated := self._interpolate(token, inputs):
-                command.append(interpolated)
-
-        return command
+        return self._render_command_tokens(plugin.command_template, inputs)
 
 # Global plugin manager instance
 plugin_manager: Optional[PluginManager] = None

--- a/backend/secuscan/plugins.py
+++ b/backend/secuscan/plugins.py
@@ -624,8 +624,9 @@ class PluginManager:
                 msg = validation.get("message", f"Value does not match pattern {pattern!r}")
                 raise ValueError(f"Field '{field_id}': {msg}")
 
-        # Reject argv-level flag injection
+        # Reject argv-level flag injection and filesystem path traversal
         self._reject_injected_args(field_id, value_str)
+        self._reject_path_traversal(value_str)
 
     def _validate_inputs_against_schema(
         self, plugin: PluginMetadata, inputs: Dict[str, Any]

--- a/testing/backend/unit/test_api_auth.py
+++ b/testing/backend/unit/test_api_auth.py
@@ -6,6 +6,7 @@ import asyncio
 import tempfile
 from pathlib import Path
 
+import sys
 import pytest
 from fastapi.testclient import TestClient
 
@@ -37,6 +38,7 @@ class TestApiKeyInit:
         k2 = auth_module.init_api_key(str(tmp_path))
         assert k1 == k2
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file permission bits are not supported on Windows")
     def test_key_file_permissions(self, tmp_path):
         auth_module.init_api_key(str(tmp_path))
         mode = (tmp_path / ".api_key").stat().st_mode & 0o777

--- a/testing/backend/unit/test_auth.py
+++ b/testing/backend/unit/test_auth.py
@@ -13,6 +13,7 @@ Covers:
 import os
 import stat
 import tempfile
+import pytest
 from pathlib import Path
 
 # Patch out the module-level _api_key before importing init_api_key
@@ -64,6 +65,7 @@ class TestInitApiKey:
         # No .api_key in data_dir either
         assert not (tmp_path / ".api_key").exists()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file permission bits are not supported on Windows")
     def test_file_mode_is_0600(self, tmp_path: Path):
         """The key file is created with mode 0o600 (owner rw only)."""
         fresh_key(str(tmp_path))

--- a/testing/backend/unit/test_parser_sandbox_timeout_cleanup.py
+++ b/testing/backend/unit/test_parser_sandbox_timeout_cleanup.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import subprocess
 import pytest
 import time
+import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -34,8 +35,8 @@ class TestParserSandboxTimeoutCleanup:
 
         with pytest.raises(subprocess.TimeoutExpired):
             proc = subprocess.Popen(
-                ["python3", "-c", _BOOTSTRAP_TEMPLATE.format(
-                    parser_path=str(parser),
+                ["python3", "-c", _BOOTSTRAP_TEMPLATE.safe_substitute(
+                    parser_path_repr=repr(str(parser)),
                     max_input_bytes=1024,
                 )],
                 stdin=subprocess.PIPE,
@@ -93,9 +94,9 @@ class TestParserSandboxTimeoutCleanup:
         with pytest.raises(Exception) as exc_info:
             run_parser_in_sandbox(parser, "stderr_plugin", "data", timeout_seconds=1)
 
-        exc_message = str(exc_info.value)
-        assert "early error" in exc_message
+        assert "early error" in exc_info.value.stderr_excerpt
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="resource module and /proc/pid/fd are not available on Windows")
     def test_multiple_consecutive_timeouts_do_not_leak_resources(self, tmp_path):
         """Running multiple timeouts in sequence must not accumulate open file handles."""
         from backend.secuscan.parser_sandbox import run_parser_in_sandbox

--- a/testing/backend/unit/test_plugins_enable_disable.py
+++ b/testing/backend/unit/test_plugins_enable_disable.py
@@ -1,0 +1,61 @@
+import asyncio
+import pytest
+from backend.secuscan.config import settings
+from backend.secuscan.plugins import PluginManager
+
+
+def test_plugins_list_defaults_to_enabled(setup_test_environment):
+    """By default, all loaded plugins should have enabled=True."""
+    manager = PluginManager(settings.plugins_dir)
+    asyncio.run(manager.load_plugins())
+
+    plugins = manager.list_plugins()
+    assert len(plugins) > 0
+    for plugin in plugins:
+        assert plugin["enabled"] is True
+
+
+def test_plugins_list_reflects_disabled_settings(setup_test_environment, monkeypatch):
+    """Plugins specified in settings.disabled_plugins should have enabled=False."""
+    manager = PluginManager(settings.plugins_dir)
+    asyncio.run(manager.load_plugins())
+
+    # Verify we have the target plugin loaded first
+    target_id = "http_inspector"
+    original_plugin = manager.get_plugin(target_id)
+    assert original_plugin is not None
+
+    # Disable the target plugin via settings
+    monkeypatch.setattr(settings, "disabled_plugins", [target_id])
+
+    plugins = manager.list_plugins()
+    by_id = {p["id"]: p for p in plugins}
+
+    # Verify the target plugin is reported as disabled
+    assert by_id[target_id]["enabled"] is False
+
+    # Verify other plugins remain enabled
+    for p_id, plugin in by_id.items():
+        if p_id != target_id:
+            assert plugin["enabled"] is True
+
+
+def test_disabled_plugins_remain_executable_for_compatibility(setup_test_environment, monkeypatch):
+    """Disabled plugins should still build commands normally to preserve backward compatibility."""
+    manager = PluginManager(settings.plugins_dir)
+    asyncio.run(manager.load_plugins())
+
+    target_id = "http_inspector"
+    monkeypatch.setattr(settings, "disabled_plugins", [target_id])
+
+    # Command generation should succeed even if disabled
+    command = manager.build_command(
+        target_id,
+        {
+            "url": "http://127.0.0.1",
+            "follow_redirects": True,
+        },
+    )
+
+    assert command is not None
+    assert "curl" in command

--- a/testing/backend/unit/test_process_tree_cancellation.py
+++ b/testing/backend/unit/test_process_tree_cancellation.py
@@ -22,6 +22,8 @@ import pytest
 import pytest_asyncio
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Process tree cancellation is Unix-only")
+
 from backend.secuscan.executor import _terminate_process_group, _CANCEL_GRACE_SECONDS
 
 


### PR DESCRIPTION
## Description
This Pull Request refactors the `PluginManager` in `backend/secuscan/plugins.py` to make the code simpler, cleaner, and easier to maintain. Specifically, it breaks down three large, complex methods (`load_plugins`, `_validate_inputs_against_schema`, and `build_command`) into smaller, single-purpose helper functions.

Additionally, this PR adds a configuration setting (`disabled_plugins` in `Settings`) to allow disabling specific plugins by listing their IDs, while maintaining backward compatibility so they can still be run if needed.

Finally, this PR resolves regression failures caused by merge conflicts and makes Unix-specific test cases compatible when running on Windows.

## Related Issues
<!-- Link any related issues using #issue-number. -->

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
I ran the entire backend unit test suite:
- Command: `.\venv\Scripts\pytest testing/backend/unit`
- Result: **2200 tests passed, 19 skipped** (Unix-specific tests like process groups and permissions are gracefully skipped on Windows).

I also added new tests in `testing/backend/unit/test_plugins_enable_disable.py` to verify:
1. Plugins default to being enabled.
2. Plugins listed in the disabled settings are correctly returned as disabled.
3. Disabled plugins remain executable for backward compatibility.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.

note :- though i used Ai to solve the issue but i definitly understand the changes made by ai and also did checked it myself and by an another i also