### PR TITLE
test : added parser unit tests for volatility plugin

### DIFF
--- a/testing/backend/unit/test_volatility_plugin.py
+++ b/testing/backend/unit/test_volatility_plugin.py
@@ -1,0 +1,82 @@
+"""Parser and contract coverage for plugins/volatility."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Derive the plugins directory relative to this test file.
+_PLUGINS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "plugins"
+PARSER_PATH = _PLUGINS_DIR / "volatility" / "parser.py"
+
+
+def _load_volatility_parser():
+    spec = importlib.util.spec_from_file_location("volatility_parser", PARSER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_volatility_parser_multiple_rows():
+    parser = _load_volatility_parser()
+    output = "PID    Name    ImageBase\n100    explorer    0x00a00000\n200    svchost    0x00b00000\n300    chrome    0x00c00000"
+    parsed = parser.parse(output)
+    assert parsed["count"] == 3
+    assert len(parsed["findings"]) == 3
+    assert parsed["findings"][0]["category"] == "Memory Forensics"
+    assert parsed["findings"][0]["severity"] == "medium"
+    assert parsed["findings"][0]["metadata"]["header"] == "PID    Name    ImageBase"
+    assert parsed["findings"][0]["metadata"]["row"] == "100    explorer    0x00a00000"
+
+
+def test_volatility_parser_empty_output():
+    parser = _load_volatility_parser()
+    parsed = parser.parse("")
+    assert parsed["count"] == 0
+    assert parsed["findings"] == []
+
+
+def test_volatility_parser_header_only():
+    parser = _load_volatility_parser()
+    output = "PID    Name    ImageBase"
+    parsed = parser.parse(output)
+    assert parsed["count"] == 0
+    assert parsed["findings"] == []
+
+
+def test_volatility_parser_more_than_25_rows():
+    parser = _load_volatility_parser()
+    header = "Offset    PID    Name"
+    rows = "\n".join(f"{i*0x1000:08x}    {100+i}    proc_{100+i}" for i in range(1, 31))
+    output = header + "\n" + rows
+    parsed = parser.parse(output)
+    assert parsed["count"] == 26  # 25 artifact rows + 1 truncation row
+    assert len(parsed["findings"]) == 26
+    # The last finding should be the truncation notice
+    truncation_finding = parsed["findings"][-1]
+    assert truncation_finding["title"] == "Volatility Output Truncated"
+    assert truncation_finding["metadata"]["total_rows"] == 30
+
+
+def test_volatility_parser_exactly_25_rows():
+    parser = _load_volatility_parser()
+    header = "Offset    PID    Name"
+    rows = "\n".join(f"{i*0x1000:08x}    {i}    proc_{i}" for i in range(1, 26))
+    output = header + "\n" + rows
+    parsed = parser.parse(output)
+    assert parsed["count"] == 25
+    # No truncation finding since exactly 25 rows
+    titles = [f["title"] for f in parsed["findings"]]
+    assert "Volatility Output Truncated" not in titles
+
+
+def test_volatility_parser_whitespace_only_lines_skipped():
+    parser = _load_volatility_parser()
+    output = "Offset    PID\n  \n  \n0x1000    100"
+    parsed = parser.parse(output)
+    # Only the actual data row should be a finding, whitespace lines skipped
+    assert parsed["count"] == 1
+    assert parsed["findings"][0]["metadata"]["row"] == "0x1000    100"


### PR DESCRIPTION
Closes #1668.

Summary of What Has Been Done:

Added testing/backend/unit/test_volatility_plugin.py covering the volatility plugin parser at plugins/volatility/parser.py. The parser treats the first non-empty line as a header and subsequent lines (up to 25) as memory artifact rows, with a truncation notice when output exceeds 25 rows.

Changes Made:

- test_volatility_parser_multiple_rows: verifies multi-row output with header/data split
- test_volatility_parser_empty_output: verifies empty output returns empty findings
- test_volatility_parser_header_only: verifies header-only input returns count 0
- test_volatility_parser_more_than_25_rows: verifies 25 artifact findings plus truncation finding
- test_volatility_parser_exactly_25_rows: verifies exactly 25 rows with no truncation finding
- test_volatility_parser_whitespace_only_lines_skipped: verifies whitespace-only lines are not treated as findings

Impact it Made:

- Validates the 25-row truncation guard that prevents unbounded memory usage on large memory dumps
- Ensures the header/data split works correctly for real Volatility output formats
- Covers graceful handling of empty and malformed inputs

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.