### PR TITLE
test : added parser unit tests for ssh_runner plugin

### DIFF
--- a/testing/backend/unit/test_ssh_runner_plugin.py
+++ b/testing/backend/unit/test_ssh_runner_plugin.py
@@ -1,0 +1,72 @@
+"""Parser and contract coverage for plugins/ssh_runner."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Derive the plugins directory relative to this test file.
+_PLUGINS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "plugins"
+PARSER_PATH = _PLUGINS_DIR / "ssh_runner" / "parser.py"
+
+
+def _load_ssh_runner_parser():
+    spec = importlib.util.spec_from_file_location("ssh_runner_parser", PARSER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ssh_runner_clean_output():
+    parser = _load_ssh_runner_parser()
+    output = "Disk usage: 45%\nMemory: 2.1 GB free"
+    parsed = parser.parse(output)
+    assert len(parsed["findings"]) == 1
+    finding = parsed["findings"][0]
+    assert finding["title"] == "SSH Command Executed Successfully"
+    assert finding["severity"] == "info"
+    assert finding["category"] == "Remote Execution"
+    assert parsed["raw_output"] == output
+
+
+def test_ssh_runner_permission_denied():
+    parser = _load_ssh_runner_parser()
+    output = "Permission denied for user admin"
+    parsed = parser.parse(output)
+    assert len(parsed["findings"]) == 1
+    finding = parsed["findings"][0]
+    assert finding["title"] == "SSH Execution Failed / Error"
+    assert finding["severity"] == "medium"
+
+
+def test_ssh_runner_connection_refused():
+    parser = _load_ssh_runner_parser()
+    output = "ssh: connect to host 10.0.0.1 port 22: Connection refused"
+    parsed = parser.parse(output)
+    assert len(parsed["findings"]) == 1
+    finding = parsed["findings"][0]
+    assert finding["title"] == "SSH Execution Failed / Error"
+    assert finding["severity"] == "medium"
+
+
+def test_ssh_runner_both_failure_indicators():
+    parser = _load_ssh_runner_parser()
+    output = "Permission denied\nConnection refused"
+    parsed = parser.parse(output)
+    assert len(parsed["findings"]) == 1
+    finding = parsed["findings"][0]
+    assert finding["title"] == "SSH Execution Failed / Error"
+    assert finding["severity"] == "medium"
+
+
+def test_ssh_runner_empty_output():
+    parser = _load_ssh_runner_parser()
+    parsed = parser.parse("")
+    assert len(parsed["findings"]) == 1
+    finding = parsed["findings"][0]
+    # Empty output still produces the default successful-info finding
+    assert finding["title"] == "SSH Command Executed Successfully"
+    assert finding["severity"] == "info"


### PR DESCRIPTION
Closes #1670.

Summary of What Has Been Done:

Added testing/backend/unit/test_ssh_runner_plugin.py covering the ssh_runner plugin parser at plugins/ssh_runner/parser.py. The parser captures SSH command output and detects failure indicators (Permission denied, Connection refused) to escalate severity.

Changes Made:

- test_ssh_runner_clean_output: verifies info-severity finding with raw_output capture
- test_ssh_runner_permission_denied: verifies medium severity and updated title on Permission denied
- test_ssh_runner_connection_refused: verifies medium severity and updated title on Connection refused
- test_ssh_runner_both_failure_indicators: verifies both indicators present triggers severity upgrade
- test_ssh_runner_empty_output: verifies empty output still returns a default successful finding

Impact it Made:

- Ensures SSH failure indicators are correctly detected and severity is escalated
- Validates that successful command output is captured without false severity changes
- Provides regression coverage for the failure detection logic

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.