### PR TITLE
test : added unit tests for get_delivery_configuration in notification_service

### DIFF
--- a/testing/backend/unit/test_notification_service_delivery_config.py
+++ b/testing/backend/unit/test_notification_service_delivery_config.py
@@ -1,0 +1,58 @@
+"""
+Unit tests for get_delivery_configuration in notification_service.
+
+Tests that the function returns the correct static configuration dict
+for webhook/email delivery parameters.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.secuscan.notification_service import get_delivery_configuration
+
+
+class TestGetDeliveryConfiguration:
+    def test_returns_expected_keys(self):
+        """All required keys must be present in the returned dict."""
+        cfg = get_delivery_configuration()
+        assert "webhook_timeout_seconds" in cfg
+        assert "webhook_connect_timeout_seconds" in cfg
+        assert "max_retries" in cfg
+        assert "backoff_factor_seconds" in cfg
+
+    def test_webhook_timeout_is_positive_number(self):
+        """webhook_timeout_seconds must be a positive number (int or float)."""
+        cfg = get_delivery_configuration()
+        assert isinstance(cfg["webhook_timeout_seconds"], (int, float))
+        assert cfg["webhook_timeout_seconds"] > 0
+
+    def test_webhook_connect_timeout_is_positive_number(self):
+        """webhook_connect_timeout_seconds must be a positive number (int or float)."""
+        cfg = get_delivery_configuration()
+        assert isinstance(cfg["webhook_connect_timeout_seconds"], (int, float))
+        assert cfg["webhook_connect_timeout_seconds"] > 0
+
+    def test_max_retries_is_zero(self):
+        """max_retries is currently 0 (no retries configured)."""
+        cfg = get_delivery_configuration()
+        assert cfg["max_retries"] == 0
+
+    def test_backoff_factor_is_zero(self):
+        """backoff_factor_seconds is currently 0.0."""
+        cfg = get_delivery_configuration()
+        assert cfg["backoff_factor_seconds"] == 0.0
+
+    def test_returns_new_dict_each_call(self):
+        """Each call returns an independent dict — no shared mutable state."""
+        cfg1 = get_delivery_configuration()
+        cfg2 = get_delivery_configuration()
+        assert cfg1 is not cfg2
+        cfg1["webhook_timeout_seconds"] = 999
+        assert cfg2["webhook_timeout_seconds"] != 999
+
+    def test_timeout_values_are_reasonable(self):
+        """Timeout values should be within reasonable bounds (<300s)."""
+        cfg = get_delivery_configuration()
+        assert cfg["webhook_timeout_seconds"] < 300
+        assert cfg["webhook_connect_timeout_seconds"] < 300


### PR DESCRIPTION
Closes #1706.

Summary of What Has Been Done:
Added `testing/backend/unit/test_notification_service_delivery_config.py` with 7 unit tests covering `get_delivery_configuration` in `backend/secuscan/notification_service.py`.

Changes Made:
- `test_returns_expected_keys`: verifies all 4 required keys are present
- `test_webhook_timeout_is_positive_number`: webhook_timeout_seconds is a positive number
- `test_webhook_connect_timeout_is_positive_number`: webhook_connect_timeout_seconds is a positive number
- `test_max_retries_is_zero`: max_retries equals 0
- `test_backoff_factor_is_zero`: backoff_factor_seconds equals 0.0
- `test_returns_new_dict_each_call`: each call returns an independent dict (no shared mutable state)
- `test_timeout_values_are_reasonable`: timeout values are < 300s

Impact it Made:
- Brings the static delivery configuration function under test coverage
- Prevents accidental changes to critical timeout and retry values
- Documents the expected shape of the delivery configuration

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.