### PR TITLE
test : added explicit None input test for scanner normalize_severity

### DIFF
--- a/testing/backend/unit/test_scanners_base.py
+++ b/testing/backend/unit/test_scanners_base.py
@@ -154,3 +154,8 @@ class TestNormalizeSeverity:
     def test_non_string_input(self):
         scanner = _ConcreteScanner("task21", None)
         assert scanner.normalize_severity(123) == "info"
+
+    def test_none_input_returns_info(self):
+        """None is a common input in real pipelines — str(None)='None' is not in the mapping, so returns 'info'."""
+        scanner = _ConcreteScanner("task_none", None)
+        assert scanner.normalize_severity(None) == "info"


### PR DESCRIPTION
Closes #1708.

Summary of What Has Been Done:
Added a single test `test_none_input_returns_info` to `testing/backend/unit/test_scanners_base.py` inside the `TestNormalizeSeverity` class.

The existing `test_non_string_input` test covers numeric input (123) returning "info", but `None` as an explicit input value was not tested. `str(None)` produces `"None"` which is not in the severity mapping, so the function returns `"info"`. This behavior is now made explicit.

Changes Made:
```python
def test_none_input_returns_info(self):
    """None is a common input in real pipelines — str(None)="None" is not in the mapping, so returns "info"."""
    scanner = _ConcreteScanner("task_none", None)
    assert scanner.normalize_severity(None) == "info"
```

Impact it Made:
- Documents the None input expectation explicitly
- Prevents accidental regression if the str() coercion logic changes

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.