### PR TITLE
fix: tighten API client response types

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -391,8 +391,15 @@ export function getPluginSchema(id: string) {
   return request<PluginSchemaResponse>(`/plugin/${id}/schema`)
 }
 
-export function getSettings() {
-  return request<any>(`/settings`)
+export interface SettingsResponse {
+  execution_context?: {
+    default?: ExecutionContext
+  }
+  [key: string]: unknown
+}
+
+export function getSettings(): Promise<SettingsResponse | null> {
+  return request<SettingsResponse | null>('/settings')
 }
 
 export function getDashboardSummary() {
@@ -453,7 +460,7 @@ export interface NotificationRuleUpdatePayload {
 }
 
 export async function listNotificationRules(): Promise<NotificationRule[]> {
-  const data: any = await request('/notifications/rules')
+  const data = await request<NotificationRule[] | { rules: NotificationRule[] }>('/notifications/rules')
   const rules = Array.isArray(data) ? data : data?.rules
   return Array.isArray(rules) ? (rules as NotificationRule[]) : []
 }
@@ -490,7 +497,12 @@ export async function listNotificationHistory(params?: {
   if (typeof params?.limit === 'number') sp.set('limit', String(params.limit))
   if (typeof params?.offset === 'number') sp.set('offset', String(params.offset))
   const suffix = sp.toString() ? `?${sp.toString()}` : ''
-  const data: any = await request(`/notifications/history${suffix}`)
+  const data = await request<{
+    history?: NotificationHistoryRow[]
+    total?: number
+    limit?: number
+    offset?: number
+  }>(`/notifications/history${suffix}`)
   return {
     history: Array.isArray(data?.history) ? (data.history as NotificationHistoryRow[]) : [],
     total: Number(data?.total ?? 0),
@@ -532,12 +544,21 @@ export function getTasks(params?: URLSearchParams) {
 
 export type ScanPhase = 'queued' | 'running_command' | 'parsing' | 'reporting' | 'finished'
 
-export function getTaskStatus(taskId: string): Promise<any> {
-  return request<any>(`/task/${taskId}/status`)
+export interface TaskStatusResponse {
+  task_id?: string
+  status: string
+  phase?: ScanPhase
+  progress?: number
+  message?: string
+  error_message?: string | null
 }
 
-export function getTaskResult(taskId: string): Promise<any> {
-  return request<TaskResultResponse>(`/task/${taskId}/result`)
+export function getTaskStatus(taskId: string): Promise<TaskStatusResponse> {
+  return request<TaskStatusResponse>(`/task/${taskId}/status`)
+}
+
+export function getTaskResult(taskId: string): Promise<TaskResultResponse | null> {
+  return request<TaskResultResponse | null>(`/task/${taskId}/result`)
 }
 
 export function getTaskDiff(taskId: string): Promise<ScanDiff> {
@@ -636,8 +657,26 @@ export interface WorkflowUpdatePayload {
 }
 
 interface WorkflowListResponse {
-  workflows: unknown[]
+  workflows: RawWorkflow[]
   total: number
+}
+
+interface RawWorkflow {
+  id: unknown
+  name?: unknown
+  schedule_seconds?: unknown
+  enabled?: unknown
+  steps?: unknown
+  steps_json?: unknown
+  last_run_at?: string | null
+  queued_task_ids?: unknown
+  queued_tasks?: unknown
+  created_at?: string
+}
+
+interface WorkflowRunResponse {
+  queued_task_ids?: string[]
+  queued_tasks?: string[]
 }
 
 function parseWorkflowSteps(value: unknown): WorkflowStep[] {
@@ -658,7 +697,7 @@ function parseScheduleSeconds(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
-function normalizeWorkflow(raw: any): Workflow {
+function normalizeWorkflow(raw: RawWorkflow): Workflow {
   return {
     id: String(raw.id),
     name: String(raw.name ?? ''),
@@ -676,13 +715,13 @@ function normalizeWorkflow(raw: any): Workflow {
 }
 
 export async function getWorkflows(): Promise<Workflow[]> {
-  const data = await request<WorkflowListResponse | unknown[]>('/workflows')
+  const data = await request<WorkflowListResponse | RawWorkflow[]>('/workflows')
   const workflows = Array.isArray(data) ? data : data.workflows
   return Array.isArray(workflows) ? workflows.map(normalizeWorkflow) : []
 }
 
 export async function createWorkflow(data: WorkflowCreatePayload): Promise<Workflow> {
-  const workflow = await request<unknown>('/workflows', {
+  const workflow = await request<RawWorkflow>('/workflows', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
@@ -691,7 +730,7 @@ export async function createWorkflow(data: WorkflowCreatePayload): Promise<Workf
 }
 
 export async function runWorkflow(workflowId: string): Promise<{ queued_task_ids: string[] }> {
-  const result: any = await request(`/workflows/${workflowId}/run`, {
+  const result = await request<WorkflowRunResponse>(`/workflows/${workflowId}/run`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
   })
@@ -705,7 +744,7 @@ export async function runWorkflow(workflowId: string): Promise<{ queued_task_ids
 }
 
 export async function updateWorkflow(workflowId: string, data: WorkflowUpdatePayload): Promise<Workflow> {
-  const workflow = await request<unknown>(`/workflows/${workflowId}`, {
+  const workflow = await request<RawWorkflow>(`/workflows/${workflowId}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
@@ -764,7 +803,7 @@ export async function rollbackWorkflow(workflowId: string, versionNumber: number
     workflow_id: string
     rolled_back_to_version: number
     new_version_number: number
-    workflow: any
+    workflow: RawWorkflow
   }>(`/workflows/${workflowId}/rollback/${versionNumber}`, {
     method: 'POST',
   })

--- a/frontend/testing/unit/hooks/useTaskSubscription.test.ts
+++ b/frontend/testing/unit/hooks/useTaskSubscription.test.ts
@@ -153,7 +153,7 @@ describe('useTaskSubscription', () => {
   })
 
   it('stops polling on terminal status', async () => {
-    let resolveGetTaskStatus: (value: unknown) => void
+    let resolveGetTaskStatus: (value: Awaited<ReturnType<typeof getTaskStatus>>) => void
     vi.mocked(getTaskStatus).mockImplementation(() => new Promise(resolve => {
       resolveGetTaskStatus = resolve
     }))


### PR DESCRIPTION
## Description
Tightens frontend API client response typing by replacing `any` return values with explicit response interfaces and typed request contracts.

Changes include:
- Added explicit response types for settings and task status endpoints.
- Typed notification rules and notification history responses.
- Added raw workflow and workflow execution response types.
- Updated task result typing to reflect nullable responses.
- Updated the task subscription test resolver type to match the typed `getTaskStatus` response.

## Related Issues
Closes #1406 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- Ran `npm run typecheck` successfully.
- Ran targeted frontend tests successfully: 21 tests passed.
- Ran the full frontend test suite successfully: 530 tests passed across 59 test files.
- Ran `npm run build` successfully.
- Ran `git diff --check` successfully.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
