### PR TITLE
fix: log blocked and failed scan attempts to the audit trail

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -324,9 +324,18 @@ async def start_task(
     if not ok:
         raise HTTPException(status_code=status_code, detail=error_msg)
 
+    db = await get_db()
+
     # Validate consent
     if settings.require_consent and not request.consent_granted:
         logger.warning(f"Task start failed: Consent not granted. Request: {request}")
+        await db.log_audit(
+            "scan_blocked_consent",
+            f"Scan start blocked: consent not granted for plugin {request.plugin_id}",
+            severity="warning",
+            context={"plugin_id": request.plugin_id},
+            plugin_id=request.plugin_id,
+        )
         raise HTTPException(
             status_code=400,
             detail="Consent required. You must acknowledge the legal notice."
@@ -349,7 +358,6 @@ async def start_task(
         logger.warning("Task start failed: %s", preset_error)
         raise HTTPException(status_code=400, detail=preset_error)
 
-    db = await get_db()
     target_policy = await get_target_policy(db, owner, execution_context.get("target_policy_id"))
     credential_profile = await get_credential_profile(db, owner, execution_context.get("credential_profile_id"))
     session_profile = await get_session_profile(db, owner, execution_context.get("session_profile_id"))
@@ -423,6 +431,18 @@ async def start_task(
 
             if not is_valid:
                 logger.warning(f"Task start failed: Target validation failed for '{target}': {error_msg}")
+                await db.log_audit(
+                    "scan_blocked_target_validation",
+                    f"Scan start blocked: target validation failed for plugin {request.plugin_id}",
+                    severity="warning",
+                    context={
+                        "plugin_id": request.plugin_id,
+                        "target": target_str,
+                        "safe_mode": safe_mode,
+                        "reason": error_msg,
+                    },
+                    plugin_id=request.plugin_id,
+                )
                 raise HTTPException(status_code=400, detail=error_msg)
 
     # Check rate limits per (client, plugin) so one client cannot exhaust

--- a/testing/backend/integration/test_scan_block_audit_log.py
+++ b/testing/backend/integration/test_scan_block_audit_log.py
@@ -1,0 +1,87 @@
+"""
+Integration tests: blocked/failed scan attempts create an audit trail.
+
+Covers the fix for the bug where scans rejected by the consent gate or
+blocked by safe-mode target validation left no entry in the audit log,
+making it impossible for an administrator to reconstruct misuse attempts
+after the fact.
+"""
+
+import json
+import asyncio
+
+from backend.secuscan.database import get_db
+
+
+async def get_audit_entries(event_type: str, plugin_id: str):
+    db = await get_db()
+    return await db.fetchall(
+        "SELECT event_type, message, severity, context_json, plugin_id "
+        "FROM audit_log WHERE event_type = ? AND plugin_id = ?",
+        (event_type, plugin_id),
+    )
+
+
+def test_consent_rejection_creates_audit_entry(test_client):
+    """A scan blocked by the consent gate must leave an audit trail."""
+    response = test_client.post(
+        "/api/v1/task/start",
+        json={
+            "plugin_id": "amass",
+            "inputs": {"target": "192.168.1.1"},
+            "consent_granted": False,
+        },
+    )
+    assert response.status_code == 400
+
+    entries = asyncio.run(get_audit_entries("scan_blocked_consent", "amass"))
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["severity"] == "warning"
+    assert entry["plugin_id"] == "amass"
+
+    ctx = json.loads(entry["context_json"])
+    assert ctx["plugin_id"] == "amass"
+
+
+def test_safe_mode_target_validation_creates_audit_entry(test_client):
+    """A scan blocked by safe-mode target validation must leave an audit trail."""
+    response = test_client.post(
+        "/api/v1/task/start",
+        json={
+            "plugin_id": "amass",
+            "inputs": {"target": "8.8.8.8"},
+            "consent_granted": True,
+        },
+    )
+    assert response.status_code == 400
+
+    entries = asyncio.run(get_audit_entries("scan_blocked_target_validation", "amass"))
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["severity"] == "warning"
+    assert entry["plugin_id"] == "amass"
+
+    ctx = json.loads(entry["context_json"])
+    assert ctx["plugin_id"] == "amass"
+    assert ctx["target"] == "8.8.8.8"
+    assert ctx["safe_mode"] is True
+    assert "reason" in ctx
+
+
+def test_successful_task_start_does_not_create_blocked_audit_entries(test_client):
+    """A scan that starts successfully must not create either blocked-attempt entry."""
+    response = test_client.post(
+        "/api/v1/task/start",
+        json={
+            "plugin_id": "amass",
+            "inputs": {"target": "192.168.1.1"},
+            "consent_granted": True,
+        },
+    )
+    assert response.status_code == 200
+
+    consent_entries = asyncio.run(get_audit_entries("scan_blocked_consent", "amass"))
+    target_entries = asyncio.run(get_audit_entries("scan_blocked_target_validation", "amass"))
+    assert len(consent_entries) == 0
+    assert len(target_entries) == 0


### PR DESCRIPTION
## Description

The audit log only recorded scans that passed consent and safe-mode validation and began executing. Scans blocked by safe mode, rejected by consent checks, or that failed during initialisation left no entry in the audit log, so an administrator could not reconstruct misuse attempts after the fact.

This PR adds audit log entries at the two points described in the issue:

- `scan_blocked_consent`: logged when a scan request is rejected because consent was not granted.
- `scan_blocked_target_validation`: logged when safe-mode target validation rejects the target (for example, a public IP, or a domain resolving to an address outside the allowed private ranges).

Both entries record the plugin ID and are queryable through the existing `audit_log` table (`event_type`, `plugin_id`, `context_json`), consistent with the `report_downloaded` audit entries already present in this codebase.

## Related Issues

Closes #1623

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Added `testing/backend/integration/test_scan_block_audit_log.py` with 3 tests:
- Consent rejection creates a `scan_blocked_consent` audit entry with the correct plugin ID and severity.
- Safe-mode target rejection (public IP target) creates a `scan_blocked_target_validation` entry with target, safe_mode, and reason in the context.
- A scan that starts successfully creates neither blocked-attempt entry (regression guard).

Full local verification before opening this PR:
- `pytest testing/backend/unit -q -m "not benchmark"`: 2210 passed. 6 pre-existing failures in `test_parser_sandbox*` / `test_plugin_validator` confirmed present on `main` before this change (verified via `git stash`), unrelated to `routes.py`.
- `pytest testing/backend/integration -q -m "not benchmark"`: 287 passed, 9 skipped (up from 284 passed on main, +3 for the new tests).
- `pytest testing/backend/integration/test_parser_output_contract.py` for all 4 capability groups (network, intrusive, credentials, exploit): all passed.
- `ruff check backend testing/backend`: all checks passed.
- `scripts/check-artifacts.sh origin/main`: all clear, no generated artifacts or cache files in the diff.
- `git diff --check`: no whitespace/formatting issues.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation. (N/A — no user-facing docs affected)
- [x] My changes generate no new warnings.

Contributing through GSSoC 2026.