### PR TITLE
fix(frontend): remove exhaustive-deps suppression from Findings virtualizer effect

### DIFF
--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -639,16 +639,30 @@ export default function Findings() {
     overscan: 6,
   })
 
-  // Scroll selected finding into view when it changes
+  // Keep latest virtualRows/virtualizer available without making them
+  // reactive dependencies — they change on every filter/sort, but we only
+  // want to re-scroll when the *selection* actually changes.
+  const virtualRowsRef = useRef(virtualRows)
   useEffect(() => {
-    if (!selectedFinding) return
-    const rowIdx = virtualRows.findIndex(
-      (row) => row.kind === 'finding' && row.finding.id === selectedFinding.id,
+    virtualRowsRef.current = virtualRows
+  })
+
+  const virtualizerRef = useRef(virtualizer)
+  useEffect(() => {
+    virtualizerRef.current = virtualizer
+  })
+
+  // Scroll selected finding into view when the selection changes
+  useEffect(() => {
+    if (!selectedFindingId) return
+    const rows = virtualRowsRef.current
+    const rowIdx = rows.findIndex(
+      (row) => row.kind === 'finding' && row.finding.id === selectedFindingId,
     )
     if (rowIdx !== -1) {
-      virtualizer.scrollToIndex(rowIdx, { align: 'auto', behavior: 'smooth' })
+      virtualizerRef.current.scrollToIndex(rowIdx, { align: 'auto', behavior: 'smooth' })
     }
-  }, [selectedFindingId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [selectedFindingId])
   return (
     <div className="min-h-screen bg-charcoal-dark text-silver px-4 py-6 md:px-8 md:py-10">
       <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-8">

--- a/frontend/testing/unit/pages/Findings.test.tsx
+++ b/frontend/testing/unit/pages/Findings.test.tsx
@@ -535,3 +535,30 @@ describe('Findings — virtualizer scrolling', () => {
     expect(mockScrollToIndex).not.toHaveBeenCalled()
   })
 })
+
+it('scrolls to the correct fresh index after sort order changes then selection changes', async () => {
+    const findings = [
+      makeFinding({ id: 'f1', title: 'Finding Alpha', severity: 'critical', discovered_at: '2024-01-01T00:00:00Z' }),
+      makeFinding({ id: 'f2', title: 'Finding Beta', severity: 'high', discovered_at: '2024-01-03T00:00:00Z' }),
+      makeFinding({ id: 'f3', title: 'Finding Gamma', severity: 'medium', discovered_at: '2024-01-02T00:00:00Z' }),
+    ]
+    vi.mocked(getFindings).mockResolvedValue({ findings })
+
+    render(<Findings />)
+    await waitFor(() => expect(screen.queryByText('Synchronizing findings feed...')).not.toBeInTheDocument())
+
+    // Switch to "newest" sort — new order is Beta(0), Gamma(1), Alpha(2)
+    const selects = screen.getAllByRole('combobox')
+    const sortSelect = selects.find((s) =>
+      Array.from(s.querySelectorAll('option')).some((o) => /Newest First/i.test(o.textContent || '')),
+    )
+    await userEvent.selectOptions(sortSelect!, 'newest')
+
+    mockScrollToIndex.mockClear()
+
+    // Now select Gamma — should scroll to its *post-sort* index (1), not a stale pre-sort index
+    const gammaOption = await screen.findByRole('option', { name: /Finding Gamma/i })
+    await userEvent.click(gammaOption)
+
+    expect(mockScrollToIndex).toHaveBeenCalledWith(1, { align: 'auto', behavior: 'smooth' })
+  })


### PR DESCRIPTION
## Description
Removes the `eslint-disable react-hooks/exhaustive-deps` suppression on the Findings virtualizer scroll effect. The effect previously read `selectedFinding`, `virtualRows`, and `virtualizer` from render scope while only depending on `selectedFindingId`, which could leave stale virtualizer/row data after filtering or sorting. Fixed by keeping `selectedFindingId` as the only reactive dependency, while `virtualRows` and `virtualizer` are now read through refs kept fresh via separate no-dependency-array effects, satisfying exhaustive-deps without over-firing the scroll on every filter/sort.

## Related Issues
Closes #1407

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Added a regression test covering selection changing after a sort-order change, verifying `scrollToIndex` is called with the correct post-sort index rather than a stale pre-sort one.
- Ran full frontend suite: `npm run test` - 531/531 passing.
- Ran `npm run typecheck` - no errors.
- Ran `npm run build` - succeeds (pre-existing vendor chunk size warning is unrelated to this change).
- Ran `scripts/check-artifacts.sh` - all clear, no generated artifacts staged.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.