### PR TITLE
test : added unit tests for _should_run datetime logic in workflow scheduling

### DIFF
--- a/backend/secuscan/workflow_scheduling.py
+++ b/backend/secuscan/workflow_scheduling.py
@@ -1,0 +1,35 @@
+"""
+Workflow scheduling datetime helpers.
+
+Extracted from workflows.py for safe unit testing (the parent module imports
+database/ratelimit/executor which require heavy runtime dependencies).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _should_run(now: datetime, last_run_at: str | None, schedule_seconds: int) -> bool:
+    """Return True if the schedule interval has elapsed since last_run_at.
+
+    Args:
+        now: current timestamp (UTC, timezone-aware)
+        last_run_at: ISO-format timestamp of last execution, or None/"" if never run
+        schedule_seconds: minimum seconds between executions
+
+    Returns:
+        True when the workflow should fire now.
+    """
+    if not last_run_at:
+        return True
+    last = datetime.fromisoformat(last_run_at.replace("Z", "+00:00"))
+    # SQLite's datetime('now') produces "2026-05-25 08:02:28" - no Z and
+    # no +00:00 suffix - so fromisoformat() returns a naive datetime.
+    # Subtracting a naive datetime from an aware one raises TypeError.
+    # Treat any naive timestamp from the DB as UTC.
+    if last.tzinfo is None:
+        last = last.replace(tzinfo=timezone.utc)
+    elapsed = (now - last).total_seconds()
+    return elapsed >= schedule_seconds

--- a/testing/backend/unit/test_workflows.py
+++ b/testing/backend/unit/test_workflows.py
@@ -1,0 +1,125 @@
+"""
+Unit tests for backend/secuscan/workflow_scheduling.py _should_run helper.
+
+Covers the pure datetime-computing function:
+  - _should_run: elapsed-time scheduling logic
+
+The function was extracted from WorkflowScheduler in workflows.py into
+workflow_scheduling.py to allow safe unit testing without pulling in the
+heavy dependency chain (database, ratelimit, executor).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.secuscan.workflow_scheduling import _should_run
+
+
+class TestShouldRun:
+    """WorkflowScheduler._should_run datetime logic."""
+
+    def test_none_last_run_at_returns_true(self):
+        """Never-run workflows (last_run_at=None) should always run."""
+        now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+        result = _should_run(now, None, 3600)
+        assert result is True
+
+    def test_never_run_empty_string_returns_true(self):
+        """Empty string last_run_at is treated as never run."""
+        now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+        result = _should_run(now, "", 3600)
+        assert result is True
+
+    def test_elapsed_exceeds_schedule_returns_true(self):
+        """Run when elapsed time >= schedule interval."""
+        now = datetime(2026, 7, 6, 2, 0, 0, tzinfo=timezone.utc)
+        last = datetime(2026, 7, 6, 1, 0, 0, tzinfo=timezone.utc)
+        result = _should_run(now, last.isoformat(), 3600)
+        assert result is True
+
+    def test_elapsed_equals_schedule_returns_true(self):
+        """Run when elapsed time exactly equals schedule (boundary)."""
+        now = datetime(2026, 7, 6, 2, 0, 0, tzinfo=timezone.utc)
+        last = datetime(2026, 7, 6, 1, 0, 0, tzinfo=timezone.utc)
+        result = _should_run(now, last.isoformat(), 3600)
+        assert result is True
+
+    def test_elapsed_less_than_schedule_returns_false(self):
+        """Skip when not enough time has elapsed."""
+        now = datetime(2026, 7, 6, 1, 30, 0, tzinfo=timezone.utc)
+        last = datetime(2026, 7, 6, 1, 0, 0, tzinfo=timezone.utc)
+        result = _should_run(now, last.isoformat(), 3600)
+        assert result is False
+
+    def test_naive_datetime_treated_as_utc(self):
+        """SQLite datetime('now') returns naive datetime (no Z suffix).
+
+        The method must treat naive timestamps as UTC (the comment in
+        workflows.py explains this).
+        """
+        now = datetime(2026, 7, 6, 2, 0, 0, tzinfo=timezone.utc)
+        # SQLite format: "2026-07-06 01:00:00" (no Z, no +00:00)
+        naive_last = "2026-07-06 01:00:00"
+        result = _should_run(now, naive_last, 3600)
+        assert result is True
+
+    def test_naive_datetime_still_in_future_returns_false(self):
+        """Naive last_run_at that is still within the schedule window."""
+        now = datetime(2026, 7, 6, 1, 30, 0, tzinfo=timezone.utc)
+        naive_last = "2026-07-06 01:00:00"
+        result = _should_run(now, naive_last, 3600)
+        assert result is False
+
+    def test_z_suffix_datetime_handled(self):
+        """Datetime with Z suffix is parsed correctly."""
+        now = datetime(2026, 7, 6, 2, 0, 0, tzinfo=timezone.utc)
+        last = "2026-07-06T01:00:00Z"
+        result = _should_run(now, last, 3600)
+        assert result is True
+
+    def test_positive_offset_timezone_handled(self):
+        """Datetime with explicit +HH:MM timezone is parsed correctly."""
+        now = datetime(2026, 7, 6, 6, 30, 0, tzinfo=timezone.utc)
+        last = "2026-07-06T02:00:00+05:30"
+        # 02:00+05:30 == 20:30Z, elapsed ~4h, 3600s threshold
+        result = _should_run(now, last, 3600)
+        assert result is True
+
+    def test_negative_offset_timezone_handled(self):
+        """Datetime with negative timezone offset is parsed correctly."""
+        now = datetime(2026, 7, 6, 8, 0, 0, tzinfo=timezone.utc)
+        last = "2026-07-06T02:00:00-05:00"
+        # 02:00-05:00 == 07:00Z, elapsed from 07:00 to 08:00 = 1h = 3600s -> True (boundary)
+        result = _should_run(now, last, 3600)
+        assert result is True
+
+    def test_short_schedule_interval(self):
+        """Schedule interval of 60 seconds works correctly."""
+        now = datetime(2026, 7, 6, 1, 1, 0, tzinfo=timezone.utc)
+        last = datetime(2026, 7, 6, 1, 0, 0, tzinfo=timezone.utc)
+        result = _should_run(now, last.isoformat(), 60)
+        assert result is True
+
+    def test_short_interval_not_yet_elapsed(self):
+        """60-second interval not elapsed returns False."""
+        now = datetime(2026, 7, 6, 1, 0, 30, tzinfo=timezone.utc)
+        last = datetime(2026, 7, 6, 1, 0, 0, tzinfo=timezone.utc)
+        result = _should_run(now, last.isoformat(), 60)
+        assert result is False
+
+    def test_does_not_mutate_now_parameter(self):
+        """_should_run must not mutate the passed-in now datetime."""
+        now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+        now_before = now.isoformat()
+        _should_run(now, None, 3600)
+        assert now.isoformat() == now_before
+
+    def test_zero_schedule_seconds_is_true(self):
+        """schedule_seconds=0: elapsed >= 0 is always True for any past timestamp."""
+        now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+        last = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        result = _should_run(now, last.isoformat(), 0)
+        assert result is True


### PR DESCRIPTION
Closes #1704.

Summary of What Has Been Done:
Extracted the pure datetime-computing function _should_run from WorkflowScheduler into a standalone import-safe module (backend/secuscan/workflow_scheduling.py), then added comprehensive unit tests covering all datetime edge cases.

Changes Made:
- New file: backend/secuscan/workflow_scheduling.py - contains the _should_run standalone function
- New file: testing/backend/unit/test_workflows.py - 14 unit tests for _should_run
- Modified: backend/secuscan/workflows.py - WorkflowScheduler._should_run now delegates to the standalone function (callers unchanged)

Impact it Made:
- Reliability: covers the naive/aware datetime edge case that SQLite datetime produces
- Coverage: adds tests for one of the last untested core modules in the backend
- Maintainability: extraction into a small module makes the dependency chain testable

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.