### PR TITLE
refactor(Scans): replace task inputs any with ScanInputs type #1400

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -58,6 +58,8 @@ export interface ExecutionContext {
   evidence_level: 'minimal' | 'standard' | 'full'
 }
 
+export type ScanInputs = Record<string, unknown>
+
 export interface EvidenceRecord {
   type: string
   label?: string
@@ -567,7 +569,7 @@ export function getTaskDiff(taskId: string): Promise<ScanDiff> {
 
 export function startTask(
   plugin_id: string,
-  inputs: Record<string, unknown>,
+  inputs: ScanInputs,
   consent_granted: boolean,
   preset?: string,
   execution_context?: Partial<ExecutionContext>,
@@ -626,7 +628,7 @@ export function streamTask(taskId: string, onEvent: (ev: MessageEvent) => void) 
 }
 export interface WorkflowStep {
   plugin_id: string
-  inputs: Record<string, unknown>
+  inputs: ScanInputs
   preset?: string
   execution_context?: ExecutionContext
 }

--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence, type Variants } from "framer-motion";
-import { API_BASE, deleteTask, clearAllTasks, bulkDeleteTasks, startTask, ExecutionContext } from "../api";
+import { API_BASE, deleteTask, clearAllTasks, bulkDeleteTasks, startTask, ExecutionContext, ScanInputs } from "../api";
 import { routePath } from "../routes";
 import {
   parseDateSafe,
@@ -24,7 +24,7 @@ interface Task {
   completed_at?: string;
   duration_seconds?: number;
   error_message?: string;
-  inputs?: any;
+  inputs?: ScanInputs;
   preset?: string;
   execution_context?: ExecutionContext;
   queue_position?: number;


### PR DESCRIPTION
## Summary
- Introduces a shared `ScanInputs` type (`Record<string, unknown>`) in `api.ts`.
- Replaces `inputs?: any` in `Scans.tsx` with `inputs?: ScanInputs`.
- Applies `ScanInputs` consistently to `startTask` and `WorkflowStep` for aligned API typings.

Closes #1400

## Test plan
- [x] `npm run typecheck` (frontend)
- [x] `npm run test -- testing/unit/pages/Scans.test.tsx testing/unit/pages/ScansToastErrors.test.tsx testing/unit/pages/ScansPhases.test.tsx testing/unit/pages/Scans.polling.test.tsx` (28/28 passed)
- [x] Rescan flow remains unchanged at runtime