### PR TITLE
feat(plugins): backfill explicit capabilities for granular denial #1813

### DIFF
--- a/plugins/amass/metadata.json
+++ b/plugins/amass/metadata.json
@@ -56,5 +56,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "5a0ea8ff2a07b965685a2772bb2557afde4ef50e23dc423c99c27ce518494747"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "e8dbca61aa046afe6ca08cf3188599f94866ea11ab1d6ded3394c6345d797e10"
 }

--- a/plugins/cloud_scanner/metadata.json
+++ b/plugins/cloud_scanner/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee0\ufe0f",
+  "icon": "🛠️",
   "engine": {
     "type": "cli",
     "binary": "python3"
@@ -53,5 +53,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "3485a50459568754718e8494b5e46f141d99df609cb9da1131e19b12fa8dd3c3"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "85b7150a12faa4321f750a3e275206f3509c2d2a313fb39fd23dbf55cf1cba56"
 }

--- a/plugins/cloud_storage_auditor/metadata.json
+++ b/plugins/cloud_storage_auditor/metadata.json
@@ -66,5 +66,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "36f2fb411bd249ff428376845c08f98cbb1cfba525f554e396d733edb4106dc7"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "bd03bd0e7a10a7b0c83409f78c632f657491ede824205dbf8e8da4cd7d039220"
 }

--- a/plugins/code_analyzer/metadata.json
+++ b/plugins/code_analyzer/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udcc3",
+  "icon": "📃",
   "engine": {
     "type": "cli",
     "binary": "bandit"
@@ -88,5 +88,8 @@
     "system_packages": []
   },
   "docker_image": "pyfound/bandit:latest",
-  "checksum": "efbcbcdc76325f82a5cee1076bebf565ebcbb4237f7542b05ad52169ba7d1321"
+  "capabilities": [
+    "filesystem"
+  ],
+  "checksum": "278322d62ba27f45b19b55f2b3bba19b6863cde78eba0e19ec0a384b5fe83793"
 }

--- a/plugins/container_scanner/metadata.json
+++ b/plugins/container_scanner/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "Apache-2.0",
-  "icon": "\ud83d\udce6",
+  "icon": "📦",
   "engine": {
     "type": "cli",
     "binary": "trivy"
@@ -67,5 +67,9 @@
     "system_packages": []
   },
   "docker_image": "aquasec/trivy",
-  "checksum": "934f32fba8427ff8c93a44f9865612b8c38f2da81af25cd1e0e06dd0ca37b57a"
+  "capabilities": [
+    "network",
+    "docker"
+  ],
+  "checksum": "78d6ff063550f437db6c3a4c72ceeb69b78a5461df20a954e7e445e911543b52"
 }

--- a/plugins/crawler/metadata.json
+++ b/plugins/crawler/metadata.json
@@ -68,5 +68,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "07d6c15303a758622c1f9178c7af2edfd4dfe90110b53fbb02f4d12db9febdd9"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "2e3d4dbcdcede18f25d4a6ed5724a0afccba6fb7c4e51ea39fbf9ba7a569b97a"
 }

--- a/plugins/dir_discovery/metadata.json
+++ b/plugins/dir_discovery/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udcc2",
+  "icon": "📂",
   "engine": {
     "type": "cli",
     "binary": "ffuf"
@@ -185,5 +185,10 @@
     "system_packages": []
   },
   "docker_image": "secuscan/ffuf",
-  "checksum": "72f7b28148a646d9009d48dbf34d1fa89c7088037cd51d3e5fde2790d54b4928"
+  "capabilities": [
+    "network",
+    "intrusive",
+    "filesystem"
+  ],
+  "checksum": "dcaed043062f3d152139f7aec4a5a8fafa90fc142b52f5d9ac123b0f1686ee8b"
 }

--- a/plugins/dns_enum/metadata.json
+++ b/plugins/dns_enum/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udce6",
+  "icon": "📦",
   "engine": {
     "type": "cli",
     "binary": "dnsrecon"
@@ -91,5 +91,8 @@
     ]
   },
   "docker_image": "darkoperator/dnsrecon:latest",
-  "checksum": "12cd4e84e7bf888e9b8d5a21d597ca1487f2ab843be78ab367e486bec9b2b761"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "f815c68db918013ff6bc043ece861e15693d184fc96089ef3812f0eb51ca0967"
 }

--- a/plugins/dnsx/metadata.json
+++ b/plugins/dnsx/metadata.json
@@ -53,5 +53,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "d7a7914e25e63212882702cc8ff218819dd609e38025e24514dd36cf6670cb68"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "cf53b915d89e683fbb074c31aeb604d7ab77d80a36b648c24c1abec38ff7c8bd"
 }

--- a/plugins/domain-finder/metadata.json
+++ b/plugins/domain-finder/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "amass"
@@ -55,5 +55,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "b8bc0ebc7ba6b739c3f81be706c98cc354e9ffdad1468d62ef00600a3e8907d6"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "daf50ba8d36bf13a2996d28e19339f27f8733ec7f8994346b86bba6280c9e40c"
 }

--- a/plugins/droopescan/metadata.json
+++ b/plugins/droopescan/metadata.json
@@ -60,5 +60,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "14a813b3393bcc5a1c5ad697b8d6a283d61e61c7b1aa08481175df109d194e02"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "5d57c0084e514cff237fc7c057b7447d7db7587d7951cd15cf208997b90651d7"
 }

--- a/plugins/fuzzer/metadata.json
+++ b/plugins/fuzzer/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee0\ufe0f",
+  "icon": "🛠️",
   "engine": {
     "type": "cli",
     "binary": "python3"
@@ -53,5 +53,11 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "eaac1036bce6e14dbc2ebd48ec97c262461bae5c1611510c51581d9b907a0fe4"
+  "capabilities": [
+    "network",
+    "intrusive",
+    "exploit",
+    "filesystem"
+  ],
+  "checksum": "72db64762c6da7d6abdb891c80476724ae3751daf72ebd5ace68bfe928e51440"
 }

--- a/plugins/google-dorking/metadata.json
+++ b/plugins/google-dorking/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "python3"
@@ -52,5 +52,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "7284033396542bcc591307d2339b525d7eebd0da5365a252b79ff21a0160f208"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "3a0764f016f3a191bc621784c0255a63b2eed88835a2177ee41ccfdbee8adb56"
 }

--- a/plugins/hashcat/metadata.json
+++ b/plugins/hashcat/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\u26a1",
+  "icon": "⚡",
   "engine": {
     "type": "cli",
     "binary": "hashcat"
@@ -101,5 +101,10 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "f46f049daf6fad834f77401ca188596b68dec5ff5036b83e2ef013cf01a0d888"
+  "capabilities": [
+    "filesystem",
+    "intrusive",
+    "exploit"
+  ],
+  "checksum": "4cc480b34e3118dd635dc99c8544c307dabe4fb2a5bcdd36a6967096eb3f7cdd"
 }

--- a/plugins/http_request_logger/metadata.json
+++ b/plugins/http_request_logger/metadata.json
@@ -61,5 +61,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "f5d0d16d054e258bf928051ef4ee7716171ec533c55e081bfe98533e75781d99"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "944bef442517123068308455d94f9d25e9acf8aedf1cace13b9461b6df4cd5d3"
 }

--- a/plugins/httpx/metadata.json
+++ b/plugins/httpx/metadata.json
@@ -55,5 +55,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "6570954f2b2cae9ce3a2281445f5c4c46533ada5cd6b5c35859d592523d517e9"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "dc1b67fd28091d2258a758d01abb692edee19904d50a0ac00820d74cb58759c3"
 }

--- a/plugins/iac_scanner/metadata.json
+++ b/plugins/iac_scanner/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee0\ufe0f",
+  "icon": "🛠️",
   "engine": {
     "type": "cli",
     "binary": "python3"
@@ -54,5 +54,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "35c01e2544805a78b46b75fb168a98a486a7b80dd926a21ca3c91d721e02af78"
+  "capabilities": [
+    "filesystem"
+  ],
+  "checksum": "af5f3eae4fb0af29a18c9f9a2331b3c83c887545c0f0dff722ed0ce810db6e45"
 }

--- a/plugins/icmp_ping/metadata.json
+++ b/plugins/icmp_ping/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee0\ufe0f",
+  "icon": "🛠️",
   "engine": {
     "type": "cli",
     "binary": "ping"
@@ -69,5 +69,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "bee1387121a61c22a4d5c8d8c99024ff3ed0a45397dc240b6507792b1193d676"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "fc59e900db2274bec3152066da26eaf4b6c490b788d06e12b6060d7e2dcd9dcc"
 }

--- a/plugins/joomscan/metadata.json
+++ b/plugins/joomscan/metadata.json
@@ -56,5 +56,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "d3ffeb4aaee18cfca0ba2f9ba6958b71e5e5c29a3823a8e1855040c19de09b04"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "4cdfae1033a93a657a20294ab56863b027cef93a9892bc65ea235d939aff3e0a"
 }

--- a/plugins/katana/metadata.json
+++ b/plugins/katana/metadata.json
@@ -54,5 +54,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "539bd64f8c8774c54857bfb826f9748ba487dedcba1482a26a5383c1b022d786"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "91eecd78a8e88a1e92135215a9bafe0f612827c096b226827bf8b5013d77392d"
 }

--- a/plugins/kubernetes_scanner/metadata.json
+++ b/plugins/kubernetes_scanner/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee0\ufe0f",
+  "icon": "🛠️",
   "engine": {
     "type": "cli",
     "binary": "python3"
@@ -54,5 +54,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "a86d9187ec7f37dff67dd0c6223a9988138bd2255fc2cfeae0dc14f203630e4c"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "2ebcbbd38643308bab703617f2a5e1cfefcbe6ebb4c2ff0724b55a164c316f14"
 }

--- a/plugins/metasploit/metadata.json
+++ b/plugins/metasploit/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\ude80",
+  "icon": "🚀",
   "engine": {
     "type": "cli",
     "binary": "msfconsole"
@@ -73,5 +73,11 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "53cab335dc65a9ff39877bb3cf8666c3ae0f196f7c80254ae8a395221de771b7"
+  "capabilities": [
+    "network",
+    "intrusive",
+    "exploit",
+    "credentials"
+  ],
+  "checksum": "61a8c706c04ce3d244b5857b27e979c8a121ab9ecca4872c1090643cb8a5e73b"
 }

--- a/plugins/nikto/metadata.json
+++ b/plugins/nikto/metadata.json
@@ -333,5 +333,9 @@
     ]
   },
   "docker_image": "sullo/nikto",
-  "checksum": "31c89129a6242562db4d08cfe17d12abbc5f8b1450980db309f361fa2892fb74"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "0fe1d8f5ab5873b2aae34cface3e17d1086fbad9b9a627bf65e019d01f5823ac"
 }

--- a/plugins/nmap/metadata.json
+++ b/plugins/nmap/metadata.json
@@ -202,5 +202,8 @@
     "system_packages": []
   },
   "docker_image": "instrumentisto/nmap",
-  "checksum": "1b9579a663c854d718a5167a8833e9aa4a1e210924104ef2d97cbdaa133c992a"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "4ae83b8d264f534c4fd5671be973abd4e0282f2e3ec95571b6134986b9257c3e"
 }

--- a/plugins/nuclei/metadata.json
+++ b/plugins/nuclei/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83e\uddec",
+  "icon": "🧬",
   "engine": {
     "type": "cli",
     "binary": "nuclei"
@@ -132,5 +132,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "8304cb4226938c354aa831943de4da3dfa57e2fe4cc9c200d448f49b56f74590"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "3eb851f809d0abdfa637d305a9dc4a44e5fd36d0b8738ef3c1922c3a332c9614"
 }

--- a/plugins/password_auditor/metadata.json
+++ b/plugins/password_auditor/metadata.json
@@ -54,5 +54,10 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "303a6a52375f996d47c526a147b33362af5600d1eaa326497108868ee6b65ea5"
+  "capabilities": [
+    "network",
+    "intrusive",
+    "credentials"
+  ],
+  "checksum": "77b3934791fef2d52836906c724e99fd7fd5f341c189db2d834e6ed63905e1e4"
 }

--- a/plugins/people-email-discovery/metadata.json
+++ b/plugins/people-email-discovery/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "theHarvester"
@@ -54,5 +54,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "b637adaf26113ae2e6225ad26b61bc60bd3777a6c3e8fac58d0ec78b21ebd4e1"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "5377a2b1fa014409b40af87d8c50e9e8af7109fb6cb57136ed2cd2a4315463c1"
 }

--- a/plugins/port-scanner/metadata.json
+++ b/plugins/port-scanner/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "nmap"
@@ -67,5 +67,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "1fe95f15404deaa261d64f891dcac4e87bc4dc4c3d4ca4fb7c526bdcdcf2c762"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "061cbcacf0e61b0759350dd5cdba9aa95c61db46dde992938bed046bb40f9fad"
 }

--- a/plugins/scapy_recon/metadata.json
+++ b/plugins/scapy_recon/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udce1",
+  "icon": "📡",
   "engine": {
     "type": "cli",
     "binary": "python3"
@@ -86,5 +86,8 @@
     ]
   },
   "docker_image": "secdev/scapy:latest",
-  "checksum": "172b7870ba6be89b46ec2918c2567b9d0e5be70b719e0e0d404d81b39a7fa18d"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "0f3ace1288075e9dbec9ebde6e8545a5db2af33d5697737e506567a70d744c91"
 }

--- a/plugins/secret_scanner/metadata.json
+++ b/plugins/secret_scanner/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd11",
+  "icon": "🔑",
   "engine": {
     "type": "cli",
     "binary": "gitleaks"
@@ -66,5 +66,8 @@
     "system_packages": []
   },
   "docker_image": "zricethezav/gitleaks:latest",
-  "checksum": "4287007a8a060b41dea04e2f3e2ce98c4db0fefa8e0cca318168bc0ce4aaa032"
+  "capabilities": [
+    "filesystem"
+  ],
+  "checksum": "21be5ea70b9709f64b05352f8d9d4fded99bdb4f0471bfa76a9fec23764171e3"
 }

--- a/plugins/semgrep_scanner/metadata.json
+++ b/plugins/semgrep_scanner/metadata.json
@@ -74,5 +74,8 @@
     "system_packages": []
   },
   "docker_image": "returntocorp/semgrep:latest",
-  "checksum": "8e59254f5ad937c0a5a2af47367cddf07e07b8a528d13ff303360d6e478a51d8"
+  "capabilities": [
+    "filesystem"
+  ],
+  "checksum": "9fdbb9bf1cab5ec0a7a80aabfd5a056a04050dfad04b0ff4b835f5d1e00fc050"
 }

--- a/plugins/sharepoint_scanner/metadata.json
+++ b/plugins/sharepoint_scanner/metadata.json
@@ -58,5 +58,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "5b12fe52ee58960818ec99ed5474703682075de7bf090bcd1e9288c9c4397806"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "c3dbdb2c5c064acabf5c33c82865970fe8d90fde67402541c6eebb2824a411e8"
 }

--- a/plugins/sitemap_gen/metadata.json
+++ b/plugins/sitemap_gen/metadata.json
@@ -70,5 +70,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "e65c7ee56ef634d35f5cd13877ab2d69858e102398361acd8fd09a17f110f349"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "731a81ada0623768d68eaab7478dcdd4fc2e4f2a3b3bb618976d1b6f1f2794e5"
 }

--- a/plugins/spider/metadata.json
+++ b/plugins/spider/metadata.json
@@ -71,5 +71,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "8f16aed623f771cf396ea9ef778055da31ca2f88f6f70dde9b1cb9cfeeb58499"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "59f49edaea0b3cff03158487a89916ad6d2b4073c87d1c8af98d579128c84c65"
 }

--- a/plugins/sqli_checker/metadata.json
+++ b/plugins/sqli_checker/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83e\uddea",
+  "icon": "🧪",
   "engine": {
     "type": "cli",
     "binary": "ghauri"
@@ -124,5 +124,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "62ed5d57c77eaff266ec03e8aa81f2325d2e24d6e71dc2f657072b0df5c64354"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "ff4efa5458e87ac0c1ea761e20f53ceb94910ec63017e675111daf6ef4dd9f81"
 }

--- a/plugins/sqli_exploiter/metadata.json
+++ b/plugins/sqli_exploiter/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee0\ufe0f",
+  "icon": "🛠️",
   "engine": {
     "type": "cli",
     "binary": "sqlmap"
@@ -83,5 +83,10 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "027f567c5a99112334dce179a67b53d406e5e16eb1b08fee901c98f2683dea4f"
+  "capabilities": [
+    "network",
+    "intrusive",
+    "exploit"
+  ],
+  "checksum": "c22475c3e6cf2ba1111bc417b7f97f4be665dcecc8d25bfebfc7fcb5cf5af5b9"
 }

--- a/plugins/sqlmap/metadata.json
+++ b/plugins/sqlmap/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "GPLv2",
-  "icon": "\ud83d\udc89",
+  "icon": "💉",
   "engine": {
     "type": "cli",
     "binary": "sqlmap"
@@ -126,5 +126,10 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "3c7f16ed91fa3623540e42f1b4a3d79c29708e26cb1d130ab9bd2ec40a7d6c0e"
+  "capabilities": [
+    "network",
+    "intrusive",
+    "exploit"
+  ],
+  "checksum": "387e834cacef36634e27b87aaa3850429ed8ba7717a59343d21fbc2f980bf85b"
 }

--- a/plugins/ssh_runner/metadata.json
+++ b/plugins/ssh_runner/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udda5\ufe0f",
+  "icon": "🖥️",
   "engine": {
     "type": "cli",
     "binary": "ssh"
@@ -110,5 +110,10 @@
     ]
   },
   "docker_image": "alpine:latest",
-  "checksum": "76f62464b0e9fb8e0322b52461dae8029053769f60da9b4ce8f73604b7048aaa"
+  "capabilities": [
+    "network",
+    "intrusive",
+    "credentials"
+  ],
+  "checksum": "eb7e087228a1787a35e9e9e6ddca58a5092bb07a9d12ce552ba029049e8166a1"
 }

--- a/plugins/subdomain_discovery/metadata.json
+++ b/plugins/subdomain_discovery/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83c\udf10",
+  "icon": "🌐",
   "engine": {
     "type": "cli",
     "binary": "subfinder"
@@ -88,5 +88,8 @@
     "system_packages": []
   },
   "docker_image": "projectdiscovery/subfinder:latest",
-  "checksum": "11c9b9517e288518d4eefa78aff3a3efdfb9d2023dacf5ddfe95e2b3808eac72"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "be68aa1d7233c3e85a8d1a3af357a7debe4348859d1e30348b14c6d784248800"
 }

--- a/plugins/subdomain_takeover/metadata.json
+++ b/plugins/subdomain_takeover/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udee0\ufe0f",
+  "icon": "🛠️",
   "engine": {
     "type": "cli",
     "binary": "subfinder"
@@ -53,5 +53,10 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "f735cebb8c673daee580c4026eb8cdef2ebdb5232a3a3591350dda3aa231fc75"
+  "capabilities": [
+    "network",
+    "intrusive",
+    "exploit"
+  ],
+  "checksum": "5ee1cd0021b880563177f729aa90ac90cbf101df41fbc2d2453c38305b386076"
 }

--- a/plugins/subfinder/metadata.json
+++ b/plugins/subfinder/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "subfinder"
@@ -52,5 +52,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "f9046380e1c3a3f6d516b1d1afb7ababcc2aa23ca0d0e74e928403bda0b881f4"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "66ed20fbc902b48a1d4247b33f701ac2734da250a599fd126bd75d14ffd70cab"
 }

--- a/plugins/theharvester/metadata.json
+++ b/plugins/theharvester/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "theHarvester"
@@ -53,5 +53,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "23786b990637464c07c163aa714ba1ce60f47a94cc2d64e4beb42c419ec2da56"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "c6c1335f1315786e60d57d6a8295a70016822a09dbeab55915e13dbb6fd3fba2"
 }

--- a/plugins/tls_inspector/metadata.json
+++ b/plugins/tls_inspector/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd10",
+  "icon": "🔐",
   "engine": {
     "type": "cli",
     "binary": "openssl"
@@ -137,5 +137,8 @@
     "system_packages": []
   },
   "docker_image": "alpine:latest",
-  "checksum": "fac3b48892e86d2727495b46df5cf0b6ff6bcc72f1c40f1d218ef9afc79e1615"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "15f1ad19870fe13117dc5b29095090093fe9014fce8a308a68c65e15ca03abe9"
 }

--- a/plugins/uncover/metadata.json
+++ b/plugins/uncover/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "uncover"
@@ -65,5 +65,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "db1e801d6a027a09ce9c726d593f9dda4b79ab2775a5e824bdeb43df3ba9364d"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "ba0eac622c25207951b2e4ee820531ea14fe131c64a4ea8a3984ae0086672eaf"
 }

--- a/plugins/url-fuzzer-2/metadata.json
+++ b/plugins/url-fuzzer-2/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "ffuf"
@@ -74,5 +74,10 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "4fada9f7e171899e44ddccdb66be22500f086a7afe1c69b46a01c16e5803e66c"
+  "capabilities": [
+    "network",
+    "intrusive",
+    "filesystem"
+  ],
+  "checksum": "802e8af9ea34849eb6f3e54b8777c38dcbf3ca526992b8de78668b065bd3f066"
 }

--- a/plugins/urlfinder/metadata.json
+++ b/plugins/urlfinder/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "urlfinder"
@@ -52,5 +52,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "ad631fba1c00d10388761902571c4d35d69de55e1b7a1419ac301f5f3157447d"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "599fa38006073096d5c3059a69125e128735af936362ff62f1471e75b2ed7ac5"
 }

--- a/plugins/virtual-host-finder/metadata.json
+++ b/plugins/virtual-host-finder/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "ffuf"
@@ -68,5 +68,10 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "fb787f5f51da9f62c7a87d04694d5fa8624b0cf656f0d464436c7a8de45a58df"
+  "capabilities": [
+    "network",
+    "intrusive",
+    "filesystem"
+  ],
+  "checksum": "0b43b465c75cad8151b09e76ef25a484c9d3f76353052740e9b66126f05817eb"
 }

--- a/plugins/volatility/metadata.json
+++ b/plugins/volatility/metadata.json
@@ -67,5 +67,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "733f04bb43785f9b3350876fe9bd9c88e3294b58f540175877d34636091f1df9"
+  "capabilities": [
+    "filesystem",
+    "intrusive"
+  ],
+  "checksum": "f15e4b8b76266f42c3e2674e9f1fa304b1be1a5b78b84cedaacf5463be0add8e"
 }

--- a/plugins/website-recon-2/metadata.json
+++ b/plugins/website-recon-2/metadata.json
@@ -60,5 +60,8 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "4f8cf37fc9c3de4cdab5d4cb140c619f11bbf76ca6926aa6c41288168e8637f4"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "6bd0e14c310e9aac448576158e2bd9e5b4a0971a5e9b12894f84f7c3b866148e"
 }

--- a/plugins/whois_lookup/metadata.json
+++ b/plugins/whois_lookup/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.in"
   },
   "license": "MIT",
-  "icon": "\ud83d\udd0e",
+  "icon": "🔎",
   "engine": {
     "type": "cli",
     "binary": "python3"
@@ -60,5 +60,8 @@
     "system_packages": []
   },
   "docker_image": "alpine:latest",
-  "checksum": "6d4436abc7bb499843ec8d46a7100565631ff35a368885017c4a5f3136fbfaa1"
+  "capabilities": [
+    "network"
+  ],
+  "checksum": "3bd3e43d477b8ea7daff3919b364cc26669a81f278f413ab537473c5ec95e7e5"
 }

--- a/plugins/wpscan/metadata.json
+++ b/plugins/wpscan/metadata.json
@@ -10,7 +10,7 @@
     "email": "dev@secuscan.local"
   },
   "license": "MIT",
-  "icon": "\ud83d\udcdd",
+  "icon": "📝",
   "engine": {
     "type": "cli",
     "binary": "wpscan"
@@ -88,5 +88,9 @@
       "rubygems"
     ]
   },
-  "checksum": "7f614451043fec61f9ff59bffb749e5a549ce8a8ba9710484532f198ecea3d3a"
+  "capabilities": [
+    "network",
+    "intrusive"
+  ],
+  "checksum": "2a7ce78a3d2a67efa6729d50172bec283d590f9a82dc8d8548ede3c0481dcf75"
 }

--- a/plugins/yara_scan/metadata.json
+++ b/plugins/yara_scan/metadata.json
@@ -73,5 +73,9 @@
     "python_packages": [],
     "system_packages": []
   },
-  "checksum": "5cbd915870a7bae34f6d1b9d960e654221a0236e805a300024f38297be956ac5"
+  "capabilities": [
+    "filesystem",
+    "intrusive"
+  ],
+  "checksum": "f4db7b338b0c1ed8572378d70923cc9b3d74081b23178e283e80186623e96a71"
 }

--- a/scripts/backfill_plugin_capabilities.py
+++ b/scripts/backfill_plugin_capabilities.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Backfill explicit capabilities in plugin metadata.json files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLUGINS_DIR = REPO_ROOT / "plugins"
+
+# Explicit capability declarations for bundled plugins missing the field.
+PLUGIN_CAPABILITIES: dict[str, list[str]] = {
+    "amass": ["network"],
+    "cloud_scanner": ["network", "intrusive"],
+    "cloud_storage_auditor": ["network"],
+    "code_analyzer": ["filesystem"],
+    "container_scanner": ["network", "docker"],
+    "crawler": ["network", "intrusive"],
+    "dir_discovery": ["network", "intrusive", "filesystem"],
+    "dns_enum": ["network"],
+    "dnsx": ["network"],
+    "domain-finder": ["network"],
+    "droopescan": ["network", "intrusive"],
+    "fuzzer": ["network", "intrusive", "exploit", "filesystem"],
+    "google-dorking": ["network"],
+    "hashcat": ["filesystem", "intrusive", "exploit"],
+    "http_request_logger": ["network", "intrusive"],
+    "httpx": ["network"],
+    "iac_scanner": ["filesystem"],
+    "icmp_ping": ["network"],
+    "joomscan": ["network", "intrusive"],
+    "katana": ["network", "intrusive"],
+    "kubernetes_scanner": ["network", "intrusive"],
+    "metasploit": ["network", "intrusive", "exploit", "credentials"],
+    "nikto": ["network", "intrusive"],
+    "nmap": ["network"],
+    "nuclei": ["network", "intrusive"],
+    "password_auditor": ["network", "intrusive", "credentials"],
+    "people-email-discovery": ["network"],
+    "port-scanner": ["network", "intrusive"],
+    "scapy_recon": ["network"],
+    "secret_scanner": ["filesystem"],
+    "semgrep_scanner": ["filesystem"],
+    "sharepoint_scanner": ["network", "intrusive"],
+    "sitemap_gen": ["network", "intrusive"],
+    "spider": ["network", "intrusive"],
+    "sqli_checker": ["network", "intrusive"],
+    "sqli_exploiter": ["network", "intrusive", "exploit"],
+    "sqlmap": ["network", "intrusive", "exploit"],
+    "ssh_runner": ["network", "intrusive", "credentials"],
+    "subdomain_discovery": ["network"],
+    "subdomain_takeover": ["network", "intrusive", "exploit"],
+    "subfinder": ["network"],
+    "theharvester": ["network"],
+    "tls_inspector": ["network"],
+    "uncover": ["network"],
+    "url-fuzzer-2": ["network", "intrusive", "filesystem"],
+    "urlfinder": ["network"],
+    "virtual-host-finder": ["network", "intrusive", "filesystem"],
+    "volatility": ["filesystem", "intrusive"],
+    "website-recon-2": ["network"],
+    "whois_lookup": ["network"],
+    "wpscan": ["network", "intrusive"],
+    "yara_scan": ["filesystem", "intrusive"],
+}
+
+
+def insert_capabilities(metadata: dict, capabilities: list[str]) -> dict:
+    ordered: dict = {}
+    for key, value in metadata.items():
+        if key == "checksum":
+            ordered["capabilities"] = capabilities
+        ordered[key] = value
+    if "capabilities" not in ordered:
+        ordered["capabilities"] = capabilities
+    return ordered
+
+
+def main() -> None:
+    updated = 0
+    for plugin_id, capabilities in sorted(PLUGIN_CAPABILITIES.items()):
+        plugin_dir = PLUGINS_DIR / plugin_id
+        metadata_file = plugin_dir / "metadata.json"
+        if not metadata_file.exists():
+            raise SystemExit(f"Missing metadata for plugin: {plugin_id}")
+
+        metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+        if metadata.get("capabilities") is not None:
+            continue
+
+        metadata = insert_capabilities(metadata, capabilities)
+        metadata_file.write_text(
+            json.dumps(metadata, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        updated += 1
+        print(f"updated {plugin_id}: {capabilities}")
+
+    print(f"\nUpdated {updated} plugin metadata files.")
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/backend/unit/test_plugin_capabilities_inventory.py
+++ b/testing/backend/unit/test_plugin_capabilities_inventory.py
@@ -138,6 +138,18 @@ class TestPluginCapabilityInventory:
                     bad.append(f"{plugin_id}: non-lowercase token {token!r}")
         assert not bad, "\n".join(bad)
 
+    def test_all_shipped_plugins_declare_capabilities(self):
+        """Every bundled plugin must declare an explicit capabilities list."""
+        missing: list[str] = []
+        for plugin_id, meta in _iter_plugin_metadata():
+            caps = meta.get("capabilities")
+            if not isinstance(caps, list) or not caps:
+                missing.append(plugin_id)
+        assert not missing, (
+            "Bundled plugin(s) missing explicit capabilities declarations: "
+            f"{missing}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # CapabilityEnforcer construction-time token validation
@@ -295,7 +307,11 @@ class TestDeniedCapabilityBlocksExecution:
     def test_safe_plugin_passes_when_only_exploit_denied(self):
         enforcer = CapabilityEnforcer(denied_capabilities=["exploit"])
         # Should not raise — safe plugins do not require exploit capability.
-        enforcer.check("whois_lookup", declared=None, safety_level="safe")
+        enforcer.check("whois_lookup", declared=["network"], safety_level="safe")
+
+    def test_filesystem_only_plugin_passes_when_network_denied(self):
+        enforcer = CapabilityEnforcer(denied_capabilities=["network"])
+        enforcer.check("code_analyzer", declared=["filesystem"], safety_level="safe")
 
     def test_plugin_with_explicit_caps_blocked_on_denied_token(self):
         enforcer = CapabilityEnforcer(denied_capabilities=["credentials"])


### PR DESCRIPTION
## Summary
- Backfills explicit `capabilities` declarations for 52 bundled plugins that previously relied on safety-level implication.
- Enables granular operator denial (e.g. deny `network` without blocking filesystem-only scanners like `code_analyzer`).
- Adds `scripts/backfill_plugin_capabilities.py` and a regression test ensuring every shipped plugin declares capabilities.

Closes #1813

## Capability highlights
- **Network-only recon**: amass, httpx, nmap, whois_lookup, etc.
- **Filesystem-only analysis**: code_analyzer, secret_scanner, semgrep_scanner, iac_scanner
- **Docker runtime**: container_scanner
- **Credentials-aware**: ssh_runner, password_auditor, metasploit
- **Wordlist/filesystem fuzzers**: dir_discovery, url-fuzzer-2, virtual-host-finder

## Test plan
- [x] `python -m pytest testing/backend/unit/test_plugin_capabilities_inventory.py testing/backend/unit/test_capabilities.py testing/backend/unit/test_plugin_integrity.py -v` (75 passed)
- [x] `python scripts/refresh_plugin_checksum.py --all`
- [x] All bundled plugins now declare explicit capabilities