### PR TITLE
Add opt-in AI TriageEngine for false positive reduction (#1719)

### DIFF
--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -168,6 +168,16 @@ class Settings(BaseSettings):
     ai_summary_base_url: str = ""
     ai_summary_model: str = "gpt-4o-mini"
 
+    # AI Triage Engine — LLM-assisted false positive reduction (opt-in, off by default)
+    triage_engine_enabled: bool = False
+    triage_engine_api_key: str = ""
+    triage_engine_base_url: str = ""
+    triage_engine_model: str = "gpt-4o-mini"
+    # Findings at/above this confidence score already skip LLM triage (already trusted).
+    triage_engine_min_confidence_to_skip: float = 0.9
+    # Only these finding categories are eligible for LLM triage by default (AST/pattern-based SAST).
+    triage_engine_eligible_categories: List[str] = ["code security", "static analysis", "sast"]
+
     # SMTP Configuration for Email Notifications
     smtp_host: str = "smtp.gmail.com"
     smtp_port: int = 587

--- a/backend/secuscan/finding_intelligence.py
+++ b/backend/secuscan/finding_intelligence.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import re
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional
 from urllib.parse import urlparse
+
+from backend.secuscan import triage_engine
+from backend.secuscan.config import settings
 
 
 _OBSERVATION_CATEGORIES = {
@@ -433,6 +437,20 @@ async def normalize_and_correlate_findings(
                 match_strength=match_strength if fingerprint_score >= 0.45 else "none",
             )
         normalized.append(finding)
+
+    if settings.triage_engine_enabled and settings.triage_engine_api_key:
+        try:
+            triage_engine.triage_findings(
+                normalized,
+                model=settings.triage_engine_model,
+                api_key=settings.triage_engine_api_key,
+                base_url=settings.triage_engine_base_url or None,
+                eligible_categories=settings.triage_engine_eligible_categories,
+                min_confidence_to_skip=settings.triage_engine_min_confidence_to_skip,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Triage is a best-effort enhancement — never let it break scan results.
+            logging.getLogger(__name__).warning("triage_engine: batch triage failed — %s", exc)
 
     normalized.sort(
         key=lambda item: (

--- a/backend/secuscan/models.py
+++ b/backend/secuscan/models.py
@@ -238,6 +238,12 @@ class Finding(BaseModel):
     safe_to_apply: Optional[bool] = None
     compatible_range: Optional[str] = None
     alternatives: Optional[List[str]] = None
+    # AI Triage Engine (opt-in) — set when triage_engine_enabled and the
+    # finding was eligible (see triage_engine.is_eligible_for_triage).
+    triage_verdict: Optional[str] = None
+    triage_confidence: Optional[float] = None
+    triage_reasoning: Optional[str] = None
+    triage_remediation: Optional[str] = None
 
 
 class TaskResult(BaseModel):

--- a/backend/secuscan/triage_engine.py
+++ b/backend/secuscan/triage_engine.py
@@ -1,0 +1,313 @@
+"""
+triage_engine.py — LLM-powered context analysis for false positive reduction.
+
+Implements the TriageEngine described in issue #1719: a secondary validation
+layer that intercepts AST/regex-based static analysis findings before they
+reach the user, extracts the surrounding code context (snippet, variable
+definitions, data flow hints), and asks an LLM to judge whether the finding
+is a true or false positive, with a short rationale and remediation note.
+
+Design mirrors ai_summary.py:
+  - Opt-in and OFF by default (config.settings.triage_engine_enabled).
+  - Uses any OpenAI-compatible endpoint (OpenAI, Ollama, local LLM, etc).
+  - Fails open: any error (missing package, network failure, malformed
+    response) leaves the original finding untouched rather than blocking
+    the scan pipeline or discarding data.
+  - Never sends secrets/credentials extracted from evidence to the LLM
+    verbatim beyond what's already present in the finding's own metadata;
+    callers remain responsible for redaction upstream (see redaction.py).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from openai import OpenAI
+except ImportError:  # pragma: no cover
+    OpenAI = None  # type: ignore[misc,assignment]
+
+
+# How many lines of surrounding source to pull above/below the flagged line
+# when a readable source file is available locally.
+_CONTEXT_WINDOW = 6
+
+# Categories that AST/regex-based static analysis plugins report under.
+# Only findings in these categories are eligible for triage by default —
+# this keeps the (costlier) LLM call scoped to the class of finding the
+# feature was built for, rather than every scanner result.
+_DEFAULT_ELIGIBLE_CATEGORIES = {"code security", "static analysis", "sast"}
+
+_VALID_VERDICTS = {"true_positive", "false_positive", "needs_review"}
+
+
+def is_eligible_for_triage(
+    finding: Dict[str, Any],
+    *,
+    eligible_categories: Optional[List[str]] = None,
+    min_confidence_to_skip: float = 0.9,
+) -> bool:
+    """
+    Decide whether a finding should be sent through LLM triage.
+
+    Findings are skipped (left as-is) when they:
+      - already carry a triage verdict (idempotent — don't re-triage),
+      - fall outside the configured eligible categories (non-SAST findings
+        such as network/recon observations gain little from this analysis
+        and would just add latency/cost), or
+      - already have a high computed confidence score, since those findings
+        are already well corroborated and re-analysis adds little value.
+    """
+    if finding.get("triage_verdict"):
+        return False
+
+    category = str(finding.get("category") or "").strip().lower()
+    categories = {c.strip().lower() for c in (eligible_categories or _DEFAULT_ELIGIBLE_CATEGORIES)}
+    if category not in categories:
+        return False
+
+    confidence = finding.get("confidence")
+    if isinstance(confidence, (int, float)) and confidence >= min_confidence_to_skip:
+        return False
+
+    return True
+
+
+def extract_code_context(finding: Dict[str, Any], *, repo_root: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Extract the surrounding code context for a static-analysis finding.
+
+    Looks for a file path and line number in the finding's metadata (the
+    shape produced by plugins such as code_analyzer/semgrep_scanner) and,
+    when the source file is readable on disk, pulls a small window of
+    lines around the flagged line. Falls back to whatever snippet/proof
+    text the plugin already captured when the file can't be read (e.g. the
+    scan ran in a different environment than the triage step).
+    """
+    metadata = finding.get("metadata") if isinstance(finding.get("metadata"), dict) else {}
+    file_path = str(metadata.get("file") or metadata.get("filename") or "").strip()
+    try:
+        line_no = int(metadata.get("line") or metadata.get("line_number") or 0)
+    except (TypeError, ValueError):
+        line_no = 0
+
+    context: Dict[str, Any] = {
+        "file": file_path,
+        "line": line_no,
+        "snippet": "",
+        "variables": _extract_variable_hints(finding),
+    }
+
+    if not file_path or not line_no:
+        context["snippet"] = str(finding.get("proof") or finding.get("description") or "").strip()
+        return context
+
+    candidate = Path(repo_root) / file_path if repo_root else Path(file_path)
+    try:
+        if candidate.is_file():
+            lines = candidate.read_text(errors="replace").splitlines()
+            start = max(0, line_no - 1 - _CONTEXT_WINDOW)
+            end = min(len(lines), line_no + _CONTEXT_WINDOW)
+            context["snippet"] = "\n".join(lines[start:end])
+        else:
+            context["snippet"] = str(finding.get("proof") or finding.get("description") or "").strip()
+    except OSError as exc:
+        logger.debug("triage_engine: could not read %s for context — %s", file_path, exc)
+        context["snippet"] = str(finding.get("proof") or finding.get("description") or "").strip()
+
+    return context
+
+
+_VAR_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*=")
+
+
+def _extract_variable_hints(finding: Dict[str, Any]) -> List[str]:
+    """Best-effort variable name extraction from proof/description text."""
+    text = " ".join(
+        str(finding.get(key) or "")
+        for key in ("proof", "description", "title")
+    )
+    names = _VAR_RE.findall(text)
+    # De-duplicate while preserving order, cap to keep prompts small.
+    seen: List[str] = []
+    for name in names:
+        if name not in seen:
+            seen.append(name)
+    return seen[:10]
+
+
+def _build_triage_prompt(finding: Dict[str, Any], context: Dict[str, Any]) -> str:
+    title = str(finding.get("title") or "Untitled finding")
+    category = str(finding.get("category") or "unknown")
+    severity = str(finding.get("severity") or "unknown")
+    description = str(finding.get("description") or "").strip()
+    snippet = context.get("snippet") or "(no source snippet available)"
+    variables = ", ".join(context.get("variables") or []) or "(none identified)"
+    file_ref = context.get("file") or "(unknown file)"
+    line_ref = context.get("line") or "?"
+
+    return (
+        "You are a security engineer triaging a static-analysis finding to "
+        "reduce false positives. Static analysis (AST/regex pattern matching) "
+        "lacks semantic understanding of data flow and business logic, so it "
+        "over-flags. Use the code context below to judge whether this is a "
+        "real, exploitable issue.\n\n"
+        f"Finding: {title}\n"
+        f"Category: {category}\n"
+        f"Severity: {severity}\n"
+        f"Description: {description or '(none provided)'}\n"
+        f"File: {file_ref} (line {line_ref})\n"
+        f"Variables referenced near the flagged line: {variables}\n"
+        f"Code context:\n---\n{snippet}\n---\n\n"
+        "Consider things like: is user input actually reachable here, is the "
+        "value already sanitized/parameterized/escaped upstream, is this test "
+        "or fixture code rather than production code, and whether the "
+        "surrounding logic changes the risk.\n\n"
+        "Respond with ONLY a JSON object (no markdown fences, no preamble) "
+        "with exactly these keys:\n"
+        '  "verdict": one of "true_positive", "false_positive", "needs_review",\n'
+        '  "confidence": a number between 0 and 1,\n'
+        '  "reasoning": a one or two sentence explanation grounded in the '
+        "code context above,\n"
+        '  "remediation": a short actionable next step (empty string if the '
+        'verdict is "false_positive")'
+    )
+
+
+def _parse_triage_response(raw: str) -> Optional[Dict[str, Any]]:
+    text = raw.strip()
+    # Be tolerant of models that wrap JSON in markdown fences despite instructions.
+    fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if fence_match:
+        text = fence_match.group(1)
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning("triage_engine: LLM response was not valid JSON")
+        return None
+
+    verdict = str(data.get("verdict") or "").strip().lower()
+    if verdict not in _VALID_VERDICTS:
+        logger.warning("triage_engine: LLM returned unrecognized verdict %r", verdict)
+        return None
+
+    try:
+        confidence = float(data.get("confidence"))
+    except (TypeError, ValueError):
+        confidence = 0.5
+    confidence = max(0.0, min(1.0, confidence))
+
+    return {
+        "triage_verdict": verdict,
+        "triage_confidence": round(confidence, 2),
+        "triage_reasoning": str(data.get("reasoning") or "").strip(),
+        "triage_remediation": str(data.get("remediation") or "").strip(),
+    }
+
+
+def triage_finding(
+    finding: Dict[str, Any],
+    *,
+    model: str,
+    api_key: str,
+    base_url: Optional[str] = None,
+    repo_root: Optional[str] = None,
+    timeout: float = 15.0,
+) -> Optional[Dict[str, Any]]:
+    """
+    Run a single finding through LLM-assisted context analysis.
+
+    Returns a dict with triage_verdict / triage_confidence / triage_reasoning
+    / triage_remediation on success, or None on any failure — callers should
+    treat None as "leave the finding as-is" and never let it interrupt the
+    scan pipeline.
+    """
+    if OpenAI is None:
+        logger.warning(
+            "triage_engine: 'openai' package not installed. "
+            "Run `pip install openai>=1.0.0` to enable AI triage."
+        )
+        return None
+
+    context = extract_code_context(finding, repo_root=repo_root)
+    prompt = _build_triage_prompt(finding, context)
+
+    client_kwargs: Dict[str, Any] = {"api_key": api_key, "timeout": timeout}
+    if base_url:
+        client_kwargs["base_url"] = base_url
+
+    try:
+        client = OpenAI(**client_kwargs)
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=300,
+            temperature=0.1,
+        )
+        raw = response.choices[0].message.content or ""
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("triage_engine: LLM call failed — %s", exc)
+        return None
+
+    return _parse_triage_response(raw)
+
+
+def triage_findings(
+    findings: List[Dict[str, Any]],
+    *,
+    model: str,
+    api_key: str,
+    base_url: Optional[str] = None,
+    repo_root: Optional[str] = None,
+    eligible_categories: Optional[List[str]] = None,
+    min_confidence_to_skip: float = 0.9,
+    timeout: float = 15.0,
+) -> List[Dict[str, Any]]:
+    """
+    Apply LLM triage to a batch of findings in place (returns the same list
+    with eligible entries annotated). Ineligible findings, and any finding
+    where the LLM call fails, pass through unmodified so this can safely sit
+    in front of existing report/notification code paths.
+    """
+    if not findings:
+        return findings
+
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        if not is_eligible_for_triage(
+            finding,
+            eligible_categories=eligible_categories,
+            min_confidence_to_skip=min_confidence_to_skip,
+        ):
+            continue
+
+        result = triage_finding(
+            finding,
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            repo_root=repo_root,
+            timeout=timeout,
+        )
+        if not result:
+            continue
+
+        finding.update(result)
+        if result["triage_verdict"] == "false_positive":
+            # Surface the LLM's own reasoning as the confidence_reason so it's
+            # visible in the UI/report right next to the existing confidence
+            # scoring, without overwriting the analyst's own status field.
+            finding["confidence_reason"] = (
+                f"{finding.get('confidence_reason', '').rstrip('.')}; "
+                f"AI triage: likely false positive — {result['triage_reasoning']}"
+            ).strip("; ").strip()
+
+    return findings

--- a/testing/backend/unit/test_triage_engine.py
+++ b/testing/backend/unit/test_triage_engine.py
@@ -1,0 +1,203 @@
+"""
+Unit tests for backend/secuscan/triage_engine.py
+
+Run with:
+    ./testing/test_python.sh
+or directly:
+    python -m pytest testing/backend/unit/test_triage_engine.py -v
+"""
+
+from __future__ import annotations
+
+import textwrap
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.secuscan.triage_engine import (
+    extract_code_context,
+    is_eligible_for_triage,
+    triage_finding,
+    triage_findings,
+)
+
+
+def _mock_response(text: str) -> MagicMock:
+    choice = MagicMock()
+    choice.message.content = text
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+def _sast_finding(**overrides) -> dict:
+    finding = {
+        "title": "Possible SQL Injection",
+        "category": "code security",
+        "severity": "high",
+        "description": "User input concatenated into query = build_sql(user_id)",
+        "proof": "query = f\"SELECT * FROM users WHERE id={user_id}\"",
+        "metadata": {"file": "app/db.py", "line": 42},
+        "confidence": 0.4,
+    }
+    finding.update(overrides)
+    return finding
+
+
+class TestIsEligibleForTriage:
+    def test_eligible_sast_finding(self):
+        assert is_eligible_for_triage(_sast_finding()) is True
+
+    def test_ineligible_wrong_category(self):
+        finding = _sast_finding(category="attack surface")
+        assert is_eligible_for_triage(finding) is False
+
+    def test_ineligible_already_triaged(self):
+        finding = _sast_finding(triage_verdict="true_positive")
+        assert is_eligible_for_triage(finding) is False
+
+    def test_ineligible_high_confidence_skips(self):
+        finding = _sast_finding(confidence=0.95)
+        assert is_eligible_for_triage(finding, min_confidence_to_skip=0.9) is False
+
+    def test_eligible_respects_custom_categories(self):
+        finding = _sast_finding(category="custom-sast-tool")
+        assert is_eligible_for_triage(finding, eligible_categories=["custom-sast-tool"]) is True
+
+
+class TestExtractCodeContext:
+    def test_falls_back_to_proof_without_file(self):
+        finding = _sast_finding(metadata={})
+        context = extract_code_context(finding)
+        assert context["snippet"] == finding["proof"]
+        assert context["file"] == ""
+
+    def test_reads_source_file_when_available(self, tmp_path):
+        source = tmp_path / "db.py"
+        source.write_text(
+            textwrap.dedent(
+                """\
+                import sqlite3
+
+                def build_sql(user_id):
+                    # line 4
+                    # line 5
+                    query = f"SELECT * FROM users WHERE id={user_id}"
+                    return query
+                """
+            )
+        )
+        finding = _sast_finding(metadata={"file": "db.py", "line": 6})
+        context = extract_code_context(finding, repo_root=str(tmp_path))
+        assert "SELECT * FROM users" in context["snippet"]
+        assert context["file"] == "db.py"
+        assert context["line"] == 6
+
+    def test_missing_file_falls_back_gracefully(self):
+        finding = _sast_finding(metadata={"file": "does/not/exist.py", "line": 10})
+        context = extract_code_context(finding)
+        assert context["snippet"] == finding["proof"]
+
+    def test_extracts_variable_hints(self):
+        finding = _sast_finding()
+        context = extract_code_context(finding)
+        assert "query" in context["variables"]
+
+
+class TestTriageFinding:
+    def test_returns_parsed_verdict(self):
+        payload = (
+            '{"verdict": "false_positive", "confidence": 0.87, '
+            '"reasoning": "user_id is cast to int upstream", "remediation": ""}'
+        )
+        with patch("backend.secuscan.triage_engine.OpenAI") as mock_cls:
+            mock_cls.return_value.chat.completions.create.return_value = _mock_response(payload)
+            result = triage_finding(_sast_finding(), model="gpt-4o-mini", api_key="test-key")
+        assert result["triage_verdict"] == "false_positive"
+        assert result["triage_confidence"] == 0.87
+        assert "user_id" in result["triage_reasoning"]
+
+    def test_tolerates_markdown_fenced_json(self):
+        payload = '```json\n{"verdict": "true_positive", "confidence": 0.9, "reasoning": "x", "remediation": "y"}\n```'
+        with patch("backend.secuscan.triage_engine.OpenAI") as mock_cls:
+            mock_cls.return_value.chat.completions.create.return_value = _mock_response(payload)
+            result = triage_finding(_sast_finding(), model="gpt-4o-mini", api_key="key")
+        assert result["triage_verdict"] == "true_positive"
+
+    def test_returns_none_on_invalid_json(self):
+        with patch("backend.secuscan.triage_engine.OpenAI") as mock_cls:
+            mock_cls.return_value.chat.completions.create.return_value = _mock_response("not json")
+            result = triage_finding(_sast_finding(), model="gpt-4o-mini", api_key="key")
+        assert result is None
+
+    def test_returns_none_on_unrecognized_verdict(self):
+        payload = '{"verdict": "maybe", "confidence": 0.5, "reasoning": "x", "remediation": ""}'
+        with patch("backend.secuscan.triage_engine.OpenAI") as mock_cls:
+            mock_cls.return_value.chat.completions.create.return_value = _mock_response(payload)
+            result = triage_finding(_sast_finding(), model="gpt-4o-mini", api_key="key")
+        assert result is None
+
+    def test_returns_none_on_llm_exception(self):
+        with patch("backend.secuscan.triage_engine.OpenAI") as mock_cls:
+            mock_cls.return_value.chat.completions.create.side_effect = RuntimeError("timeout")
+            result = triage_finding(_sast_finding(), model="gpt-4o-mini", api_key="key")
+        assert result is None
+
+    def test_returns_none_when_openai_not_installed(self):
+        with patch("backend.secuscan.triage_engine.OpenAI", None):
+            result = triage_finding(_sast_finding(), model="gpt-4o-mini", api_key="key")
+        assert result is None
+
+    def test_clamps_out_of_range_confidence(self):
+        payload = '{"verdict": "true_positive", "confidence": 4.2, "reasoning": "x", "remediation": "y"}'
+        with patch("backend.secuscan.triage_engine.OpenAI") as mock_cls:
+            mock_cls.return_value.chat.completions.create.return_value = _mock_response(payload)
+            result = triage_finding(_sast_finding(), model="gpt-4o-mini", api_key="key")
+        assert result["triage_confidence"] == 1.0
+
+
+class TestTriageFindings:
+    def test_annotates_eligible_findings_in_place(self):
+        findings = [_sast_finding()]
+        payload = '{"verdict": "false_positive", "confidence": 0.8, "reasoning": "sanitized", "remediation": ""}'
+        with patch("backend.secuscan.triage_engine.OpenAI") as mock_cls:
+            mock_cls.return_value.chat.completions.create.return_value = _mock_response(payload)
+            result = triage_findings(findings, model="gpt-4o-mini", api_key="key")
+        assert result[0]["triage_verdict"] == "false_positive"
+        assert "AI triage" in result[0]["confidence_reason"]
+
+    def test_skips_ineligible_findings(self):
+        findings = [_sast_finding(category="attack surface")]
+        with patch("backend.secuscan.triage_engine.OpenAI") as mock_cls:
+            triage_findings(findings, model="gpt-4o-mini", api_key="key")
+            mock_cls.assert_not_called()
+        assert "triage_verdict" not in findings[0]
+
+    def test_leaves_finding_unmodified_when_llm_fails(self):
+        findings = [_sast_finding()]
+        with patch("backend.secuscan.triage_engine.OpenAI") as mock_cls:
+            mock_cls.return_value.chat.completions.create.side_effect = RuntimeError("down")
+            result = triage_findings(findings, model="gpt-4o-mini", api_key="key")
+        assert "triage_verdict" not in result[0]
+
+    def test_empty_list_returns_empty(self):
+        assert triage_findings([], model="gpt-4o-mini", api_key="key") == []
+
+    def test_non_dict_entries_are_skipped_safely(self):
+        findings = [_sast_finding(), "not-a-dict"]  # type: ignore[list-item]
+        payload = '{"verdict": "true_positive", "confidence": 0.7, "reasoning": "x", "remediation": "y"}'
+        with patch("backend.secuscan.triage_engine.OpenAI") as mock_cls:
+            mock_cls.return_value.chat.completions.create.return_value = _mock_response(payload)
+            result = triage_findings(findings, model="gpt-4o-mini", api_key="key")
+        assert result[0]["triage_verdict"] == "true_positive"
+        assert result[1] == "not-a-dict"
+
+
+class TestFindingIntelligenceIntegration:
+    """Confirm the opt-in hook in finding_intelligence stays inert by default."""
+
+    def test_disabled_by_default_settings(self):
+        from backend.secuscan.config import settings
+
+        assert settings.triage_engine_enabled is False
+        assert settings.triage_engine_api_key == ""


### PR DESCRIPTION
Introduces backend/secuscan/triage_engine.py: an LLM-assisted context analysis layer that triages AST/regex-based static analysis findings before they reach the user.

- extract_code_context() pulls a source snippet window around the flagged file/line (falls back to existing proof/description text when the source file isn't readable locally).
- triage_finding()/triage_findings() send eligible findings to any OpenAI-compatible endpoint and parse a structured verdict (true_positive / false_positive / needs_review) with confidence, reasoning, and a remediation note.
- is_eligible_for_triage() scopes the (costlier) LLM call to static-analysis categories and skips findings that already have high computed confidence or have already been triaged.

Mirrors the existing ai_summary.py pattern: opt-in and OFF by default, fails open on any error (missing package, network failure, malformed JSON) so a triage failure never blocks or corrupts scan results.

Wired into finding_intelligence.normalize_and_correlate_findings() behind settings.triage_engine_enabled, guarded by try/except.

- Add triage_engine_* settings to config.py
- Add triage_verdict/confidence/reasoning/remediation fields to the Finding model
- Add 22 unit tests in testing/backend/unit/test_triage_engine.py

All existing tests (213) continue to pass.

## Description
Adds an opt-in TriageEngine module that reduces false positives from static analysis by validating flagged findings with an LLM before they're surfaced, per issue #1719.

## Related Issues
Closes #1719

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Added 22 new unit tests in `testing/backend/unit/test_triage_engine.py` covering eligibility rules, code context extraction (including a real temp-file read), LLM response parsing (valid JSON, markdown-fenced JSON, invalid JSON, unrecognized verdicts, out-of-range confidence), and batch triage behavior. Ran the full backend suite locally — all 213 existing tests plus the 22 new ones pass with no regressions.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.