### PR TITLE
fix(sidebar): guard localStorage JSON.parse against corrupt values #1850

### DIFF
--- a/frontend/src/context/SidebarContext.tsx
+++ b/frontend/src/context/SidebarContext.tsx
@@ -7,21 +7,34 @@ interface SidebarContextType {
 
 const SidebarContext = createContext<SidebarContextType | undefined>(undefined)
 
+const SIDEBAR_EXPANDED_KEY = 'sidebar-expanded'
+
+/**
+ * Read the persisted sidebar expanded flag from localStorage.
+ * Corrupted or non-boolean values must not crash the app — default to true.
+ */
+function readSidebarExpanded(): boolean {
+    try {
+        const saved = localStorage.getItem(SIDEBAR_EXPANDED_KEY)
+        if (saved === null) return true
+        const parsed: unknown = JSON.parse(saved)
+        return typeof parsed === 'boolean' ? parsed : true
+    } catch {
+        return true
+    }
+}
+
 export function SidebarProvider({ children }: { children: ReactNode }) {
-    const [isExpanded, setIsExpanded] = useState(() => {
-        const saved = localStorage.getItem('sidebar-expanded')
-        return saved !== null ? JSON.parse(saved) : true
-    })
+    const [isExpanded, setIsExpanded] = useState(readSidebarExpanded)
 
     useEffect(() => {
-        localStorage.setItem('sidebar-expanded', JSON.stringify(isExpanded))
+        localStorage.setItem(SIDEBAR_EXPANDED_KEY, JSON.stringify(isExpanded))
         window.dispatchEvent(new CustomEvent('sidebar-state-changed', { detail: isExpanded }))
     }, [isExpanded])
 
     useEffect(() => {
         const handleStorageChange = () => {
-            const saved = localStorage.getItem('sidebar-expanded')
-            if (saved !== null) setIsExpanded(JSON.parse(saved))
+            setIsExpanded(readSidebarExpanded())
         }
 
         const handleSidebarStateChanged = (e: Event) => {

--- a/frontend/testing/unit/components/Sidebar.test.tsx
+++ b/frontend/testing/unit/components/Sidebar.test.tsx
@@ -90,6 +90,24 @@ describe('Sidebar - Accessibility', () => {
     expect(sidebar).toHaveAttribute('aria-expanded', 'false')
   })
 
+  it('should default to expanded when localStorage JSON is corrupted', () => {
+    localStorage.setItem('sidebar-expanded', '{not-valid-json')
+
+    const { container } = renderSidebar()
+    const sidebar = container.querySelector('aside')
+
+    expect(sidebar).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('should default to expanded when localStorage value is a non-boolean JSON value', () => {
+    localStorage.setItem('sidebar-expanded', JSON.stringify({ expanded: false }))
+
+    const { container } = renderSidebar()
+    const sidebar = container.querySelector('aside')
+
+    expect(sidebar).toHaveAttribute('aria-expanded', 'true')
+  })
+
   it('should not toggle sidebar on navigation item click', () => {
     const { container } = renderSidebar()
     const sidebar = container.querySelector('aside')


### PR DESCRIPTION
## Summary
- Wraps `sidebar-expanded` localStorage reads in try/catch so corrupted JSON cannot crash the Sidebar (and app via ErrorBoundary).
- Defaults to expanded (`true`) on parse failure or non-boolean values.
- Applies the same safe read path to the cross-tab `storage` listener.

Closes #1850

## Test plan
- [x] `npm run test -- testing/unit/components/Sidebar.test.tsx testing/unit/components/AppShell.test.tsx` (25/25 passed)
- [x] New regression: corrupted JSON defaults to expanded
- [x] New regression: non-boolean JSON value defaults to expanded