### PR TITLE
feat: add global search for findings and reports (#1981)

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -1257,6 +1257,71 @@ async def get_reports(owner: str = Depends(get_current_owner)):
     return await get_or_set_cached(f"reports:list:{owner}", build)
 
 
+def _escape_like(value: str) -> str:
+    """Escape SQLite LIKE wildcards so user input can't inject % or _ patterns."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+@router.get("/search", dependencies=[Depends(read_heavy_limiter)])
+async def search(
+    q: str = Query(..., min_length=1, max_length=200),
+    limit: int = Query(20, ge=1, le=100),
+    owner: str = Depends(get_current_owner),
+):
+    """Search the caller's findings and reports by title/description/name."""
+    db = await get_db()
+    pattern = f"%{_escape_like(q.strip())}%"
+
+    finding_rows = await db.fetchall(
+        """
+        SELECT id, task_id, title, category, severity, target, discovered_at
+        FROM findings
+        WHERE owner_id = ? AND (title LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\')
+        ORDER BY discovered_at DESC
+        LIMIT ?
+        """,
+        (owner, pattern, pattern, limit),
+    )
+
+    report_rows = await db.fetchall(
+        """
+        SELECT id, task_id, name, type, generated_at
+        FROM reports
+        WHERE owner_id = ? AND name LIKE ? ESCAPE '\\'
+        ORDER BY generated_at DESC
+        LIMIT ?
+        """,
+        (owner, pattern, limit),
+    )
+
+    return {
+        "query": q,
+        "findings": [
+            {
+                "id": row["id"],
+                "task_id": row["task_id"],
+                "title": row["title"],
+                "category": row["category"],
+                "severity": row["severity"],
+                "target": row["target"],
+                "discovered_at": row["discovered_at"],
+            }
+            for row in finding_rows
+        ],
+        "reports": [
+            {
+                "id": row["id"],
+                "task_id": row["task_id"],
+                "name": row["name"],
+                "type": row["type"],
+                "generated_at": row["generated_at"],
+            }
+            for row in report_rows
+        ],
+        "total": len(finding_rows) + len(report_rows),
+    }
+
+
 @router.get("/tasks", dependencies=[Depends(read_heavy_limiter)])
 async def list_tasks(
     page: int = Query(1, ge=1),

--- a/docs/API.md
+++ b/docs/API.md
@@ -89,6 +89,59 @@ and retry with a new request.
 }
 ```
 
+## Search API
+
+### Global Search
+
+**Endpoint:** `GET /api/v1/search`
+
+**Description:** Searches the caller's findings and reports by keyword. Findings
+are matched against `title` and `description`; reports are matched against
+`name`. Results are owner-scoped (see
+[Authentication and ownership](#authentication-and-ownership)) — a search never
+returns findings or reports owned by another `X-User-Id`.
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| q | string | Yes | — | Search query (1-200 characters) |
+| limit | integer | No | 20 | Max results per category (1-100) |
+
+**Response (200 OK):**
+
+```json
+{
+  "query": "sql injection",
+  "findings": [
+    {
+      "id": "finding-id",
+      "task_id": "task-id",
+      "title": "SQL Injection in login form",
+      "category": "Injection",
+      "severity": "high",
+      "target": "example.com",
+      "discovered_at": "2026-07-01T12:00:00Z"
+    }
+  ],
+  "reports": [
+    {
+      "id": "report-id",
+      "task_id": "task-id",
+      "name": "Q3 Security Report",
+      "type": "technical",
+      "generated_at": "2026-07-05T09:15:00Z"
+    }
+  ],
+  "total": 2
+}
+```
+
+```bash
+curl -H "X-Api-Key: $API_KEY" \
+  "http://localhost:8000/api/v1/search?q=sql+injection&limit=10"
+```
+
 ## See Also
 
 * [API Authentication](api-authentication.md) — How requests are authenticated with the API key and authorized per owner (`X-User-Id` → `owner_id`), including the cross-owner test requirement.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -189,6 +189,31 @@ export interface FindingsResponse {
   per_page?: number
 }
 
+export interface SearchFindingResult {
+  id: string
+  task_id?: string | null
+  title: string
+  category: string
+  severity: string
+  target: string
+  discovered_at?: string
+}
+
+export interface SearchReportResult {
+  id: string
+  task_id?: string | null
+  name: string
+  type: string
+  generated_at: string
+}
+
+export interface SearchResponse {
+  query: string
+  findings: SearchFindingResult[]
+  reports: SearchReportResult[]
+  total: number
+}
+
 export interface TaskResultResponse {
   task_id: string
   plugin_id: string
@@ -420,6 +445,11 @@ export function getFindingGroups(page: number = 1, perPage: number = 50) {
 
 export function getReports() {
   return request('/reports')
+}
+
+export function search(query: string, limit = 20) {
+  const params = new URLSearchParams({ q: query, limit: String(limit) })
+  return request<SearchResponse>(`/search?${params.toString()}`)
 }
 
 export type NotificationChannelType = 'webhook' | 'email'

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
 import Sidebar from './Sidebar'
 import Background from './Background'
+import GlobalSearch from './GlobalSearch'
 import { useShortcuts } from '../hooks/useShortcuts'
 import { SidebarProvider, useSidebar } from '../context/SidebarContext'
 import { routes } from '../routes'
@@ -91,11 +92,11 @@ function AppShellInner({ children }: AppShellProps) {
             <Background state="idle" />
             <div className="flex bg-charcoal-dark min-h-screen">
                 <Sidebar />
-                <div className="lg:hidden fixed inset-x-0 top-0 z-[60] bg-[var(--bg-secondary)] border-b border-accent-silver/10 h-14 px-4 flex items-center justify-between">
+                <div className="lg:hidden fixed inset-x-0 top-0 z-[60] bg-[var(--bg-secondary)] border-b border-accent-silver/10 h-14 px-4 flex items-center gap-3">
                     <button
                         ref={menuButtonRef}
                         onClick={() => setMobileMenuOpen((prev) => !prev)}
-                        className="w-9 h-9 border border-accent-silver/20 flex items-center justify-center text-silver-bright bg-charcoal-dark"
+                        className="w-9 h-9 shrink-0 border border-accent-silver/20 flex items-center justify-center text-silver-bright bg-charcoal-dark"
                         aria-label="Toggle navigation menu"
                         aria-expanded={mobileMenuOpen}
                         aria-controls="mobile-nav-drawer"
@@ -104,8 +105,7 @@ function AppShellInner({ children }: AppShellProps) {
                             {mobileMenuOpen ? 'close' : 'menu'}
                         </span>
                     </button>
-                    <span className="text-[12px] font-black tracking-[0.2em] text-silver-bright uppercase">SecuScan</span>
-                    <span className="w-9 h-9" />
+                    <GlobalSearch className="flex-1 min-w-0" />
                 </div>
 
                 {mobileMenuOpen && (
@@ -146,12 +146,20 @@ function AppShellInner({ children }: AppShellProps) {
                     </>
                 )}
 
-                <main
-                    className="flex-1 overflow-auto transition-all duration-300 ease-in-out ml-0 lg:ml-[var(--sidebar-width)] pt-14 lg:pt-0 pb-20 lg:pb-0"
+                <div
+                    className="flex-1 flex flex-col min-w-0 transition-all duration-300 ease-in-out ml-0 lg:ml-[var(--sidebar-width)]"
                     style={{ '--sidebar-width': `${desktopSidebarWidth}px` } as React.CSSProperties}
                 >
-                    {children}
-                </main>
+                    <div className="hidden lg:flex items-center h-14 px-6 border-b border-accent-silver/10 bg-[var(--bg-secondary)]">
+                        <GlobalSearch className="w-full max-w-md" />
+                    </div>
+                    <main
+                        className="flex-1 overflow-auto pt-14 lg:pt-0 pb-20 lg:pb-0"
+                        style={{ '--sidebar-width': `${desktopSidebarWidth}px` } as React.CSSProperties}
+                    >
+                        {children}
+                    </main>
+                </div>
 
                 <nav className="lg:hidden fixed bottom-0 inset-x-0 z-40 h-16 bg-[var(--bg-secondary)] border-t border-accent-silver/10 grid grid-cols-5 px-1 pb-safe">
                     {mobilePrimaryNav.map((item) => (

--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { search, SearchFindingResult, SearchReportResult } from '../api'
+import { useDebouncedValue } from '../hooks/useDebouncedValue'
+import { routes } from '../routes'
+
+interface GlobalSearchProps {
+  className?: string
+  onNavigate?: () => void
+}
+
+export default function GlobalSearch({ className = '', onNavigate }: GlobalSearchProps) {
+  const [query, setQuery] = useState('')
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [findings, setFindings] = useState<SearchFindingResult[]>([])
+  const [reports, setReports] = useState<SearchReportResult[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const navigate = useNavigate()
+
+  const debouncedQuery = useDebouncedValue(query.trim(), 300)
+
+  useEffect(() => {
+    if (!debouncedQuery) {
+      setFindings([])
+      setReports([])
+      setError(null)
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+
+    search(debouncedQuery)
+      .then((data) => {
+        if (cancelled) return
+        setFindings(data.findings)
+        setReports(data.reports)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setError('Search failed. Try again.')
+        setFindings([])
+        setReports([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [debouncedQuery])
+
+  useEffect(() => {
+    if (!open) return
+    function onPointerDown(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  function goTo(path: string) {
+    setOpen(false)
+    setQuery('')
+    onNavigate?.()
+    navigate(path)
+  }
+
+  const hasResults = findings.length > 0 || reports.length > 0
+  const showDropdown = open && debouncedQuery.length > 0
+
+  return (
+    <div ref={containerRef} className={`relative ${className}`}>
+      <div className="relative">
+        <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-[16px] text-silver/40 pointer-events-none">
+          search
+        </span>
+        <input
+          type="text"
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value)
+            setOpen(true)
+          }}
+          onFocus={() => setOpen(true)}
+          placeholder="Search findings, reports..."
+          aria-label="Global search"
+          className="h-9 w-full border border-accent-silver/20 bg-charcoal-dark pl-9 pr-3 text-xs font-mono text-silver-bright placeholder:text-silver/30 focus:border-rag-red focus:outline-none"
+        />
+      </div>
+
+      {showDropdown && (
+        <div
+          role="listbox"
+          aria-label="Search results"
+          className="absolute left-0 right-0 top-full z-[70] mt-2 max-h-96 overflow-y-auto border-2 border-black bg-charcoal shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]"
+        >
+          {loading ? (
+            <p className="px-4 py-4 text-[11px] font-mono uppercase tracking-[0.16em] text-silver/45">
+              Searching...
+            </p>
+          ) : error ? (
+            <p className="px-4 py-4 text-[11px] font-mono uppercase tracking-[0.16em] text-rag-red">
+              {error}
+            </p>
+          ) : !hasResults ? (
+            <p className="px-4 py-4 text-[11px] font-mono uppercase tracking-[0.16em] text-silver/45">
+              No results for "{debouncedQuery}"
+            </p>
+          ) : (
+            <>
+              {findings.length > 0 && (
+                <div className="border-b border-silver-bright/8">
+                  <p className="px-4 pt-3 pb-1 text-[9px] font-black uppercase tracking-[0.2em] text-silver/35">
+                    Findings
+                  </p>
+                  {findings.map((finding) => (
+                    <button
+                      key={finding.id}
+                      type="button"
+                      role="option"
+                      aria-selected={false}
+                      onClick={() => goTo(routes.findings)}
+                      className="block w-full px-4 py-2 text-left hover:bg-silver-bright/5"
+                    >
+                      <p className="text-xs font-bold text-silver-bright truncate">{finding.title}</p>
+                      <p className="text-[10px] font-mono uppercase tracking-[0.12em] text-silver/40">
+                        {finding.severity} // {finding.target}
+                      </p>
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {reports.length > 0 && (
+                <div>
+                  <p className="px-4 pt-3 pb-1 text-[9px] font-black uppercase tracking-[0.2em] text-silver/35">
+                    Reports
+                  </p>
+                  {reports.map((report) => (
+                    <button
+                      key={report.id}
+                      type="button"
+                      role="option"
+                      aria-selected={false}
+                      onClick={() => goTo(routes.reports)}
+                      className="block w-full px-4 py-2 text-left hover:bg-silver-bright/5"
+                    >
+                      <p className="text-xs font-bold text-silver-bright truncate">{report.name}</p>
+                      <p className="text-[10px] font-mono uppercase tracking-[0.12em] text-silver/40">
+                        {report.type}
+                      </p>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useDebouncedValue.ts
+++ b/frontend/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react'
+
+/** Returns `value`, updated only after `delayMs` has passed with no further changes. */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebounced(value), delayMs)
+    return () => window.clearTimeout(timer)
+  }, [value, delayMs])
+
+  return debounced
+}

--- a/frontend/testing/unit/components/GlobalSearch.test.tsx
+++ b/frontend/testing/unit/components/GlobalSearch.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import GlobalSearch from '../../../src/components/GlobalSearch'
+
+vi.mock('../../../src/api', () => ({
+  search: vi.fn(),
+}))
+
+import { search } from '../../../src/api'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<any>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+function renderSearch() {
+  return render(
+    <MemoryRouter>
+      <GlobalSearch />
+    </MemoryRouter>,
+  )
+}
+
+describe('GlobalSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the search input', () => {
+    renderSearch()
+    expect(screen.getByLabelText('Global search')).toBeInTheDocument()
+  })
+
+  it('does not call search for an empty query', async () => {
+    renderSearch()
+    await new Promise((r) => setTimeout(r, 350))
+    expect(search).not.toHaveBeenCalled()
+  })
+
+  it('debounces and calls search after typing', async () => {
+    vi.mocked(search).mockResolvedValue({
+      query: 'sql',
+      findings: [
+        { id: 'f1', title: 'SQL Injection', category: 'Injection', severity: 'critical', target: 'example.com' },
+      ],
+      reports: [],
+      total: 1,
+    })
+
+    renderSearch()
+    const input = screen.getByLabelText('Global search')
+    await userEvent.type(input, 'sql')
+
+    await waitFor(() => expect(search).toHaveBeenCalledWith('sql'), { timeout: 1000 })
+    expect(await screen.findByText('SQL Injection')).toBeInTheDocument()
+  })
+
+  it('shows a no-results message when nothing matches', async () => {
+    vi.mocked(search).mockResolvedValue({ query: 'zzz', findings: [], reports: [], total: 0 })
+
+    renderSearch()
+    await userEvent.type(screen.getByLabelText('Global search'), 'zzz')
+
+    await waitFor(() => expect(search).toHaveBeenCalled(), { timeout: 1000 })
+    expect(await screen.findByText(/No results for "zzz"/i)).toBeInTheDocument()
+  })
+
+  it('shows an error message when the search request fails', async () => {
+    vi.mocked(search).mockRejectedValue(new Error('network error'))
+
+    renderSearch()
+    await userEvent.type(screen.getByLabelText('Global search'), 'fail')
+
+    await waitFor(() => expect(search).toHaveBeenCalled(), { timeout: 1000 })
+    expect(await screen.findByText(/Search failed/i)).toBeInTheDocument()
+  })
+
+  it('navigates to the findings page when a finding result is clicked', async () => {
+    vi.mocked(search).mockResolvedValue({
+      query: 'sql',
+      findings: [
+        { id: 'f1', title: 'SQL Injection', category: 'Injection', severity: 'critical', target: 'example.com' },
+      ],
+      reports: [],
+      total: 1,
+    })
+
+    renderSearch()
+    await userEvent.type(screen.getByLabelText('Global search'), 'sql')
+
+    const result = await screen.findByText('SQL Injection')
+    await userEvent.click(result)
+
+    expect(mockNavigate).toHaveBeenCalledWith('/findings')
+  })
+
+  it('closes the dropdown on Escape', async () => {
+    vi.mocked(search).mockResolvedValue({ query: 'sql', findings: [], reports: [], total: 0 })
+
+    renderSearch()
+    await userEvent.type(screen.getByLabelText('Global search'), 'sql')
+    await waitFor(() => expect(search).toHaveBeenCalled(), { timeout: 1000 })
+    expect(await screen.findByRole('listbox', { name: /search results/i })).toBeInTheDocument()
+
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() =>
+      expect(screen.queryByRole('listbox', { name: /search results/i })).not.toBeInTheDocument(),
+    )
+  })
+})

--- a/testing/backend/integration/test_search.py
+++ b/testing/backend/integration/test_search.py
@@ -1,0 +1,149 @@
+import sqlite3
+import uuid
+
+from backend.secuscan.config import settings
+
+
+def _insert_finding(owner_id="default", title="SQL Injection in login form", description="", category="Injection", severity="high", target="example.com"):
+    finding_id = str(uuid.uuid4())
+    with sqlite3.connect(settings.database_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO findings (
+                id, owner_id, task_id, plugin_id, title, category, severity,
+                target, description, remediation
+            ) VALUES (?, ?, NULL, 'test_plugin', ?, ?, ?, ?, ?, '')
+            """,
+            (finding_id, owner_id, title, category, severity, target, description),
+        )
+        conn.commit()
+    return finding_id
+
+
+def _insert_report(owner_id="default", name="Q3 Security Report", report_type="technical"):
+    report_id = str(uuid.uuid4())
+    with sqlite3.connect(settings.database_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO reports (id, owner_id, task_id, name, type)
+            VALUES (?, ?, NULL, ?, ?)
+            """,
+            (report_id, owner_id, name, report_type),
+        )
+        conn.commit()
+    return report_id
+
+
+def test_search_requires_query_param(test_client):
+    """A missing 'q' parameter should be rejected with 422."""
+    response = test_client.get("/api/v1/search")
+    assert response.status_code == 422
+
+
+def test_search_finds_matching_finding_by_title(test_client):
+    """Search should return findings whose title matches the query."""
+    finding_id = _insert_finding(title="SQL Injection in login form")
+    _insert_finding(title="Unrelated XSS issue")
+
+    response = test_client.get("/api/v1/search", params={"q": "SQL Injection"})
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["query"] == "SQL Injection"
+    matched_ids = [f["id"] for f in data["findings"]]
+    assert finding_id in matched_ids
+    assert data["total"] >= 1
+
+
+def test_search_finds_matching_finding_by_description(test_client):
+    """Search should also match against the finding description."""
+    finding_id = _insert_finding(
+        title="Generic Finding",
+        description="A reflected cross-site scripting vulnerability was found",
+    )
+
+    response = test_client.get("/api/v1/search", params={"q": "cross-site scripting"})
+    assert response.status_code == 200
+    data = response.json()
+
+    matched_ids = [f["id"] for f in data["findings"]]
+    assert finding_id in matched_ids
+
+
+def test_search_finds_matching_report_by_name(test_client):
+    """Search should return reports whose name matches the query."""
+    report_id = _insert_report(name="Quarterly Pentest Summary")
+    _insert_report(name="Unrelated Report")
+
+    response = test_client.get("/api/v1/search", params={"q": "Pentest"})
+    assert response.status_code == 200
+    data = response.json()
+
+    matched_ids = [r["id"] for r in data["reports"]]
+    assert report_id in matched_ids
+
+
+def test_search_is_case_insensitive(test_client):
+    """SQLite LIKE is case-insensitive for ASCII by default; verify that holds here."""
+    finding_id = _insert_finding(title="Broken Access Control")
+
+    response = test_client.get("/api/v1/search", params={"q": "broken access"})
+    assert response.status_code == 200
+    matched_ids = [f["id"] for f in response.json()["findings"]]
+    assert finding_id in matched_ids
+
+
+def test_search_returns_empty_for_no_matches(test_client):
+    """A query matching nothing should return empty lists, not an error."""
+    response = test_client.get("/api/v1/search", params={"q": "zzz_no_such_finding_zzz"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["findings"] == []
+    assert data["reports"] == []
+    assert data["total"] == 0
+
+
+def test_search_escapes_like_wildcards(test_client):
+    """A literal '%' or '_' in the query must not act as a SQL wildcard."""
+    # This finding's title contains no literal percent sign, so a query of
+    # '%' should NOT match it if wildcards are properly escaped.
+    _insert_finding(title="Normal finding without special characters")
+
+    response = test_client.get("/api/v1/search", params={"q": "%"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["findings"] == []
+    assert data["reports"] == []
+
+
+def test_search_respects_limit_param(test_client):
+    """The limit parameter should cap the number of results per category."""
+    for i in range(5):
+        _insert_finding(title=f"Duplicate Match Finding {i}")
+
+    response = test_client.get("/api/v1/search", params={"q": "Duplicate Match", "limit": 2})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["findings"]) <= 2
+
+
+def test_search_rejects_limit_out_of_range(test_client):
+    """limit must stay within the declared 1-100 bounds."""
+    response = test_client.get("/api/v1/search", params={"q": "test", "limit": 0})
+    assert response.status_code == 422
+
+    response = test_client.get("/api/v1/search", params={"q": "test", "limit": 101})
+    assert response.status_code == 422
+
+
+def test_search_scopes_results_to_owner(test_client):
+    """A finding belonging to a different owner must never appear in results (issue #401 pattern)."""
+    other_owner_finding_id = _insert_finding(
+        owner_id="other_owner",
+        title="Owner Isolation Test Finding",
+    )
+
+    response = test_client.get("/api/v1/search", params={"q": "Owner Isolation"})
+    assert response.status_code == 200
+    matched_ids = [f["id"] for f in response.json()["findings"]]
+    assert other_owner_finding_id not in matched_ids


### PR DESCRIPTION
## Description
Adds a global search feature for findings and reports, accessible from a search bar in the top navigation (both desktop and mobile).

**Backend:** New `GET /api/v1/search?q={query}&limit={limit}` endpoint in `routes.py`. Searches the caller's `findings` (by `title`/`description`) and `reports` (by `name`) using SQLite `LIKE`, scoped to `owner_id` per the existing BOLA-prevention pattern (issue #401) used throughout this file. User input is escaped against `%`/`_`/`\` before being used in the `LIKE` pattern so literal wildcard characters in a search query can't produce unintended matches.

**Frontend:** New `GlobalSearch` component wired into `AppShell`'s desktop top bar and mobile header. Input is debounced (300ms, via a new reusable `useDebouncedValue` hook) before calling the backend, and results render in a dropdown grouped by Findings/Reports. Clicking a result navigates to the relevant list page (Findings or Reports), no per-item detail route exists yet in the app, so this is the closest correct behavior today.

Restructured `AppShell.tsx` to add a shared top bar row (search) above `<main>` for desktop, while preserving the existing sidebar-offset layout behavior.Also documents the new endpoint in `docs/API.md` under a new "Search API" section, matching the existing per-endpoint format.

## Related Issues
Closes #1981

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Added `testing/backend/integration/test_search.py` - 10 tests covering: missing/invalid query params, matching by finding title, matching by finding description, matching by report name, case-insensitivity, empty-result handling, `LIKE` wildcard escaping (`%`/`_` treated as literal characters, not SQL wildcards), `limit` bounds enforcement, and owner-scoping (a finding belonging to another owner never appears in results).
- Added `frontend/testing/unit/components/GlobalSearch.test.tsx` - covers initial render, debounce behavior (no call on empty query, call after typing), result rendering, no-results state, error state, navigation on result click, and closing the dropdown on Escape.
- Ran `./testing/test_python.sh` - new test file: 10/10 passing.
- Ran `npm run typecheck` - clean.
- Ran `npm run test` - 546/546 passing (including the two pre-existing `AppShell.test.tsx` sidebar-width tests, which needed the `--sidebar-width` CSS var re-applied directly to `<main>` after the layout restructure).
- Ran `npm run build` - builds clean.
- Ran `bash scripts/check-artifacts.sh origin/main` - no tracked generated artifacts or cache files in the diff.
- Manually verified: typing in the search bar returns matching findings/reports, clicking a result navigates and clears the input, Escape closes the dropdown, clicking outside closes the dropdown.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.