### PR TITLE
fix(ui): prevent filter controls from overlapping in Findings page

### DIFF
--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -824,7 +824,7 @@ export default function Findings() {
             </div>
 
             <div className="flex flex-col gap-6">
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              <div className="grid gap-x-4 gap-y-5 grid-cols-[repeat(auto-fit,minmax(180px,1fr))]">
                 <div className="space-y-2 min-w-0">
                   <label className={filterLabelClass}>Target</label>
                   <select

--- a/frontend/testing/unit/pages/Findings.test.tsx
+++ b/frontend/testing/unit/pages/Findings.test.tsx
@@ -329,7 +329,7 @@ describe('Findings — virtualized list', () => {
 
     const gridContainer = fieldContainer?.parentElement
     expect(gridContainer).toHaveClass('grid', 'gap-x-4', 'gap-y-5')
-    
+
     const filterContainer = gridContainer?.parentElement
     expect(filterContainer).toHaveClass('flex', 'flex-col', 'gap-6')
   })

--- a/frontend/testing/unit/pages/Findings.test.tsx
+++ b/frontend/testing/unit/pages/Findings.test.tsx
@@ -328,8 +328,8 @@ describe('Findings — virtualized list', () => {
     expect(fieldContainer).toHaveClass('space-y-2', 'min-w-0')
 
     const gridContainer = fieldContainer?.parentElement
-    expect(gridContainer).toHaveClass('grid', 'gap-4', 'sm:grid-cols-2', 'lg:grid-cols-3', 'xl:grid-cols-4')
-
+    expect(gridContainer).toHaveClass('grid', 'gap-x-4', 'gap-y-5')
+    
     const filterContainer = gridContainer?.parentElement
     expect(filterContainer).toHaveClass('flex', 'flex-col', 'gap-6')
   })


### PR DESCRIPTION
> Contributed under GSSoC 2026
## Description
Fixes the overlapping filter controls in the Findings page search bar. Replaced the fixed responsive grid layout (`sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4`) with `grid-cols-[repeat(auto-fit,minmax(180px,1fr))]` so each filter item has a minimum width of 180px and wraps gracefully to a new line when horizontal space is insufficient, preventing labels and dropdowns from collapsing into each other.

## Related Issues
Closes #953

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Visually verified in the browser that TARGET, SCANNER, ASSET, FINDING KIND, ANALYST STATE, SORT BY, FROM DATE and TO DATE filter controls no longer overlap and wrap correctly when horizontal space is limited.

To reproduce the original issue:
1. Navigate to the Findings page
2. Look at the filter row below the search input
3. Observe filters no longer overlap after this fix

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.