### PR TITLE
fix(hooks): guard usePreferredExportFormat localStorage access #1846

### DIFF
--- a/frontend/src/hooks/usePreferredExportFormat.ts
+++ b/frontend/src/hooks/usePreferredExportFormat.ts
@@ -2,13 +2,24 @@ import { useState } from 'react'
 
 const STORAGE_KEY = 'secuscan:preferred-export-format'
 
+function readPreferredFormat(): string | null {
+    try {
+        return localStorage.getItem(STORAGE_KEY)
+    } catch {
+        // Private mode / blocked storage — do not crash render.
+        return null
+    }
+}
+
 export function usePreferredExportFormat() {
-    const [preferred, setPreferred] = useState<string | null>(
-        () => localStorage.getItem(STORAGE_KEY)
-    )
+    const [preferred, setPreferred] = useState<string | null>(readPreferredFormat)
 
     function savePreference(format: string) {
-        localStorage.setItem(STORAGE_KEY, format)
+        try {
+            localStorage.setItem(STORAGE_KEY, format)
+        } catch {
+            // Ignore write failures (quota / private mode); still update React state.
+        }
         setPreferred(format)
     }
 

--- a/frontend/testing/unit/hooks/usePreferredExportFormat.test.ts
+++ b/frontend/testing/unit/hooks/usePreferredExportFormat.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { usePreferredExportFormat } from '../../../src/hooks/usePreferredExportFormat'
 
 const STORAGE_KEY = 'secuscan:preferred-export-format'
@@ -32,5 +32,31 @@ describe('usePreferredExportFormat', () => {
 
     expect(result.current.preferred).toBe('csv')
     expect(localStorage.getItem(STORAGE_KEY)).toBe('csv')
+  })
+
+  it('returns null on init when localStorage.getItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Access denied', 'SecurityError')
+    })
+
+    const { result } = renderHook(() => usePreferredExportFormat())
+
+    expect(result.current.preferred).toBeNull()
+    vi.restoreAllMocks()
+  })
+
+  it('still updates React state when localStorage.setItem throws', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Access denied', 'SecurityError')
+    })
+
+    const { result } = renderHook(() => usePreferredExportFormat())
+
+    act(() => {
+      result.current.savePreference('html')
+    })
+
+    expect(result.current.preferred).toBe('html')
+    vi.restoreAllMocks()
   })
 })


### PR DESCRIPTION
## Summary
- Wraps `localStorage.getItem` in try/catch during hook init so private-mode / blocked storage cannot crash render.
- Also guards `setItem` in `savePreference` so write failures still update React state without throwing.
- Defaults to `null` when storage is unavailable.

Closes #1846

## Test plan
- [x] `npm run test -- testing/unit/hooks/usePreferredExportFormat.test.ts` (5/5 passed)
- [x] New regression: `getItem` throwing returns `null`
- [x] New regression: `setItem` throwing still updates preferred state