### PR TITLE
fix(security): bound NetworkPolicyEngine audit log to prevent OOM (#2012)

### DIFF
--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -82,6 +82,7 @@ class Settings(BaseSettings):
     ]
     network_audit_log_file: str = str(PROJECT_ROOT / "logs" / "network.audit.log")
     network_audit_retention_days: int = 90
+    network_audit_max_entries: int = 10000
     enforce_network_policy: bool = True
     network_policy_failure_mode: str = "block"  # "block" or "log_only"
 

--- a/backend/secuscan/network_policy.py
+++ b/backend/secuscan/network_policy.py
@@ -6,6 +6,7 @@ allowlist/denylist policies. Supports both IPv4 and IPv6.
 """
 
 import ipaddress
+import json
 import logging
 import asyncio
 import socket
@@ -80,11 +81,12 @@ class NetworkPolicyEngine:
       3. Default deny (no match = blocked)
     """
 
-    def __init__(self, audit_log_path: str = "/var/log/secuscan/network.audit.log"):
+    def __init__(self, audit_log_path: str = "/var/log/secuscan/network.audit.log", max_audit_entries: int = 10000):
         self.allowlist: List[Tuple[ipaddress.ip_network, NetworkPolicy]] = []
         self.denylist: List[Tuple[ipaddress.ip_network, NetworkPolicy]] = []
         self.audit_log_path = audit_log_path
         self.audit_entries: List[AuditLogEntry] = []
+        self._max_audit_entries = max_audit_entries
 
         # Create audit log file
         self._init_audit_log()
@@ -352,12 +354,15 @@ class NetworkPolicyEngine:
         return datetime.now() > policy.expires_at
 
     def _log_audit_entry(self, entry: AuditLogEntry) -> None:
-        """Log audit entry to file and memory"""
+        """Log audit entry to file and memory with bounded eviction."""
         self.audit_entries.append(entry)
+
+        # Evict oldest entries when the cap is exceeded
+        if len(self.audit_entries) > self._max_audit_entries:
+            self.audit_entries = self.audit_entries[-self._max_audit_entries:]
 
         try:
             with open(self.audit_log_path, 'a') as f:
-                import json
                 f.write(json.dumps(entry.to_dict()) + "\n")
         except IOError as e:
             logger.error(f"Failed to write audit log: {e}")
@@ -388,6 +393,10 @@ class NetworkPolicyEngine:
             entries = [e for e in entries if e.action == action]
 
         return entries[-limit:]  # Return most recent N
+
+    def clear_audit_entries(self) -> None:
+        """Clear all in-memory audit entries."""
+        self.audit_entries.clear()
 
     def validate_egress_target(self, host: str, port: int = 443) -> Tuple[bool, str]:
         """Validate an outbound webhook/egress destination against network policy.
@@ -466,7 +475,8 @@ def get_policy_engine() -> NetworkPolicyEngine:
     if _policy_engine is None:
         from .config import settings
         _policy_engine = NetworkPolicyEngine(
-            audit_log_path=settings.network_audit_log_file
+            audit_log_path=settings.network_audit_log_file,
+            max_audit_entries=settings.network_audit_max_entries,
         )
         _init_default_policies(_policy_engine)
     return _policy_engine


### PR DESCRIPTION
## Summary

Fixes unbounded memory accumulation in NetworkPolicyEngine audit log that causes OOM crashes in long-running instances.

Closes #2012

## Changes

- **
etwork_policy.py**: Added configurable max_audit_entries (default 10,000) to NetworkPolicyEngine.__init__() with ring-buffer eviction in _log_audit_entry()
- **
etwork_policy.py**: Moved import json from loop body to module level (was re-imported on every audit write)
- **network_policy.py**: Added clear_audit_entries() method for manual cleanup
- **config.py**: Added 
etwork_audit_max_entries setting (default 10000) wired through get_policy_engine()

## Problem

Every network access check (allow, deny, default-deny) appends an AuditLogEntry to an in-memory list with no eviction policy. In a long-running SecuScan instance, this list grows indefinitely leading to OOM crashes.

## Impact

- Prevents out-of-memory crashes in production deployments
- Reduces per-request overhead by eliminating redundant import json in the audit write loop
- Configurable via SECUSCAN_NETWORK_AUDIT_MAX_ENTRIES environment variable

## Testing

Verified that:
- Audit entries are evicted when exceeding max_audit_entries
- Existing audit filtering (by plugin_id, action, limit) still works correctly
- clear_audit_entries() properly clears the in-memory buffer