### PR TITLE
fix(security): validate X-Request-ID header to prevent injection (#2013)

### DIFF
--- a/backend/secuscan/request_context.py
+++ b/backend/secuscan/request_context.py
@@ -1,16 +1,30 @@
+import re
+import logging
 from contextvars import ContextVar
 from typing import Optional
 from uuid import uuid4
+
+logger = logging.getLogger(__name__)
 
 request_id_context: ContextVar[str] = ContextVar(
     "request_id",
     default=""
 )
 
+# Only allow alphanumeric, hyphens, underscores -- max 128 chars
+RequestIdPattern = re.compile(r'^[a-zA-Z0-9_-]{1,128}$')
+
+
 def get_request_id() -> str:
     return request_id_context.get()
 
 def set_request_id(request_id: Optional[str] = None) -> str:
+    if request_id and not RequestIdPattern.match(request_id):
+        logger.warning(
+            "Rejected malformed X-Request-ID (length=%d), generating new ID",
+            len(request_id),
+        )
+        request_id = None
     request_id = request_id or str(uuid4())
     request_id_context.set(request_id)
     return request_id

--- a/testing/backend/unit/test_request_middleware.py
+++ b/testing/backend/unit/test_request_middleware.py
@@ -51,7 +51,7 @@ class TestRequestIDMiddleware:
         except ValueError:
             raise AssertionError(f"Expected UUID format, got: {rid}")
 
-    def test_very_long_request_id_is_preserved(self):
+    def test_very_long_request_id_is_rejected(self):
         with TestClient(app) as client:
             long_id = "x" * 512
             response = client.get(
@@ -60,30 +60,50 @@ class TestRequestIDMiddleware:
             )
 
         assert response.status_code == 200
-        assert response.headers["X-Request-ID"] == long_id
+        # Oversized ID should be replaced with a generated UUID
+        assert response.headers["X-Request-ID"] != long_id
+        assert response.headers["X-Request-ID"]
 
 
 class TestRequestIDMiddlewareEdgeCases:
     """Edge case tests for RequestIDMiddleware covering special characters and concurrency."""
 
-    def test_special_characters_in_request_id_are_preserved(self):
-        """Special characters in X-Request-ID header should be preserved in response."""
-        special_ids = [
-            "req-with-dash_underscore.dot",
+    def test_malicious_request_ids_are_rejected(self):
+        """Malformed X-Request-ID values with dangerous chars should be rejected."""
+        malicious_ids = [
             "req/with/slashes",
             "req;with;semicolons",
             'req"with"quotes',
             "req with spaces",
         ]
-        for special_id in special_ids:
+        for malicious_id in malicious_ids:
             with TestClient(app) as client:
                 response = client.get(
                     "/api/v1/health",
-                    headers={"X-Request-ID": special_id},
+                    headers={"X-Request-ID": malicious_id},
                 )
 
             assert response.status_code == 200
-            assert response.headers["X-Request-ID"] == special_id
+            # Malicious ID should be replaced with a safe UUID
+            assert response.headers["X-Request-ID"] != malicious_id
+            assert response.headers["X-Request-ID"]
+
+    def test_valid_request_ids_are_preserved(self):
+        """Valid alphanumeric request IDs with hyphens/underscores should be preserved."""
+        valid_ids = [
+            "req-with-dash_underscore",
+            "abc123",
+            "550e8400-e29b-41d4-a716-446655440000",
+        ]
+        for valid_id in valid_ids:
+            with TestClient(app) as client:
+                response = client.get(
+                    "/api/v1/health",
+                    headers={"X-Request-ID": valid_id},
+                )
+
+            assert response.status_code == 200
+            assert response.headers["X-Request-ID"] == valid_id
 
     def test_concurrent_requests_get_isolated_request_ids(self):
         """Two concurrent threads should each get an isolated request ID via ContextVar."""


### PR DESCRIPTION
## Summary

Fixes X-Request-ID header injection vulnerability by validating and sanitizing client-provided request IDs.

Closes #2013

## Changes

- **equest_context.py**: Added regex validation (^[a-zA-Z0-9_-]{1,128}$) to set_request_id() to reject malformed or oversized request IDs
- Malformed IDs are rejected with a warning log and replaced with a safe UUID
- Limits request IDs to 128 characters max, alphanumeric + hyphens/underscores only

## Problem

The X-Request-ID header from clients was accepted without any validation, sanitization, or length limiting. An attacker could inject:

1. **Extremely long values** causing memory amplification and log file exhaustion
2. **Newlines/CR characters** enabling log forging and CRLF injection
3. **Arbitrary content** that gets reflected verbatim in response headers

## Impact

- Prevents header injection attacks via crafted X-Request-ID values
- Prevents log forging by rejecting IDs with dangerous characters
- Prevents memory/disk DoS by enforcing a 128-character length limit
- Malformed IDs are safely replaced with UUIDs and logged as warnings

## Testing

Verified that:
- Valid UUID-style request IDs (e.g., 550e8400-e29b-41d4-a716-446655440000) are accepted
- Valid short IDs (e.g., bc-123_DEF) are accepted
- Oversized IDs (>128 chars) are rejected and replaced with UUID
- IDs containing newlines, spaces, or special characters are rejected
- Empty/None values correctly generate a new UUID