### PR TITLE
feat(frontend): centralize stream transport URLs and reconnect backoff

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -16,6 +16,30 @@ function resolveApiBase(): string {
 
 export const API_BASE = resolveApiBase()
 
+import {
+  buildTaskStreamUrl as buildTaskStreamUrlForBase,
+  createReconnectingEventSource,
+  resolveSseUrl as resolveSseUrlForBase,
+  resolveWsBase as resolveWsBaseForBase,
+  resolveWsUrl as resolveWsUrlForBase,
+} from './utils/streamTransport'
+
+export function resolveSseUrl(pathOrUrl: string): string {
+  return resolveSseUrlForBase(API_BASE, pathOrUrl)
+}
+
+export function resolveWsBase(): string {
+  return resolveWsBaseForBase(API_BASE)
+}
+
+export function resolveWsUrl(path = '/ws/feed'): string {
+  return resolveWsUrlForBase(API_BASE, path)
+}
+
+export function buildTaskStreamUrl(taskId: string): string {
+  return buildTaskStreamUrlForBase(API_BASE, taskId)
+}
+
 export type PluginFieldType =
   | 'string'
   | 'text'
@@ -630,12 +654,63 @@ export function cancelTask(taskId: string) {
   })
 }
 
-export function streamTask(taskId: string, onEvent: (ev: MessageEvent) => void) {
-  const url = `${API_BASE}/task/${taskId}/stream`
-  const es = new EventSource(url, { withCredentials: true })
-  es.onmessage = onEvent
-  es.onerror = () => {}
-  return es
+export interface StreamTaskOptions {
+  maxReconnectAttempts?: number
+  reconnectBaseDelay?: number
+  maxReconnectDelay?: number
+  onReconnect?: (attempt: number, delayMs: number) => void
+}
+
+export function streamTask(
+  taskId: string,
+  onEvent: (ev: MessageEvent) => void,
+  options: StreamTaskOptions = {},
+) {
+  const url = buildTaskStreamUrl(taskId)
+  let activeSource: EventSource | null = null
+
+  const connection = createReconnectingEventSource(url, {
+    maxReconnectAttempts: options.maxReconnectAttempts ?? 5,
+    reconnectBaseDelay: options.reconnectBaseDelay ?? 1000,
+    maxReconnectDelay: options.maxReconnectDelay,
+    onReconnect: options.onReconnect,
+    withCredentials: true,
+    onInstance: (instance) => {
+      activeSource = instance as EventSource
+      activeSource.onmessage = onEvent
+    },
+  })
+
+  return {
+    get url() {
+      return url
+    },
+    get readyState() {
+      return activeSource?.readyState ?? EventSource.CLOSED
+    },
+    close() {
+      connection.close()
+      activeSource = null
+    },
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      activeSource?.addEventListener(type, listener)
+    },
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      activeSource?.removeEventListener(type, listener)
+    },
+    dispatchEvent(event: Event) {
+      return activeSource?.dispatchEvent(event) ?? false
+    },
+    set onmessage(handler: ((this: EventSource, ev: MessageEvent) => unknown) | null) {
+      if (activeSource) activeSource.onmessage = handler
+    },
+    set onerror(handler: ((this: EventSource, ev: Event) => unknown) | null) {
+      if (activeSource) activeSource.onerror = handler
+    },
+    set onopen(handler: ((this: EventSource, ev: Event) => unknown) | null) {
+      if (activeSource) activeSource.onopen = handler
+    },
+  }
 }
 export interface WorkflowStep {
   plugin_id: string

--- a/frontend/src/hooks/useTaskSubscription.ts
+++ b/frontend/src/hooks/useTaskSubscription.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { API_BASE, getTaskStatus } from '../api'
+import { buildTaskStreamUrl, getTaskStatus } from '../api'
+import { createReconnectBackoff } from '../utils/streamTransport'
 
 export interface UseTaskSubscriptionOptions {
   taskId: string
@@ -35,7 +36,9 @@ export function useTaskSubscription({
   const onOutputRef = useRef(onOutput)
   const esRef = useRef<EventSource | null>(null)
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const reconnectAttemptRef = useRef(0)
+  const reconnectBackoffRef = useRef(
+    createReconnectBackoff({ baseDelay: reconnectBaseDelay, maxAttempts: maxReconnectAttempts }),
+  )
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastStatusRef = useRef<string | null>(null)
   const cleanupRef = useRef(false)
@@ -102,7 +105,7 @@ export function useTaskSubscription({
       esRef.current = null
     }
 
-    const url = `${API_BASE}/task/${taskId}/stream`
+    const url = buildTaskStreamUrl(taskId)
     const es = new EventSource(url, { withCredentials: true })
     esRef.current = es
 
@@ -155,9 +158,8 @@ export function useTaskSubscription({
       setIsConnected(false)
       setError('SSE connection lost')
 
-      if (reconnectAttemptRef.current < maxReconnectAttempts) {
-        const delay = reconnectBaseDelay * Math.pow(2, reconnectAttemptRef.current)
-        reconnectAttemptRef.current++
+      if (reconnectBackoffRef.current.canRetry()) {
+        const delay = reconnectBackoffRef.current.nextDelay()
         reconnectTimerRef.current = setTimeout(() => {
           if (!cleanupRef.current) connectSSE()
         }, delay)
@@ -168,24 +170,27 @@ export function useTaskSubscription({
 
     es.onopen = () => {
       if (cleanupRef.current || versionRef.current !== version) return
-      reconnectAttemptRef.current = 0
+      reconnectBackoffRef.current.reset()
       setIsConnected(true)
       setIsPolling(false)
       setError(null)
     }
-  }, [taskId, maxReconnectAttempts, reconnectBaseDelay, cleanupAll, startPolling])
+  }, [taskId, cleanupAll, startPolling])
 
   useEffect(() => {
     cleanupRef.current = false
     lastStatusRef.current = null
-    reconnectAttemptRef.current = 0
+    reconnectBackoffRef.current = createReconnectBackoff({
+      baseDelay: reconnectBaseDelay,
+      maxAttempts: maxReconnectAttempts,
+    })
 
     connectSSE()
 
     return () => {
       cleanupAll()
     }
-  }, [taskId, connectSSE, cleanupAll])
+  }, [taskId, connectSSE, cleanupAll, reconnectBaseDelay, maxReconnectAttempts])
 
   return { isConnected, isPolling, error }
 }

--- a/frontend/src/utils/streamTransport.ts
+++ b/frontend/src/utils/streamTransport.ts
@@ -1,0 +1,262 @@
+export interface ReconnectBackoffOptions {
+  baseDelay?: number
+  maxAttempts?: number
+  maxDelay?: number
+}
+
+export interface ReconnectBackoff {
+  reset: () => void
+  canRetry: () => boolean
+  nextDelay: () => number
+  readonly attempts: number
+}
+
+export function createReconnectBackoff({
+  baseDelay = 1000,
+  maxAttempts = 5,
+  maxDelay = 30_000,
+}: ReconnectBackoffOptions = {}): ReconnectBackoff {
+  let attempts = 0
+
+  return {
+    get attempts() {
+      return attempts
+    },
+    reset() {
+      attempts = 0
+    },
+    canRetry() {
+      return attempts < maxAttempts
+    },
+    nextDelay() {
+      const delay = Math.min(baseDelay * Math.pow(2, attempts), maxDelay)
+      attempts++
+      return delay
+    },
+  }
+}
+
+export interface StreamOrigins {
+  httpOrigin: string
+  wsOrigin: string
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value
+}
+
+function ensureLeadingSlash(value: string): string {
+  return value.startsWith('/') ? value : `/${value}`
+}
+
+export function resolveStreamOrigins(apiBase: string): StreamOrigins {
+  if (apiBase.startsWith('http://') || apiBase.startsWith('https://')) {
+    const url = new URL(apiBase)
+    const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+    return {
+      httpOrigin: `${url.protocol}//${url.host}`,
+      wsOrigin: `${wsProtocol}//${url.host}`,
+    }
+  }
+
+  if (typeof window === 'undefined') {
+    return { httpOrigin: '', wsOrigin: '' }
+  }
+
+  const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return {
+    httpOrigin: window.location.origin,
+    wsOrigin: `${wsProtocol}//${window.location.host}`,
+  }
+}
+
+export function resolveSseUrl(apiBase: string, pathOrUrl: string): string {
+  if (pathOrUrl.startsWith('http://') || pathOrUrl.startsWith('https://')) {
+    return pathOrUrl
+  }
+
+  const normalizedPath = ensureLeadingSlash(pathOrUrl)
+  if (normalizedPath.startsWith('/api/')) {
+    if (apiBase.startsWith('http://') || apiBase.startsWith('https://')) {
+      return `${resolveStreamOrigins(apiBase).httpOrigin}${normalizedPath}`
+    }
+    return normalizedPath
+  }
+
+  const base = trimTrailingSlash(apiBase)
+  if (apiBase.startsWith('http://') || apiBase.startsWith('https://')) {
+    return `${base}${normalizedPath}`
+  }
+
+  return `${base}${normalizedPath}`
+}
+
+export function resolveWsBase(apiBase: string): string {
+  const base = trimTrailingSlash(apiBase)
+
+  if (apiBase.startsWith('http://') || apiBase.startsWith('https://')) {
+    const url = new URL(base)
+    const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+    return `${wsProtocol}//${url.host}${url.pathname}`
+  }
+
+  const { wsOrigin } = resolveStreamOrigins(apiBase)
+  return `${wsOrigin}${base}`
+}
+
+export function resolveWsUrl(apiBase: string, path = '/ws/feed'): string {
+  const normalizedPath = ensureLeadingSlash(path)
+  if (normalizedPath.startsWith('/api/')) {
+    return `${resolveStreamOrigins(apiBase).wsOrigin}${normalizedPath}`
+  }
+
+  return `${resolveWsBase(apiBase)}${normalizedPath}`
+}
+
+export function buildTaskStreamUrl(apiBase: string, taskId: string): string {
+  return resolveSseUrl(apiBase, `/task/${taskId}/stream`)
+}
+
+export interface ReconnectingTransportOptions {
+  maxReconnectAttempts?: number
+  reconnectBaseDelay?: number
+  maxReconnectDelay?: number
+  withCredentials?: boolean
+  onReconnect?: (attempt: number, delayMs: number) => void
+  onExhausted?: () => void
+  onInstance?: (instance: EventSource | WebSocket) => void
+}
+
+export interface ReconnectingTransportHandle {
+  close: () => void
+}
+
+export function createReconnectingEventSource(
+  url: string,
+  options: ReconnectingTransportOptions = {},
+): ReconnectingTransportHandle & { get current(): EventSource | null } {
+  const backoff = createReconnectBackoff({
+    baseDelay: options.reconnectBaseDelay,
+    maxAttempts: options.maxReconnectAttempts,
+    maxDelay: options.maxReconnectDelay,
+  })
+
+  let closed = false
+  let es: EventSource | null = null
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+
+  const clearReconnectTimer = () => {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+  }
+
+  const connect = () => {
+    if (closed) return
+    es?.close()
+    es = new EventSource(
+      url,
+      options.withCredentials ? { withCredentials: true } : undefined,
+    )
+    options.onInstance?.(es)
+
+    es.onopen = () => {
+      backoff.reset()
+    }
+
+    es.onerror = () => {
+      if (closed) return
+      es?.close()
+      es = null
+
+      if (backoff.canRetry()) {
+        const delay = backoff.nextDelay()
+        options.onReconnect?.(backoff.attempts, delay)
+        reconnectTimer = setTimeout(connect, delay)
+        return
+      }
+
+      options.onExhausted?.()
+    }
+  }
+
+  connect()
+
+  return {
+    get current() {
+      return es
+    },
+    close() {
+      closed = true
+      clearReconnectTimer()
+      es?.close()
+      es = null
+    },
+  }
+}
+
+export function createReconnectingWebSocket(
+  url: string,
+  options: ReconnectingTransportOptions = {},
+): ReconnectingTransportHandle & { get current(): WebSocket | null } {
+  const backoff = createReconnectBackoff({
+    baseDelay: options.reconnectBaseDelay,
+    maxAttempts: options.maxReconnectAttempts,
+    maxDelay: options.maxReconnectDelay,
+  })
+
+  let closed = false
+  let ws: WebSocket | null = null
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+
+  const clearReconnectTimer = () => {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+  }
+
+  const connect = () => {
+    if (closed) return
+    ws?.close()
+    ws = new WebSocket(url)
+    options.onInstance?.(ws)
+
+    ws.onopen = () => {
+      backoff.reset()
+    }
+
+    ws.onclose = () => {
+      if (closed) return
+      ws = null
+
+      if (backoff.canRetry()) {
+        const delay = backoff.nextDelay()
+        options.onReconnect?.(backoff.attempts, delay)
+        reconnectTimer = setTimeout(connect, delay)
+        return
+      }
+
+      options.onExhausted?.()
+    }
+
+    ws.onerror = () => {
+      ws?.close()
+    }
+  }
+
+  connect()
+
+  return {
+    get current() {
+      return ws
+    },
+    close() {
+      closed = true
+      clearReconnectTimer()
+      ws?.close()
+      ws = null
+    },
+  }
+}

--- a/frontend/testing/unit/hooks/useTaskSubscription.test.ts
+++ b/frontend/testing/unit/hooks/useTaskSubscription.test.ts
@@ -4,7 +4,7 @@ import React from 'react'
 import { useTaskSubscription } from '../../../src/hooks/useTaskSubscription'
 
 vi.mock('../../../src/api', () => ({
-  API_BASE: 'http://localhost',
+  buildTaskStreamUrl: (taskId: string) => `http://localhost/task/${taskId}/stream`,
   getTaskStatus: vi.fn().mockResolvedValue({ status: 'running' }),
 }))
 

--- a/frontend/testing/unit/pages/ScanPhases.test.tsx
+++ b/frontend/testing/unit/pages/ScanPhases.test.tsx
@@ -6,6 +6,7 @@ import * as api from '../../../src/api';
 
 vi.mock('../../../src/api', () => ({
   API_BASE: 'http://localhost',
+  buildTaskStreamUrl: (taskId: string) => `http://localhost/task/${taskId}/stream`,
   getTaskStatus: vi.fn(),
   getTaskResult: vi.fn(),
   getPluginSchema: vi.fn().mockResolvedValue(null),

--- a/frontend/testing/unit/utils/streamTransport.test.ts
+++ b/frontend/testing/unit/utils/streamTransport.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildTaskStreamUrl,
+  createReconnectBackoff,
+  createReconnectingEventSource,
+  createReconnectingWebSocket,
+  resolveSseUrl,
+  resolveWsBase,
+  resolveWsUrl,
+} from '../../../src/utils/streamTransport'
+
+describe('streamTransport URL resolution', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    vi.stubGlobal('location', {
+      ...originalLocation,
+      protocol: 'http:',
+      host: 'localhost:5173',
+      origin: 'http://localhost:5173',
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('resolves relative SSE task stream URLs from a proxied API base', () => {
+    expect(buildTaskStreamUrl('/api/v1', 'task-1')).toBe('/api/v1/task/task-1/stream')
+  })
+
+  it('resolves absolute SSE task stream URLs from an explicit API base', () => {
+    expect(buildTaskStreamUrl('http://127.0.0.1:8000/api/v1', 'task-1')).toBe(
+      'http://127.0.0.1:8000/api/v1/task/task-1/stream',
+    )
+  })
+
+  it('resolves backend-provided stream_url values consistently', () => {
+    expect(resolveSseUrl('/api/v1', '/api/v1/task/task-1/stream')).toBe('/api/v1/task/task-1/stream')
+    expect(resolveSseUrl('http://127.0.0.1:8000/api/v1', '/api/v1/task/task-1/stream')).toBe(
+      'http://127.0.0.1:8000/api/v1/task/task-1/stream',
+    )
+  })
+
+  it('resolves WebSocket feed URLs under the same API base', () => {
+    expect(resolveWsUrl('/api/v1')).toBe('ws://localhost:5173/api/v1/ws/feed')
+    expect(resolveWsUrl('http://127.0.0.1:8000/api/v1')).toBe('ws://127.0.0.1:8000/api/v1/ws/feed')
+    expect(resolveWsUrl('https://secuscan.example/api/v1')).toBe('wss://secuscan.example/api/v1/ws/feed')
+  })
+
+  it('exposes the WebSocket base without the feed suffix', () => {
+    expect(resolveWsBase('/api/v1')).toBe('ws://localhost:5173/api/v1')
+    expect(resolveWsBase('http://127.0.0.1:8000/api/v1')).toBe('ws://127.0.0.1:8000/api/v1')
+  })
+})
+
+describe('createReconnectBackoff', () => {
+  it('returns exponential delays until max attempts are exhausted', () => {
+    const backoff = createReconnectBackoff({ baseDelay: 1000, maxAttempts: 3 })
+
+    expect(backoff.canRetry()).toBe(true)
+    expect(backoff.nextDelay()).toBe(1000)
+    expect(backoff.canRetry()).toBe(true)
+    expect(backoff.nextDelay()).toBe(2000)
+    expect(backoff.canRetry()).toBe(true)
+    expect(backoff.nextDelay()).toBe(4000)
+    expect(backoff.canRetry()).toBe(false)
+  })
+
+  it('resets attempt count after a successful connection', () => {
+    const backoff = createReconnectBackoff({ baseDelay: 500, maxAttempts: 2 })
+    backoff.nextDelay()
+    backoff.reset()
+
+    expect(backoff.canRetry()).toBe(true)
+    expect(backoff.nextDelay()).toBe(500)
+  })
+})
+
+class MockEventSource {
+  static instances: MockEventSource[] = []
+  onopen: (() => void) | null = null
+  onerror: ((err: Event) => void) | null = null
+  readyState = 0
+  closeCount = 0
+
+  constructor(public url: string) {
+    MockEventSource.instances.push(this)
+  }
+
+  close() {
+    this.closeCount++
+    const idx = MockEventSource.instances.indexOf(this)
+    if (idx !== -1) MockEventSource.instances.splice(idx, 1)
+  }
+
+  triggerOpen() {
+    this.readyState = 1
+    this.onopen?.()
+  }
+
+  triggerError() {
+    this.onerror?.(new Event('error'))
+  }
+
+  static reset() {
+    MockEventSource.instances = []
+  }
+}
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  onopen: (() => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: ((err: Event) => void) | null = null
+  readyState = 0
+  closeCount = 0
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this)
+  }
+
+  close() {
+    this.closeCount++
+    const idx = MockWebSocket.instances.indexOf(this)
+    if (idx !== -1) MockWebSocket.instances.splice(idx, 1)
+    this.onclose?.()
+  }
+
+  triggerOpen() {
+    this.readyState = 1
+    this.onopen?.()
+  }
+
+  triggerClose() {
+    this.onclose?.()
+  }
+
+  static reset() {
+    MockWebSocket.instances = []
+  }
+}
+
+describe('reconnecting transports', () => {
+  beforeEach(() => {
+    MockEventSource.reset()
+    MockWebSocket.reset()
+    vi.stubGlobal('EventSource', MockEventSource as unknown as typeof EventSource)
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('reconnects SSE with exponential backoff', () => {
+    const onReconnect = vi.fn()
+    const connection = createReconnectingEventSource('http://localhost/stream', {
+      maxReconnectAttempts: 2,
+      reconnectBaseDelay: 1000,
+      onReconnect,
+    })
+
+    const first = MockEventSource.instances[0]
+    first.triggerError()
+
+    expect(onReconnect).toHaveBeenCalledWith(1, 1000)
+    vi.advanceTimersByTime(1000)
+    expect(MockEventSource.instances).toHaveLength(1)
+
+    MockEventSource.instances[0].triggerError()
+    expect(onReconnect).toHaveBeenCalledWith(2, 2000)
+
+    connection.close()
+  })
+
+  it('reconnects WebSocket with exponential backoff', () => {
+    const onReconnect = vi.fn()
+    const connection = createReconnectingWebSocket('ws://localhost/api/v1/ws/feed', {
+      maxReconnectAttempts: 2,
+      reconnectBaseDelay: 500,
+      onReconnect,
+    })
+
+    MockWebSocket.instances[0].triggerClose()
+    expect(onReconnect).toHaveBeenCalledWith(1, 500)
+
+    vi.advanceTimersByTime(500)
+    expect(MockWebSocket.instances[MockWebSocket.instances.length - 1]?.url).toBe('ws://localhost/api/v1/ws/feed')
+
+    connection.close()
+  })
+})


### PR DESCRIPTION
## Description

Centralizes WebSocket and SSE base URL resolution and adds shared exponential reconnect backoff for both transports.

## Related Issues

Closes #1871

## Changes

- Add `frontend/src/utils/streamTransport.ts` as the single source of truth for SSE/WS URL resolution and reconnect backoff
- Export API-bound wrappers from `api.ts` (`resolveWsBase`, `resolveSseUrl`, `buildTaskStreamUrl`)
- Refactor `useTaskSubscription` and `streamTask` to use centralized URL builders and backoff

## How Has This Been Tested?

- [x] `npm run typecheck`
- [x] `npx vitest run testing/unit/utils/streamTransport.test.ts`
- [x] `npx vitest run testing/unit/hooks/useTaskSubscription.test.ts`