### PR TITLE
fix: avoid confidence boost for unknown fingerprint strength

### DIFF
--- a/backend/secuscan/finding_intelligence.py
+++ b/backend/secuscan/finding_intelligence.py
@@ -273,7 +273,7 @@ def _fingerprint_score(finding: Dict[str, Any]) -> tuple[float, str]:
         or ("validated" if finding.get("validated") else "none")
     ).lower()
     mapping = {"validated": 1.0, "exact": 0.95, "strong_fuzzy": 0.8, "fuzzy": 0.7, "family": 0.45, "none": 0.25}
-    return mapping.get(match_strength, 0.35), match_strength
+    return mapping.get(match_strength, 0.0), match_strength
 
 
 def _source_quality(sources: Iterable[str]) -> float:

--- a/testing/backend/unit/test_finding_intelligence_confidence.py
+++ b/testing/backend/unit/test_finding_intelligence_confidence.py
@@ -144,6 +144,13 @@ class TestFingerprintScore:
         assert score == 0.25
         assert strength == "none"
 
+    def test_unknown_match_strength_has_no_fingerprint_confidence(self):
+        score, strength = _fingerprint_score(
+            {"metadata": {"match_strength": "unknown_strength"}}
+        )
+        assert score == 0.0
+        assert strength == "unknown_strength"
+
     def test_missing_metadata(self):
         score, strength = _fingerprint_score({})
         assert score == 0.25


### PR DESCRIPTION


Fixes #1835.

Unknown fingerprint match strengths previously defaulted to a score of `0.35`, which could inflate confidence for findings without a recognized fingerprint match.

This change makes unknown match strengths contribute `0.0` fingerprint confidence while preserving the existing scores for known match strengths.

## Changes

- Changed the fallback fingerprint score from `0.35` to `0.0`
- Added a regression test for unknown match strengths

## Testing

- `py -m pytest testing/backend/unit/test_finding_intelligence_confidence.py -v`
- 35 passed