### PR TITLE
fix(security): enforce API key auth on saved views router [#2035]

### DIFF
--- a/backend/secuscan/saved_views.py
+++ b/backend/secuscan/saved_views.py
@@ -4,12 +4,17 @@ import json
 import uuid
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
+from .auth import require_api_key
 from .database import get_db
 
-saved_views_router = APIRouter(prefix="/api/v1/saved-views", tags=["saved-views"])
+saved_views_router = APIRouter(
+    prefix="/api/v1/saved-views",
+    tags=["saved-views"],
+    dependencies=[Depends(require_api_key)],
+)
 
 _VALID_SORT_MODES = {"severity", "newest", "oldest", "target"}
 _VALID_SEVERITIES = {"all", "critical", "high", "medium", "low", "info"}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -390,7 +390,7 @@ export async function logoutSession(): Promise<void> {
   _apiKey = null
 }
 
-function getApiKey(): string | null {
+export function getApiKey(): string | null {
   return _apiKey
 }
 

--- a/frontend/src/hooks/useSavedViews.ts
+++ b/frontend/src/hooks/useSavedViews.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { API_BASE } from '../api'
+import { API_BASE, getApiKey } from '../api'
 
 export interface FilterPreset {
   severity: string
@@ -126,8 +126,15 @@ async function apiFetch<T>(
   init?: RequestInit,
 ): Promise<T | null> {
   try {
+    const apiKey = getApiKey()
+    const authHeaders: Record<string, string> = apiKey ? { 'X-Api-Key': apiKey } : {}
     const res = await fetch(`${API_BASE}${path}`, {
       ...init,
+      headers: {
+        ...authHeaders,
+        ...(init?.headers as Record<string, string> | undefined),
+      },
+      credentials: 'include',
       signal: AbortSignal.timeout(8000),
     })
     if (!res.ok) return null


### PR DESCRIPTION
## Summary
Enforce API key authentication on the saved views router, closing an authentication bypass vulnerability.

Closes #2035

## Problem
The `saved_views_router` in `backend/secuscan/saved_views.py` was registered in `main.py` **without** the `require_api_key` dependency. This allowed unauthenticated access to all CRUD endpoints:

- `GET /api/v1/saved-views` — enumerate all saved views
- `POST /api/v1/saved-views` — create views
- `PUT /api/v1/saved-views/{view_id}` — modify views
- `DELETE /api/v1/saved-views/{view_id}` — delete views

Compare with the protected main router in `routes.py:133`:
```python
router = APIRouter(prefix="/api/v1", dependencies=[Depends(require_api_key)])
```

## Fix
Added `dependencies=[Depends(require_api_key)]` to the `saved_views_router` definition, matching the pattern used by the main API router:

```python
saved_views_router = APIRouter(
    prefix="/api/v1/saved-views",
    tags=["saved-views"],
    dependencies=[Depends(require_api_key)],
)
```

## Impact
- **Before:** Any HTTP client without an API key could read, create, modify, and delete saved views
- **After:** All saved views endpoints require a valid API key via `Authorization: Bearer <key>`, `X-Api-Key: <key>`, or a valid session cookie

## Testing
1. Start the application
2. `curl http://localhost:8000/api/v1/saved-views` → returns 401
3. `curl -H "X-Api-Key: <valid-key>" http://localhost:8000/api/v1/saved-views` → returns 200

## Labels
`type:security`, `level:critical`, `priority:high`, `area:backend`
