### PR TITLE
fix: resolve TypeError in TLS verification unit tests-#1414

### DIFF
--- a/testing/backend/unit/test_tls_verification.py
+++ b/testing/backend/unit/test_tls_verification.py
@@ -54,15 +54,23 @@ class TestSettingsVerifySslDefault:
 class TestCrawlerVerifySsl:
     @pytest.mark.asyncio
     async def test_crawl_target_passes_verify_ssl(self):
+        async def mock_aiter_bytes():
+            yield b"<html></html>"
+
         mock_response = MagicMock()
         mock_response.text = "<html></html>"
         mock_response.url = "https://example.com/"
         mock_response.status_code = 200
         mock_response.headers = {}
         mock_response.history = []
+        mock_response.aiter_bytes = mock_aiter_bytes
+
+        mock_stream_ctx = MagicMock()
+        mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
 
         mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.stream = MagicMock(return_value=mock_stream_ctx)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
@@ -79,15 +87,23 @@ class TestCrawlerVerifySsl:
 
     @pytest.mark.asyncio
     async def test_crawl_target_verify_ssl_false_when_disabled(self):
+        async def mock_aiter_bytes():
+            yield b"<html></html>"
+
         mock_response = MagicMock()
         mock_response.text = "<html></html>"
         mock_response.url = "https://example.com/"
         mock_response.status_code = 200
         mock_response.headers = {}
         mock_response.history = []
+        mock_response.aiter_bytes = mock_aiter_bytes
+
+        mock_stream_ctx = MagicMock()
+        mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
 
         mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.stream = MagicMock(return_value=mock_stream_ctx)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
@@ -121,14 +137,15 @@ class TestAPIScannerVerifySsl:
 
         with patch("backend.secuscan.scanners.api_scanner.httpx.AsyncClient", return_value=mock_client) as mock_cls:
             with patch("backend.secuscan.scanners.api_scanner.settings") as mock_settings:
-                mock_settings.verify_ssl = True
-                with patch.object(scanner, "_fetch_spec", return_value=None):
-                    with patch.object(scanner, "_probe_graphql", return_value=([], [])):
-                        await scanner.run("https://example.com", {})
+                with patch("backend.secuscan.scanners.api_scanner.crawl_target", return_value={"api_hints": []}):
+                    mock_settings.verify_ssl = True
+                    with patch.object(scanner, "_fetch_spec", return_value=None):
+                        with patch.object(scanner, "_probe_graphql", return_value=([], [])):
+                            await scanner.run("https://example.com", {})
 
-                        mock_cls.assert_called()
-                        _, kwargs = mock_cls.call_args
-                        assert kwargs["verify"] is True
+                            mock_cls.assert_called()
+                            _, kwargs = mock_cls.call_args
+                            assert kwargs["verify"] is True
 
     @pytest.mark.asyncio
     async def test_api_scanner_verify_ssl_false_when_disabled(self):
@@ -143,13 +160,14 @@ class TestAPIScannerVerifySsl:
 
         with patch("backend.secuscan.scanners.api_scanner.httpx.AsyncClient", return_value=mock_client) as mock_cls:
             with patch("backend.secuscan.scanners.api_scanner.settings") as mock_settings:
-                mock_settings.verify_ssl = False
-                with patch.object(scanner, "_fetch_spec", return_value=None):
-                    with patch.object(scanner, "_probe_graphql", return_value=([], [])):
-                        await scanner.run("https://example.com", {})
+                with patch("backend.secuscan.scanners.api_scanner.crawl_target", return_value={"api_hints": []}):
+                    mock_settings.verify_ssl = False
+                    with patch.object(scanner, "_fetch_spec", return_value=None):
+                        with patch.object(scanner, "_probe_graphql", return_value=([], [])):
+                            await scanner.run("https://example.com", {})
 
-                        _, kwargs = mock_cls.call_args
-                        assert kwargs["verify"] is False
+                            _, kwargs = mock_cls.call_args
+                            assert kwargs["verify"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1414


## Description
This PR resolves the `TypeError: 'coroutine' object does not support the asynchronous context manager protocol` failure in the TLS verification unit tests. 

### Key Changes:
- **Crawler Tests**: Mocked the `client.stream` async context manager and the `aiter_bytes` generator in `TestCrawlerVerifySsl` to match the new `client.stream` implementation in `crawler.py`.
- **API Scanner Tests**: Mocked the `crawl_target` function inside the `TestAPIScannerVerifySsl` tests to isolate the API scanner testing flow and avoid running the actual client stream method.

## Related Issues
<!-- Link any related issues using #issue-number. -->
Closes #1736 (TLS verification regression tests)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran the backend unit tests locally using:
```bash
pytest testing/backend/unit/test_tls_verification.py
```


## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
