### PR TITLE
Fix #1748: make cloud-metadata/private-range denylist non-overridable

### DIFF
--- a/backend/secuscan/config.py
+++ b/backend/secuscan/config.py
@@ -12,6 +12,29 @@ import os
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
+# Mandatory network denylist. These ranges cover cloud metadata endpoints,
+# loopback, RFC1918/CGNAT private space, and IPv6 link-local/unique-local
+# addresses. They are enforced unconditionally by NetworkPolicyEngine
+# regardless of operator configuration, and are intentionally NOT part of
+# the SECUSCAN_NETWORK_DENYLIST env-configurable setting below: Pydantic
+# treats an env-provided list as a full replacement of the field default,
+# so if these lived only in that field, an operator adding a single custom
+# denylist entry would silently drop all of them and reopen SSRF to
+# 169.254.169.254 and friends. Keeping them here means they can never be
+# disabled via configuration, only supplemented.
+MANDATORY_DENYLIST: List[str] = [
+    "169.254.169.254/32",          # Cloud metadata (AWS/GCP/Azure/OCI)
+    "169.254.0.0/16",               # Reserved/link-local (incl. metadata)
+    "127.0.0.0/8",                  # Loopback
+    "10.0.0.0/8",                   # Private RFC 1918
+    "172.16.0.0/12",                # Private RFC 1918
+    "192.168.0.0/16",                # Private RFC 1918
+    "100.64.0.0/10",                 # Carrier-grade NAT (RFC 6598)
+    "fc00::/7",                       # IPv6 Unique Local Address
+    "fe80::/10",                      # IPv6 Link-local
+    "::1/128",                        # IPv6 Loopback
+]
+
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables"""
@@ -69,18 +92,10 @@ class Settings(BaseSettings):
 
     # Network Policy Configuration
     network_allowlist: List[str] = []  # IPs/networks to allow (CIDR); empty = deny all egress
-    network_denylist: List[str] = [    # IPs/networks to deny (CIDR)
-        "169.254.169.254/32",          # AWS metadata
-        "169.254.0.0/16",              # Reserved/metadata
-        "127.0.0.0/8",                 # Loopback (for remote execution)
-        "10.0.0.0/8",                  # Private RFC 1918
-        "172.16.0.0/12",               # Private RFC 1918
-        "192.168.0.0/16",              # Private RFC 1918
-        "100.64.0.0/10",               # Carrier-grade NAT (RFC 6598)
-        "fc00::/7",                    # IPv6 Unique Local Address
-        "fe80::/10",                   # IPv6 Link-local
-        "::1/128",                     # IPv6 Loopback
-    ]
+    # Operator-supplied ADDITIONS to the denylist (CIDR). This is on top of,
+    # never a replacement for, MANDATORY_DENYLIST above -- see the comment
+    # on MANDATORY_DENYLIST for why those ranges live outside this field.
+    network_denylist: List[str] = []
     network_audit_log_file: str = str(PROJECT_ROOT / "logs" / "network.audit.log")
     network_audit_retention_days: int = 90
     network_audit_max_entries: int = 10000

--- a/backend/secuscan/network_policy.py
+++ b/backend/secuscan/network_policy.py
@@ -483,9 +483,23 @@ def get_policy_engine() -> NetworkPolicyEngine:
 
 def _init_default_policies(engine: NetworkPolicyEngine) -> None:
     """Initialize default security policies"""
-    from .config import settings
+    from .config import settings, MANDATORY_DENYLIST
 
-    # Add operator-configured denylist (always enforced)
+    # Add the mandatory denylist first. These entries (cloud metadata,
+    # loopback, private/CGNAT ranges, IPv6 link-local/ULA) are enforced
+    # unconditionally and are NOT affected by SECUSCAN_NETWORK_DENYLIST --
+    # an operator customizing the denylist can only add to this set, never
+    # replace or remove it, so SSRF to 169.254.169.254 (and equivalents on
+    # GCP/Azure/OCI) stays blocked no matter how the operator configures
+    # things.
+    for cidr in MANDATORY_DENYLIST:
+        try:
+            engine.add_deny_rule(cidr, reason="Mandatory denylist (not operator-configurable)")
+        except ValueError:
+            logger.warning(f"Skipping invalid mandatory denylist CIDR: {cidr}")
+
+    # Add operator-configured denylist additions (layered on top of the
+    # mandatory set above, never a replacement for it)
     for cidr in settings.network_denylist:
         try:
             engine.add_deny_rule(cidr, reason="Operator configured denylist")

--- a/testing/backend/unit/test_network_policy.py
+++ b/testing/backend/unit/test_network_policy.py
@@ -416,20 +416,40 @@ class TestResolveAndPin:
 
 
 class TestDefaultDenylistSSRFProtection:
-    """Test that private subnets are blocked by default in settings"""
+    """Test that private subnets and cloud metadata are always blocked, and
+    that this protection cannot be silently dropped via operator config."""
 
-    def test_private_subnets_in_default_denylist(self):
-        """Standard private ranges (RFC1918, RFC6598, IPv6 local) must be in the default denylist"""
-        from backend.secuscan.config import Settings
-        default_settings = Settings()
-        denylist = default_settings.network_denylist
-        assert "10.0.0.0/8" in denylist
-        assert "172.16.0.0/12" in denylist
-        assert "192.168.0.0/16" in denylist
-        assert "100.64.0.0/10" in denylist
-        assert "fc00::/7" in denylist
-        assert "fe80::/10" in denylist
-        assert "::1/128" in denylist
+    def test_mandatory_ranges_present(self):
+        """Standard private ranges, CGNAT, and cloud metadata must be in MANDATORY_DENYLIST"""
+        from backend.secuscan.config import MANDATORY_DENYLIST
+        assert "169.254.169.254/32" in MANDATORY_DENYLIST
+        assert "169.254.0.0/16" in MANDATORY_DENYLIST
+        assert "10.0.0.0/8" in MANDATORY_DENYLIST
+        assert "172.16.0.0/12" in MANDATORY_DENYLIST
+        assert "192.168.0.0/16" in MANDATORY_DENYLIST
+        assert "100.64.0.0/10" in MANDATORY_DENYLIST
+        assert "fc00::/7" in MANDATORY_DENYLIST
+        assert "fe80::/10" in MANDATORY_DENYLIST
+        assert "::1/128" in MANDATORY_DENYLIST
+
+    def test_operator_denylist_override_does_not_drop_mandatory_ranges(self, monkeypatch, tmp_path):
+        """Regression test for #1748: an operator setting SECUSCAN_NETWORK_DENYLIST
+        to a custom, unrelated value must not lose metadata/private-range protection."""
+        monkeypatch.setattr(
+            "backend.secuscan.config.settings.network_denylist",
+            ["203.0.113.0/24"],  # operator's own unrelated addition
+        )
+        audit_log = tmp_path / "audit.log"
+        engine = NetworkPolicyEngine(audit_log_path=str(audit_log))
+        _init_default_policies(engine)
+
+        for blocked_ip in ["169.254.169.254", "10.0.0.1", "192.168.1.1",
+                           "172.16.0.1", "127.0.0.1", "100.64.0.1"]:
+            allowed, _, _ = engine.check_access(blocked_ip, plugin_id="test")
+            assert not allowed, f"{blocked_ip} should still be blocked after operator denylist override"
+
+        allowed, _, _ = engine.check_access("203.0.113.1", plugin_id="test")
+        assert not allowed, "operator-configured denylist entry should still be enforced"
 
 def test_check_access_logs_url_parse_failure(caplog, tmp_path):
     engine = NetworkPolicyEngine(audit_log_path=str(tmp_path / "audit.log"))


### PR DESCRIPTION
## Description

`_init_default_policies()` built the entire network denylist from a single Pydantic field, `settings.network_denylist`. Pydantic replaces (rather than merges) a list field's default when `SECUSCAN_NETWORK_DENYLIST` is set via env var, so any operator adding even one custom denylist entry silently dropped the built-in protection for cloud metadata (`169.254.169.254`), loopback, RFC1918/CGNAT ranges, and IPv6 link-local/ULA space — reopening SSRF to the metadata endpoint despite the code comment claiming the denylist was "always enforced."

Note: the issue's literal repro (default denylist missing the metadata IP entirely) doesn't reproduce as-is on current `main` — that part looks to have been partially addressed already. This PR fixes the related, still-live variant: the protection exists by default but isn't durable against operator customization.

**Fix:** moved those ranges into a new `MANDATORY_DENYLIST` module constant that is not read from settings/env and is applied unconditionally in `_init_default_policies()` before any operator-configured entries. The operator-facing `network_denylist` setting is now purely additive.

## Related Issues

Closes #1748

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- Updated the existing default-denylist test, which had been asserting on the old (overridable) field.
- Added a regression test reproducing the exact scenario from #1748: an operator setting `SECUSCAN_NETWORK_DENYLIST` to a custom, unrelated value must not lose metadata/private-range protection.
- Ran `testing/backend/unit/test_network_policy.py`, `test_admin_network_policy.py`, `test_validate_command_egress_policy.py`, and `test_network_scanner_plugin.py` — all 63 tests pass.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.