### PR TITLE
docs: add Python launcher and Git line ending fixes to Windows guide

### DIFF
--- a/docs/windows_contributor_guide.md
+++ b/docs/windows_contributor_guide.md
@@ -249,18 +249,39 @@ Then retry activation.
 
 ---
 
-### Python PATH Issues
+### Python PATH & Launcher Issues
 
-If `python` is not recognized:
+If `python` is not recognized, redirects to the Microsoft Store, or fails:
 
-* Reinstall Python
-* Ensure "Add Python to PATH" is checked during installation
+* Try using the Windows Python Launcher `py` or `py -3` directly:
+  ```powershell
+  py -3 --version
+  py -3 -m venv venv
+  py -3 -m uvicorn backend.secuscan.main:app --reload --host 127.0.0.1 --port 8000
+  ```
+* Alternatively, reinstall Python and ensure **"Add python.exe to PATH"** is checked during installation.
 
 Verify again:
 
 ```powershell
 python --version
+# or
+py -3 --version
 ```
+
+---
+
+### Git Line Endings (CRLF vs LF) for Shell Scripts
+
+If running `./setup.sh`, `./start.sh`, or `./testing/test_python.sh` in Git Bash fails with errors like `\r: command not found` or `syntax error near unexpected token $'r\r'`:
+
+* This occurs because Git on Windows converted shell scripts to Windows CRLF line endings upon checkout.
+* Configure Git to preserve LF line endings for the repository:
+  ```powershell
+  git config core.autocrlf input
+  git checkout-index --force --all
+  ```
+* Or check `.gitattributes` to ensure `.sh` files retain `text eol=lf`.
 
 ---
 

--- a/docs/windows_contributor_guide.md
+++ b/docs/windows_contributor_guide.md
@@ -275,13 +275,13 @@ py -3 --version
 
 If running `./setup.sh`, `./start.sh`, or `./testing/test_python.sh` in Git Bash fails with errors like `\r: command not found` or `syntax error near unexpected token $'r\r'`:
 
-* This occurs because Git on Windows converted shell scripts to Windows CRLF line endings upon checkout.
+* This occurs because Git on Windows may convert shell scripts to Windows CRLF line endings upon checkout.
 * Configure Git to preserve LF line endings for the repository:
   ```powershell
   git config core.autocrlf input
-  git checkout-index --force --all
   ```
-* Or check `.gitattributes` to ensure `.sh` files retain `text eol=lf`.
+* Verify the repository `.gitattributes` configuration to ensure `*.sh` files retain `text eol=lf`.
+* If shell scripts were already checked out with CRLF line endings, convert them using your editor (e.g. VS Code line-ending selector) or re-clone the repository fresh if needed.
 
 ---
 


### PR DESCRIPTION
…(GSSoC)

## Description
This PR enhances `docs/windows_contributor_guide.md` with targeted troubleshooting instructions for Windows developers contributing to SecuScan:
- Added guidance for Python Launcher (`py` / `py -3`) execution when the system `python` command is unmapped or redirects to Microsoft Store placeholders.
- Added troubleshooting for Git line endings (`CRLF` vs `LF`) preventing shell scripts (`setup.sh`, `start.sh`, `testing/test_python.sh`) from executing cleanly in Git Bash (`\r: command not found`).
- Contributed as part of **GSSoC (GirlScript Summer of Code)**.

## Related Issues
N/A - GSSoC documentation and onboarding enhancement.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- Verified Markdown formatting and link integrity in `docs/windows_contributor_guide.md`.
- Ran repository validation script using `py -3 scripts/validate_issue_template_labels.py` (Confirmed: "All issue template labels are valid.").

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.