### PR TITLE
fix(tests): restore require_api_key in saved_views auth rejection tests

### DIFF
--- a/testing/backend/unit/test_saved_views.py
+++ b/testing/backend/unit/test_saved_views.py
@@ -357,19 +357,31 @@ async def test_filter_json_with_null_values_rejected(app_client: AsyncClient):
 @pytest.mark.asyncio
 async def test_unauthenticated_request_rejected(app_client: AsyncClient):
     """Requests without a valid API key/session are rejected, not served."""
-    res = await app_client.get(
-        "/api/v1/saved-views", headers={"X-Api-Key": ""}
-    )
-    assert res.status_code == 401
+    app = app_client.test_transport.app
+    old_override = app.dependency_overrides.pop(require_api_key, None)
+    try:
+        res = await app_client.get(
+            "/api/v1/saved-views", headers={"X-Api-Key": ""}
+        )
+        assert res.status_code == 401
+    finally:
+        if old_override is not None:
+            app.dependency_overrides[require_api_key] = old_override
 
 
 @pytest.mark.asyncio
 async def test_wrong_api_key_rejected(app_client: AsyncClient):
     """A malformed/incorrect API key is rejected."""
-    res = await app_client.get(
-        "/api/v1/saved-views", headers={"X-Api-Key": "not-the-real-key"}
-    )
-    assert res.status_code == 401
+    app = app_client.test_transport.app
+    old_override = app.dependency_overrides.pop(require_api_key, None)
+    try:
+        res = await app_client.get(
+            "/api/v1/saved-views", headers={"X-Api-Key": "not-the-real-key"}
+        )
+        assert res.status_code == 401
+    finally:
+        if old_override is not None:
+            app.dependency_overrides[require_api_key] = old_override
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Fixes failing auth rejection unit tests in `testing/backend/unit/test_saved_views.py` (`test_unauthenticated_request_rejected` and `test_wrong_api_key_rejected`).

Because `app_client` fixture sets `_app.dependency_overrides[require_api_key] = _mock_require_api_key`, requests with empty or incorrect API keys were bypassing authentication and returning `200 OK` instead of `401 Unauthorized`.

This PR temporarily restores `require_api_key` for those two auth rejection tests, bringing `test_saved_views.py` to **47/47 PASSED** (100%).

Contributed as part of **GSSoC (GirlScript Summer of Code)**.

## Related Issues
Fixes failing auth tests in `testing/backend/unit/test_saved_views.py`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran pytest directly on `testing/backend/unit/test_saved_views.py`:
```powershell
.\venv_tests\Scripts\pytest testing/backend/unit/test_saved_views.py -v
Checklist
 My code follows the code style of this project.
 I have performed a self-review of my own code.
 I have commented my code, particularly in hard-to-understand areas.
 I have made corresponding changes to the documentation.
 My changes generate no new warnings.