### PR TITLE
test : added unit tests for plugin_health_dashboard script helpers

### DIFF
--- a/testing/backend/unit/test_plugin_health_dashboard.py
+++ b/testing/backend/unit/test_plugin_health_dashboard.py
@@ -1,0 +1,188 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
+from scripts.plugin_health_dashboard import (
+    safe_relative_path,
+    discover_plugins,
+    build_report,
+    format_markdown,
+)
+
+
+def test_safe_relative_path_normal_case():
+    base = Path("/a/b")
+    path = Path("/a/b/c/d")
+    assert safe_relative_path(path, base) == "c/d"
+
+
+def test_safe_relative_path_exact_match():
+    base = Path("/a/b")
+    path = Path("/a/b")
+    assert safe_relative_path(path, base) == "."
+
+
+def test_safe_relative_path_outside_returns_absolute():
+    base = Path("/a/b")
+    path = Path("/a/x/y")
+    result = safe_relative_path(path, base)
+    assert result == str(path)
+
+
+def test_safe_relative_path_deeply_nested():
+    base = Path("/x")
+    path = Path("/x/y/z/w/v")
+    assert safe_relative_path(path, base) == "y/z/w/v"
+
+
+def test_discover_plugins_returns_list():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        plugin_dir = root / "my_plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "parser.py").write_text("# parser")
+        (plugin_dir / "metadata.json").write_text(
+            '{"name": "My Plugin", "category": "recon"}'
+        )
+
+        result = discover_plugins(plugin_root=root)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["name"] == "My Plugin"
+        assert result[0]["category"] == "recon"
+        assert result[0]["has_parser"] is True
+
+
+def test_discover_plugins_detects_missing_parser():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        plugin_dir = root / "no_parser"
+        plugin_dir.mkdir()
+        (plugin_dir / "metadata.json").write_text('{"name": "No Parser"}')
+
+        result = discover_plugins(plugin_root=root)
+        assert len(result) == 1
+        assert result[0]["has_parser"] is False
+
+
+def test_discover_plugins_handles_invalid_json():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        plugin_dir = root / "bad_json"
+        plugin_dir.mkdir()
+        (plugin_dir / "parser.py").write_text("# x")
+        (plugin_dir / "metadata.json").write_text("not json{{{")
+
+        result = discover_plugins(plugin_root=root)
+        assert len(result) == 1
+        assert result[0]["name"] == "bad_json"
+
+
+def test_discover_plugins_sorts_by_name():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        z_dir = root / "zebra"
+        z_dir.mkdir()
+        (z_dir / "metadata.json").write_text('{"name": "Zebra"}')
+        a_dir = root / "alpha"
+        a_dir.mkdir()
+        (a_dir / "metadata.json").write_text('{"name": "Alpha"}')
+
+        result = discover_plugins(plugin_root=root)
+        assert result[0]["name"] == "Alpha"
+        assert result[1]["name"] == "Zebra"
+
+
+def test_discover_plugins_empty_directory():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = discover_plugins(plugin_root=Path(tmpdir))
+        assert result == []
+
+
+def test_build_report_summary_counts():
+    plugins = [
+        {"name": "A", "category": "recon", "has_parser": True},
+        {"name": "B", "category": "recon", "has_parser": False},
+        {"name": "C", "category": "web", "has_parser": True},
+    ]
+    report = build_report(plugins)
+    assert report["summary"]["total_plugins"] == 3
+    assert report["summary"]["plugins_with_parser"] == 2
+    assert report["summary"]["plugins_without_parser"] == 1
+    assert report["categories"]["recon"] == 2
+    assert report["categories"]["web"] == 1
+
+
+def test_build_report_empty():
+    report = build_report([])
+    assert report["summary"]["total_plugins"] == 0
+    assert report["summary"]["plugins_with_parser"] == 0
+    assert report["summary"]["plugins_without_parser"] == 0
+    assert report["categories"] == {}
+
+
+def test_format_markdown_contains_summary():
+    report = {
+        "summary": {
+            "total_plugins": 3,
+            "plugins_with_parser": 2,
+            "plugins_without_parser": 1,
+        },
+        "categories": {"recon": 2, "web": 1},
+        "plugins": [
+            {
+                "name": "Plugin A",
+                "category": "recon",
+                "has_parser": True,
+                "path": "recon/plugin_a",
+            }
+        ],
+    }
+    output = format_markdown(report)
+    assert "Total plugins: 3" in output
+    assert "Plugins with parser.py: 2" in output
+    assert "Plugins without parser.py: 1" in output
+    assert "recon: 2" in output
+    assert "web: 1" in output
+    assert "Plugin A" in output
+    assert "| Plugin | Category | Parser | Path |" in output
+
+
+def test_format_markdown_categories_sorted():
+    report = {
+        "summary": {"total_plugins": 2, "plugins_with_parser": 2, "plugins_without_parser": 0},
+        "categories": {"z_cat": 1, "a_cat": 1},
+        "plugins": [],
+    }
+    output = format_markdown(report)
+    assert "- a_cat: 1" in output
+    assert "- z_cat: 1" in output
+    assert output.index("- a_cat: 1") < output.index("- z_cat: 1")
+
+
+def test_format_markdown_plugin_table_shows_parser_status():
+    plugins = [
+        {
+            "name": "With Parser",
+            "category": "web",
+            "has_parser": True,
+            "path": "web/with_parser",
+        },
+        {
+            "name": "No Parser",
+            "category": "web",
+            "has_parser": False,
+            "path": "web/no_parser",
+        },
+    ]
+    report = {
+        "summary": {"total_plugins": 2, "plugins_with_parser": 1, "plugins_without_parser": 1},
+        "categories": {"web": 2},
+        "plugins": plugins,
+    }
+    output = format_markdown(report)
+    assert "| With Parser | web | Yes | `web/with_parser` |" in output
+    assert "| No Parser | web | No | `web/no_parser` |" in output

--- a/testing/backend/unit/test_validate_plugins_catalog.py
+++ b/testing/backend/unit/test_validate_plugins_catalog.py
@@ -1,0 +1,295 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Add root to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
+from scripts.validate_plugins_catalog import (
+    parse_plugins_md,
+    extract_counts_from_catalog,
+    extract_category_counts_from_catalog,
+    validate_catalog,
+)
+
+
+def test_parse_plugins_md_extracts_plugin_entries():
+    catalog_content = """# Title
+
+## Plugin Index
+
+| Plugin | ID | Category | Safety | Primary Binary | Summary |
+| --- | --- | --- | --- | --- | --- |
+| Amass | `amass` | `recon` | `safe` | `amass` | Deep mapping. |
+| Nuclei | `nuclei` | `vulnerability` | `intrusive` | `nuclei` | Fast scanner. |
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(catalog_content)
+        path = Path(f.name)
+
+    try:
+        result = parse_plugins_md(path)
+        assert "amass" in result
+        assert result["amass"]["name"] == "Amass"
+        assert result["amass"]["category"] == "recon"
+        assert result["amass"]["safety"] == "safe"
+        assert "nuclei" in result
+        assert result["nuclei"]["category"] == "vulnerability"
+        assert result["nuclei"]["safety"] == "intrusive"
+    finally:
+        path.unlink()
+
+
+def test_parse_plugins_md_skips_header_row():
+    catalog_content = """# Title
+
+| Plugin | ID | Category | Safety | Primary Binary | Summary |
+| --- | --- | --- | --- | --- | --- |
+| Plugin | ID | Category | Safety | Primary Binary | Summary |
+| Real Plugin | `real` | `recon` | `safe` | `x` | desc. |
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(catalog_content)
+        path = Path(f.name)
+
+    try:
+        result = parse_plugins_md(path)
+        assert "real" in result
+        assert "ID" not in result
+    finally:
+        path.unlink()
+
+
+def test_parse_plugins_md_empty_file():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        path = Path(f.name)
+
+    try:
+        result = parse_plugins_md(path)
+        assert result == {}
+    finally:
+        path.unlink()
+
+
+def test_extract_counts_from_catalog_parses_all_counts():
+    catalog_content = """## At a Glance
+
+- Total plugins: 59
+- Safe plugins: 26
+- Intrusive plugins: 25
+- Exploit plugins: 8
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(catalog_content)
+        path = Path(f.name)
+
+    try:
+        counts = extract_counts_from_catalog(path)
+        assert counts["total_plugins"] == 59
+        assert counts["safe_plugins"] == 26
+        assert counts["intrusive_plugins"] == 25
+        assert counts["exploit_plugins"] == 8
+    finally:
+        path.unlink()
+
+
+def test_extract_counts_from_catalog_empty():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        path = Path(f.name)
+
+    try:
+        counts = extract_counts_from_catalog(path)
+        assert counts == {}
+    finally:
+        path.unlink()
+
+
+def test_extract_category_counts_from_catalog_parses_table():
+    catalog_content = """## Category Summary
+
+| Category | Count |
+| --- | ---: |
+| `recon` | 17 |
+| `vulnerability` | 12 |
+| `web` | 5 |
+
+## Another Section
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(catalog_content)
+        path = Path(f.name)
+
+    try:
+        counts = extract_category_counts_from_catalog(path)
+        assert counts["recon"] == 17
+        assert counts["vulnerability"] == 12
+        assert counts["web"] == 5
+        assert "Category" not in counts
+    finally:
+        path.unlink()
+
+
+def test_extract_category_counts_from_catalog_stops_at_next_header():
+    catalog_content = """## Category Summary
+
+| Category | Count |
+| --- | ---: |
+| `recon` | 17 |
+
+## Next Section
+
+| `web` | 5 |
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(catalog_content)
+        path = Path(f.name)
+
+    try:
+        counts = extract_category_counts_from_catalog(path)
+        assert counts["recon"] == 17
+        assert "web" not in counts
+    finally:
+        path.unlink()
+
+
+def test_validate_catalog_in_sync_returns_true():
+    catalog_content = """# Title
+
+| Plugin | ID | Category | Safety | Primary Binary | Summary |
+| --- | --- | --- | --- | --- | --- |
+| Test Plugin | `test_plugin` | `recon` | `safe` | `x` | desc. |
+
+## At a Glance
+
+- Total plugins: 1
+- Safe plugins: 1
+- Intrusive plugins: 0
+- Exploit plugins: 0
+
+## Category Summary
+
+| Category | Count |
+| --- | ---: |
+| `recon` | 1 |
+"""
+    plugin_meta = '{"id": "test_plugin", "category": "recon", "safety": {"level": "safe"}}'
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        catalog_path = Path(tmpdir) / "PLUGINS.md"
+        plugins_dir = Path(tmpdir) / "plugins"
+        plugins_dir.mkdir()
+        plugin_dir = plugins_dir / "test_plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "metadata.json").write_text(plugin_meta)
+
+        catalog_path.write_text(catalog_content)
+
+        valid, issues = validate_catalog(catalog_path, plugins_dir)
+        assert valid is True
+        assert issues == []
+
+
+def test_validate_catalog_missing_from_catalog_returns_false():
+    catalog_content = """# Title
+
+| Plugin | ID | Category | Safety | Primary Binary | Summary |
+| --- | --- | --- | --- | --- | --- |
+| Listed Plugin | `listed` | `recon` | `safe` | `x` | desc. |
+
+## At a Glance
+
+- Total plugins: 1
+- Safe plugins: 1
+- Intrusive plugins: 0
+- Exploit plugins: 0
+
+## Category Summary
+
+| Category | Count |
+| --- | ---: |
+| `recon` | 1 |
+"""
+    plugin_meta = '{"id": "actual", "category": "recon", "safety": {"level": "safe"}}'
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        catalog_path = Path(tmpdir) / "PLUGINS.md"
+        plugins_dir = Path(tmpdir) / "plugins"
+        plugins_dir.mkdir()
+        plugin_dir = plugins_dir / "actual"
+        plugin_dir.mkdir()
+        (plugin_dir / "metadata.json").write_text(plugin_meta)
+
+        catalog_path.write_text(catalog_content)
+
+        valid, issues = validate_catalog(catalog_path, plugins_dir)
+        assert valid is False
+        assert any("Missing from PLUGINS.md" in i for i in issues)
+
+
+def test_validate_catalog_extra_in_catalog_returns_false():
+    catalog_content = """# Title
+
+| Plugin | ID | Category | Safety | Primary Binary | Summary |
+| --- | --- | --- | --- | --- | --- |
+| Extra Plugin | `extra` | `recon` | `safe` | `x` | desc. |
+
+## At a Glance
+
+- Total plugins: 0
+- Safe plugins: 0
+- Intrusive plugins: 0
+- Exploit plugins: 0
+
+## Category Summary
+
+| Category | Count |
+| --- | ---: |
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        catalog_path = Path(tmpdir) / "PLUGINS.md"
+        plugins_dir = Path(tmpdir) / "plugins"
+        plugins_dir.mkdir()
+
+        catalog_path.write_text(catalog_content)
+
+        valid, issues = validate_catalog(catalog_path, plugins_dir)
+        assert valid is False
+        assert any("In PLUGINS.md but not in plugins/" in i for i in issues)
+
+
+def test_validate_catalog_count_mismatch_returns_false():
+    catalog_content = """# Title
+
+| Plugin | ID | Category | Safety | Primary Binary | Summary |
+| --- | --- | --- | --- | --- | --- |
+| Test Plugin | `test` | `recon` | `safe` | `x` | desc. |
+
+## At a Glance
+
+- Total plugins: 99
+- Safe plugins: 99
+- Intrusive plugins: 0
+- Exploit plugins: 0
+
+## Category Summary
+
+| Category | Count |
+| --- | ---: |
+| `recon` | 99 |
+"""
+    plugin_meta = '{"id": "test", "category": "recon", "safety": {"level": "safe"}}'
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        catalog_path = Path(tmpdir) / "PLUGINS.md"
+        plugins_dir = Path(tmpdir) / "plugins"
+        plugins_dir.mkdir()
+        plugin_dir = plugins_dir / "test"
+        plugin_dir.mkdir()
+        (plugin_dir / "metadata.json").write_text(plugin_meta)
+
+        catalog_path.write_text(catalog_content)
+
+        valid, issues = validate_catalog(catalog_path, plugins_dir)
+        assert valid is False
+        assert any("Total plugins mismatch" in i for i in issues)


### PR DESCRIPTION
Closes #2071.

Summary of What Has Been Done:

Added `testing/backend/unit/test_plugin_health_dashboard.py` with 14 unit tests covering the four helper functions in `scripts/plugin_health_dashboard.py`.

Changes Made:

- `safe_relative_path`: tests for normal paths, exact match, outside-base (returns absolute), deeply nested
- `discover_plugins`: tests for list return, missing parser detection, invalid JSON handling, name sorting, empty directory
- `build_report`: tests for summary counts (total/with-parser/without), category aggregation, empty input
- `format_markdown`: tests for summary section content, alphabetical category order, plugin table with parser status

All tests use `tempfile.TemporaryDirectory` for fixture data. Tests pass with `python3 -m pytest --noconftest`.

Impact it Made:

- Prevents regressions in plugin health reporting
- Validates markdown output format for maintainer dashboards
- Ensures discover_plugins correctly categorizes plugins

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.