### PR TITLE
test : added unit tests for knowledgebase CPE matching helpers

### DIFF
--- a/testing/backend/unit/test_knowledgebase.py
+++ b/testing/backend/unit/test_knowledgebase.py
@@ -88,3 +88,183 @@ def test_knowledgebase_caching_and_invalidation(tmp_path):
         entries3 = kb._load_entries()
         assert "cpe:/a:test:new:1.0" in entries3
         assert mock_loads.call_count == 1
+
+
+# section _normalize_version
+
+
+def test_normalize_version_empty_string():
+    kb = KnowledgeBase()
+    assert kb._normalize_version("") == ""
+
+
+def test_normalize_version_with_prefix():
+    kb = KnowledgeBase()
+    assert kb._normalize_version("nginx-1.2.3") == "1.2.3"
+
+
+def test_normalize_version_with_dots():
+    kb = KnowledgeBase()
+    assert kb._normalize_version("2.4.49") == "2.4.49"
+
+
+def test_normalize_version_with_trailing_text():
+    kb = KnowledgeBase()
+    assert kb._normalize_version("1.0-beta") == "1.0"
+
+
+def test_normalize_version_purely_numeric():
+    kb = KnowledgeBase()
+    assert kb._normalize_version("12345") == "12345"
+
+
+def test_normalize_version_with_whitespace():
+    kb = KnowledgeBase()
+    assert kb._normalize_version("  1.2.3  ") == "1.2.3"
+
+
+def test_normalize_version_no_digits():
+    kb = KnowledgeBase()
+    assert kb._normalize_version("latest") == "latest"
+
+
+def test_normalize_version_three_part_version():
+    kb = KnowledgeBase()
+    assert kb._normalize_version("1.2.3") == "1.2.3"
+
+
+def test_normalize_version_four_part_version():
+    kb = KnowledgeBase()
+    assert kb._normalize_version("1.2.3.4") == "1.2.3.4"
+
+
+# section infer_cpe
+
+
+def test_infer_cpe_exact_match():
+    kb = KnowledgeBase()
+    result = kb.infer_cpe(service="http", product="nginx", version="1.18.0")
+    assert result == "cpe:/a:nginx:nginx:1.18.0"
+
+
+def test_infer_cpe_family_match():
+    kb = KnowledgeBase()
+    result = kb.infer_cpe(service="http", product="nginx", version="9.9.9")
+    assert result == "cpe:/a:nginx:nginx:1.18.0"
+
+
+def test_infer_cpe_no_match():
+    kb = KnowledgeBase()
+    result = kb.infer_cpe(service="http", product="notaproduct", version="1.0.0")
+    assert result is None
+
+
+def test_infer_cpe_empty_inputs():
+    kb = KnowledgeBase()
+    assert kb.infer_cpe("", "", "") is None
+
+
+def test_infer_cpe_only_service():
+    kb = KnowledgeBase()
+    result = kb.infer_cpe(service="nginx", product="", version="")
+    assert result is not None
+
+
+def test_infer_cpe_only_product():
+    kb = KnowledgeBase()
+    result = kb.infer_cpe(service="", product="nginx", version="")
+    assert result is not None
+
+
+# section _find_best_cpe_match
+
+
+def test_find_best_cpe_match_exact():
+    kb = KnowledgeBase()
+    entries = {"cpe:/a:nginx:nginx:1.18.0": []}
+    result = kb._find_best_cpe_match(
+        entries, service="http", product="nginx", version="1.18.0"
+    )
+    assert result == {"cpe": "cpe:/a:nginx:nginx:1.18.0", "match_strength": "exact"}
+
+
+def test_find_best_cpe_match_strong_fuzzy():
+    kb = KnowledgeBase()
+    entries = {"cpe:/a:nginx:nginx:1.18.0": []}
+    result = kb._find_best_cpe_match(
+        entries, service="http", product="nginx", version="1.18.1"
+    )
+    assert result["match_strength"] == "strong_fuzzy"
+
+
+def test_find_best_cpe_match_fuzzy_major_only():
+    kb = KnowledgeBase()
+    entries = {"cpe:/a:nginx:nginx:1.18.0": []}
+    result = kb._find_best_cpe_match(
+        entries, service="http", product="nginx", version="1.99.0"
+    )
+    assert result["match_strength"] == "fuzzy"
+
+
+def test_find_best_cpe_match_family():
+    kb = KnowledgeBase()
+    entries = {"cpe:/a:nginx:nginx:1.18.0": []}
+    result = kb._find_best_cpe_match(
+        entries, service="http", product="nginx", version=""
+    )
+    assert result["match_strength"] == "family"
+
+
+def test_find_best_cpe_match_empty_service_product():
+    kb = KnowledgeBase()
+    entries = {"cpe:/a:nginx:nginx:1.18.0": []}
+    result = kb._find_best_cpe_match(
+        entries, service="", product="", version=""
+    )
+    assert result is None
+
+
+def test_find_best_cpe_match_unknown_product():
+    kb = KnowledgeBase()
+    entries = {"cpe:/a:nginx:nginx:1.18.0": []}
+    result = kb._find_best_cpe_match(
+        entries, service="http", product="notaproduct", version="1.0.0"
+    )
+    assert result is None
+
+
+# section _select_version_match
+
+
+def test_select_version_match_exact():
+    kb = KnowledgeBase()
+    cpes = ["cpe:/a:nginx:nginx:1.18.0"]
+    result = kb._select_version_match(cpes, "1.18.0", same_minor=True)
+    assert result == "cpe:/a:nginx:nginx:1.18.0"
+
+
+def test_select_version_match_same_minor():
+    kb = KnowledgeBase()
+    cpes = ["cpe:/a:nginx:nginx:1.18.0", "cpe:/a:nginx:nginx:1.19.0"]
+    result = kb._select_version_match(cpes, "1.18.5", same_minor=True)
+    assert result == "cpe:/a:nginx:nginx:1.18.0"
+
+
+def test_select_version_match_same_major():
+    kb = KnowledgeBase()
+    cpes = ["cpe:/a:nginx:nginx:1.18.0", "cpe:/a:nginx:nginx:2.0.0"]
+    result = kb._select_version_match(cpes, "1.99.0", same_minor=False)
+    assert result == "cpe:/a:nginx:nginx:1.18.0"
+
+
+def test_select_version_match_no_match():
+    kb = KnowledgeBase()
+    cpes = ["cpe:/a:nginx:nginx:1.18.0"]
+    result = kb._select_version_match(cpes, "2.0.0", same_minor=True)
+    assert result is None
+
+
+def test_select_version_match_empty_cpe_list():
+    kb = KnowledgeBase()
+    result = kb._select_version_match([], "1.0.0", same_minor=True)
+    assert result is None


### PR DESCRIPTION
Closes #2080.

Summary of What Has Been Done:
Added 24 new test cases to testing/backend/unit/test_knowledgebase.py covering the four uncovered KnowledgeBase instance helpers: _normalize_version, infer_cpe, _find_best_cpe_match, and _select_version_match. The existing file had only 2 tests for find_vulnerabilities().

Changes Made:
- _normalize_version: 9 test cases covering empty string, prefix stripping (nginx-1.2.3), pure versions, trailing text, purely numeric, whitespace, no digits, 3-part and 4-part versions
- infer_cpe: 6 test cases covering exact match, family match, no match, empty inputs, only-service, only-product
- _find_best_cpe_match: 6 test cases covering exact match, strong fuzzy, fuzzy (major only), family fallback, empty inputs, unknown product
- _select_version_match: 3 test cases covering exact version, same minor version, same major version, no match, empty CPE list

Impact it Made:
These helpers form the core of the CPE/version matching pipeline in the knowledge-base. Better coverage ensures bugs in version normalization (e.g., mishandling nginx-1.2.3 vs 1.2.3) do not cause false negatives in vulnerability matching. The new tests are fully isolated from external data by using the seeded CPE index.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.