### PR TITLE
fix(tests) : add unauthed_client fixture for saved-views auth tests

### DIFF
--- a/testing/backend/unit/test_saved_views.py
+++ b/testing/backend/unit/test_saved_views.py
@@ -62,6 +62,37 @@ async def app_client():
 
 
 @pytest_asyncio.fixture
+async def unauthed_client():
+    """
+    FastAPI app with saved_views_router and NO auth dependency override.
+    Used for tests that verify the real require_api_key enforcement,
+    specifically auth-rejection tests that must exercise the actual
+    authentication logic (not a mock that always succeeds).
+    """
+    test_db = Database(":memory:")
+    await test_db.connect()
+    _db_module.db = test_db
+
+    _app = FastAPI()
+    _app.include_router(saved_views_router)
+    # No dependency override — real require_api_key runs
+
+    with tempfile.TemporaryDirectory() as tmp_data_dir:
+        api_key = _auth_module.init_api_key(tmp_data_dir)
+
+        transport = ASGITransport(app=_app)
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+        ) as client:
+            yield client
+
+    await test_db.disconnect()
+    _db_module.db = None
+    _auth_module._api_key = None
+
+
+@pytest_asyncio.fixture
 async def other_owner_client(app_client: AsyncClient):
     """A second authenticated client acting as a different owner (`bob`),
     sharing the same app/db as ``app_client`` but scoped to a different
@@ -355,18 +386,16 @@ async def test_filter_json_with_null_values_rejected(app_client: AsyncClient):
 # ─── Auth & owner isolation (issue #1743) ────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_unauthenticated_request_rejected(app_client: AsyncClient):
+async def test_unauthenticated_request_rejected(unauthed_client: AsyncClient):
     """Requests without a valid API key/session are rejected, not served."""
-    res = await app_client.get(
-        "/api/v1/saved-views", headers={"X-Api-Key": ""}
-    )
+    res = await unauthed_client.get("/api/v1/saved-views")
     assert res.status_code == 401
 
 
 @pytest.mark.asyncio
-async def test_wrong_api_key_rejected(app_client: AsyncClient):
+async def test_wrong_api_key_rejected(unauthed_client: AsyncClient):
     """A malformed/incorrect API key is rejected."""
-    res = await app_client.get(
+    res = await unauthed_client.get(
         "/api/v1/saved-views", headers={"X-Api-Key": "not-the-real-key"}
     )
     assert res.status_code == 401


### PR DESCRIPTION
Closes #2195.

Summary of What Has Been Done:
Added an unauthed_client fixture to test_saved_views.py that creates a FastAPI app with saved_views_router but WITHOUT the dependency override for require_api_key. Updated test_unauthenticated_request_rejected and test_wrong_api_key_rejected to use this fixture instead of app_client.

Changes Made:
- Added unauthed_client fixture: creates in-memory DB + app with saved_views_router, NO dependency override
- Changed test_unauthenticated_request_rejected to use unauthed_client with no X-Api-Key header -> expects 401
- Changed test_wrong_api_key_rejected to use unauthed_client with invalid X-Api-Key header -> expects 401

Impact it Made:
Fixes the backend-unit test failures where these tests were asserting 200 == 401. The app_client fixture unconditionally bypassed auth, so the tests never actually verified auth enforcement. The unauthed_client lets the real require_api_key run.

Note: This task is being handled by tmdeveloper007 -- please assign to that account when picking it up.