### PR TITLE
test : added unit tests for handle_caret handle_tilde and handle_wildcard helpers

### DIFF
--- a/testing/backend/unit/test_remediation_helpers.py
+++ b/testing/backend/unit/test_remediation_helpers.py
@@ -1,0 +1,106 @@
+"""Tests for remediation.py internal helpers: handle_caret, handle_tilde, handle_wildcard."""
+
+import pytest
+
+from backend.secuscan.remediation import handle_caret, handle_tilde, handle_wildcard
+
+
+class TestHandleCaret:
+    """handle_caret must correctly translate npm-style caret ranges to PEP 440."""
+
+    def test_caret_standard(self):
+        assert handle_caret("1.2.3") == [">=1.2.3", "<2.0.0"]
+
+    def test_caret_minor_above_zero(self):
+        assert handle_caret("0.2.3") == [">=0.2.3", "<0.3.0"]
+
+    def test_caret_patch_only(self):
+        assert handle_caret("0.0.3") == [">=0.0.3", "<0.0.4"]
+
+    def test_caret_patch_only_edge_case(self):
+        """0.0.x bumps only the patch version."""
+        assert handle_caret("0.0.1") == [">=0.0.1", "<0.0.2"]
+
+    def test_caret_minor_only(self):
+        """^0.x.y bumps only the minor version."""
+        assert handle_caret("0.1.0") == [">=0.1.0", "<0.2.0"]
+
+    def test_caret_returns_list(self):
+        result = handle_caret("2.0.0")
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_caret_upper_bound_increments_major(self):
+        result = handle_caret("5.4.3")
+        assert result[0] == ">=5.4.3"
+        assert result[1].startswith("<6")
+
+
+class TestHandleTilde:
+    """handle_tilde must correctly translate npm-style tilde ranges to PEP 440."""
+
+    def test_tilde_patch_level(self):
+        assert handle_tilde("1.2.3") == [">=1.2.3", "<1.3.0"]
+
+    def test_tilde_minor_level(self):
+        assert handle_tilde("1.2") == [">=1.2", "<1.3.0"]
+
+    def test_tilde_major_level(self):
+        assert handle_tilde("1") == [">=1", "<1.1.0"]
+
+    def test_tilde_returns_list(self):
+        result = handle_tilde("2.0.0")
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_tilde_upper_bound_increments_minor(self):
+        result = handle_tilde("5.4.3")
+        assert result[0] == ">=5.4.3"
+        assert result[1].startswith("<5.5")
+
+
+class TestHandleWildcard:
+    """handle_wildcard must correctly translate wildcard versions to PEP 440 ranges."""
+
+    def test_wildcard_major_x_replacement(self):
+        """1.x should expand to >=1.0.0,<2.0.0."""
+        result = handle_wildcard("1.x")
+        assert len(result) == 2
+        assert result[0] == ">=1.0.0"
+        assert result[1] == "<2.0.0"
+
+    def test_wildcard_star_replacement(self):
+        """1.* should behave like 1.x."""
+        result = handle_wildcard("1.*")
+        assert result[0] == ">=1.0.0"
+        assert result[1] == "<2.0.0"
+
+    def test_wildcard_minor_level(self):
+        """1.2.x should expand to >=1.2.0,<1.3.0."""
+        result = handle_wildcard("1.2.x")
+        assert result[0] == ">=1.2.0"
+        assert result[1] == "<1.3.0"
+
+    def test_wildcard_partial_major_preserves_leading_zero(self):
+        """01.x preserves the leading zero as written."""
+        result = handle_wildcard("01.x")
+        assert ">=01.0.0" in result
+
+    def test_wildcard_single_number_returns_empty(self):
+        """A bare major version number has no wildcards to expand."""
+        result = handle_wildcard("1")
+        assert result == []
+
+    def test_wildcard_three_part_exact_returns_empty(self):
+        """A fully-specified version has no wildcards to expand."""
+        result = handle_wildcard("1.2.3")
+        assert result == []
+
+    def test_wildcard_returns_list(self):
+        result = handle_wildcard("2.x")
+        assert isinstance(result, list)
+
+    def test_wildcard_x_replacement_behaves_like_star(self):
+        """x and * should be interchangeable."""
+        assert handle_wildcard("2.x") == handle_wildcard("2.*")
+        assert handle_wildcard("2.3.x") == handle_wildcard("2.3.*")


### PR DESCRIPTION
Closes #2274.

Summary of What Has Been Done:
Added 20 unit tests in testing/backend/unit/test_remediation_helpers.py covering the handle_caret, handle_tilde, and handle_wildcard internal helpers from backend/secuscan/remediation.py. These are the low-level building blocks of semver_to_pep440 and were not directly tested despite being indirectly covered by semver_to_pep440 tests.

Changes Made:
- Created testing/backend/unit/test_remediation_helpers.py with 20 tests in 3 test classes:
  - TestHandleCaret: 7 tests for caret (^) operator translation to PEP 440
  - TestHandleTilde: 6 tests for tilde (~) operator translation to PEP 440
  - TestHandleWildcard: 7 tests for wildcard (*/x) version translation to PEP 440 ranges

Key edge cases covered:
- handle_caret: ^0.0.x, ^0.x.y, major/minor/patch increment logic
- handle_tilde: ~x.y.z, ~x.y, ~x variants
- handle_wildcard: 1.x, 1.*, 1.2.x, bare numbers returning empty, x==* equivalence

Impact it Made:
- Reliability: Tests the individual components of semver_to_pep440 in isolation
- Testing: Fills gaps left by existing semver_to_pep440 tests which only test the top-level function
- Maintainability: Makes future changes to these helpers safer with direct coverage
- No production code changes

All 20 tests pass with --noconftest.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.