### PR TITLE
test : added unit tests for _parse_discovered_at helper

### DIFF
--- a/backend/secuscan/executor.py
+++ b/backend/secuscan/executor.py
@@ -18,6 +18,9 @@ import re
 
 _CANCEL_GRACE_SECONDS = 5
 
+# Re-export helpers from the import-safe module so existing import paths keep working.
+from .executor_helpers import _parse_discovered_at, _validate_risk_fields, _row_value
+
 from .auth import DEFAULT_OWNER_ID
 from .redaction import redact
 from .cache import get_cache
@@ -90,33 +93,7 @@ async def _terminate_process_group(pid: int, task_id: str, grace_seconds: int = 
         logger.debug("SIGKILL to pgid %d failed: %s", pgid, exc)
 
 
-def _parse_discovered_at(finding: dict) -> Optional[datetime]:
-    """Extract and parse discovered_at from a finding dict as timezone-aware UTC."""
-    from .time_utils import parse_to_utc, utc_now
 
-    parsed = parse_to_utc(finding.get("discovered_at"))
-    return parsed if parsed is not None else utc_now()
-
-
-def _validate_risk_fields(finding: dict) -> None:
-    """Validate exploitability, confidence, and asset_exposure bounds in-place."""
-    exp = finding.get("exploitability")
-    if exp is not None:
-        if not isinstance(exp, (int, float)):
-            raise ValueError(f"exploitability must be numeric, got {type(exp).__name__}")
-        if exp < 0 or exp > 10:
-            raise ValueError(f"exploitability must be in [0, 10], got {exp}")
-
-    conf = finding.get("confidence")
-    if conf is not None:
-        if not isinstance(conf, (int, float)):
-            raise ValueError(f"confidence must be numeric, got {type(conf).__name__}")
-        if conf < 0 or conf > 1:
-            raise ValueError(f"confidence must be in [0, 1], got {conf}")
-
-    ae = finding.get("asset_exposure")
-    if ae is not None and ae.lower() not in ("critical", "high", "medium", "low"):
-        raise ValueError(f"asset_exposure must be one of critical/high/medium/low, got {ae}")
 
 # Modular Scanners
 from .scanners.port_scanner import PortScanner
@@ -153,16 +130,6 @@ def _stable_asset_id(target: str, host: Any, port: Any, protocol: Any) -> str:
     return f"asset:{uuid.uuid5(uuid.NAMESPACE_URL, material).hex[:16]}"
 
 
-def _row_value(row: Any, key: str, default: Any = None) -> Any:
-    """Read a dict/sqlite row key with a default for backward-compatible mocks."""
-    if row is None:
-        return default
-    if isinstance(row, dict):
-        return row.get(key, default)
-    try:
-        return row[key]
-    except (KeyError, IndexError, TypeError):
-        return default
 
 
 class TaskExecutor:

--- a/backend/secuscan/executor_helpers.py
+++ b/backend/secuscan/executor_helpers.py
@@ -1,0 +1,49 @@
+"""Pure helper functions extracted from backend/secuscan/executor.py.
+
+This module is import-safe: it has no FastAPI/database/scanner dependencies.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+
+def _parse_discovered_at(finding: dict) -> Optional[datetime]:
+    """Extract and parse discovered_at from a finding dict as timezone-aware UTC."""
+    from .time_utils import parse_to_utc, utc_now
+
+    parsed = parse_to_utc(finding.get("discovered_at"))
+    return parsed if parsed is not None else utc_now()
+
+
+def _validate_risk_fields(finding: dict) -> None:
+    """Validate exploitability, confidence, and asset_exposure bounds in-place."""
+    exp = finding.get("exploitability")
+    if exp is not None:
+        if not isinstance(exp, (int, float)):
+            raise ValueError(f"exploitability must be numeric, got {type(exp).__name__}")
+        if exp < 0 or exp > 10:
+            raise ValueError(f"exploitability must be in [0, 10], got {exp}")
+
+    conf = finding.get("confidence")
+    if conf is not None:
+        if not isinstance(conf, (int, float)):
+            raise ValueError(f"confidence must be numeric, got {type(conf).__name__}")
+        if conf < 0 or conf > 1:
+            raise ValueError(f"confidence must be in [0, 1], got {conf}")
+
+    ae = finding.get("asset_exposure")
+    if ae is not None and ae.lower() not in ("critical", "high", "medium", "low"):
+        raise ValueError(f"asset_exposure must be one of critical/high/medium/low, got {ae}")
+
+
+def _row_value(row: Any, key: str, default: Any = None) -> Any:
+    """Read a dict/sqlite row key with a default for backward-compatible mocks."""
+    if row is None:
+        return default
+    if isinstance(row, dict):
+        return row.get(key, default)
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        return default

--- a/testing/backend/unit/test_executor_parse_discovered_at.py
+++ b/testing/backend/unit/test_executor_parse_discovered_at.py
@@ -1,0 +1,65 @@
+"""Unit tests for _parse_discovered_at in backend/secuscan/executor.py."""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from backend.secuscan.executor_helpers import _parse_discovered_at
+
+
+class TestParseDiscoveredAt:
+    def test_iso_string_returns_aware_datetime(self):
+        finding = {"discovered_at": "2026-01-15T10:30:00Z"}
+        result = _parse_discovered_at(finding)
+        assert result.tzinfo is not None
+        assert result.year == 2026
+        assert result.month == 1
+        assert result.day == 15
+
+    def test_iso_string_with_offset(self):
+        finding = {"discovered_at": "2026-03-20T14:00:00+05:30"}
+        result = _parse_discovered_at(finding)
+        assert result.tzinfo is not None
+
+    def test_timestamp_integer(self):
+        finding = {"discovered_at": 1704067200}  # 2024-01-01 00:00:00 UTC
+        result = _parse_discovered_at(finding)
+        assert result.tzinfo is not None
+
+    def test_datetime_object_aware(self):
+        aware_dt = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        finding = {"discovered_at": aware_dt}
+        result = _parse_discovered_at(finding)
+        assert result == aware_dt
+        assert result.tzinfo is not None
+
+    def test_naive_datetime_normalized_to_utc(self):
+        naive_dt = datetime(2026, 6, 15, 12, 0, 0)
+        finding = {"discovered_at": naive_dt}
+        result = _parse_discovered_at(finding)
+        assert result.tzinfo is not None
+
+    def test_missing_discovered_at_falls_back_to_utc_now(self):
+        fallback = datetime(2026, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+        with patch("backend.secuscan.time_utils.utc_now", return_value=fallback):
+            result = _parse_discovered_at({})
+            assert result == fallback
+
+    def test_none_discovered_at_falls_back_to_utc_now(self):
+        fallback = datetime(2026, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+        with patch("backend.secuscan.time_utils.utc_now", return_value=fallback):
+            result = _parse_discovered_at({"discovered_at": None})
+            assert result == fallback
+
+    def test_invalid_string_falls_back_to_utc_now(self):
+        fallback = datetime(2026, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+        with patch("backend.secuscan.time_utils.utc_now", return_value=fallback):
+            result = _parse_discovered_at({"discovered_at": "not-a-date"})
+            assert result == fallback
+
+    def test_empty_string_falls_back_to_utc_now(self):
+        fallback = datetime(2026, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+        with patch("backend.secuscan.time_utils.utc_now", return_value=fallback):
+            result = _parse_discovered_at({"discovered_at": ""})
+            assert result == fallback


### PR DESCRIPTION
Closes #2297.

Summary of What Has Been Done:
Extracted _parse_discovered_at into backend/secuscan/executor_helpers.py (shared with other executor helpers), and added 8 comprehensive unit tests covering ISO strings, timestamps, datetime objects, naive datetimes, and fallback to utc_now() for missing/invalid values. Updated backend/secuscan/executor.py to re-export.

Changes Made:
- New file: backend/secuscan/executor_helpers.py (shared helper module)
- Modified: backend/secuscan/executor.py (re-exports from executor_helpers)
- New file: testing/backend/unit/test_executor_parse_discovered_at.py (8 tests)

Impact it Made:
Improves test coverage for timestamp normalization during scan result processing. Ensures consistent UTC timestamps in the database regardless of input format.

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.