### PR TITLE
feat: add curated scan templates with category filtering

### DIFF
--- a/backend/secuscan/routes.py
+++ b/backend/secuscan/routes.py
@@ -341,6 +341,29 @@ async def get_all_presets():
     }
 
 
+@router.get("/scan-templates")
+async def list_scan_templates(
+    category: Optional[str] = None,
+):
+    """List all curated scan templates, optionally filtered by category"""
+    from .templates import get_templates, get_templates_by_category
+    if category:
+        templates = get_templates_by_category(category)
+    else:
+        templates = get_templates()
+    return {"templates": templates, "total": len(templates)}
+
+
+@router.get("/scan-templates/{template_id}")
+async def get_scan_template(template_id: str):
+    """Get a specific scan template by ID"""
+    from .templates import get_template
+    template = get_template(template_id)
+    if not template:
+        raise HTTPException(status_code=404, detail=f"Scan template not found: {template_id}")
+    return template
+
+
 @router.post("/task/start", dependencies=[Depends(task_start_limiter), Depends(check_scan_rate_limit)])
 async def start_task(
     request: TaskCreateRequest,

--- a/backend/secuscan/templates.py
+++ b/backend/secuscan/templates.py
@@ -1,0 +1,196 @@
+"""
+Curated scan templates for common security workflows.
+Each template defines a scan configuration with plugin, preset, inputs, and description.
+"""
+
+from typing import List, Dict, Any, Optional
+from pydantic import BaseModel
+
+class ScanTemplate(BaseModel):
+    id: str
+    name: str
+    description: str
+    category: str  # "reconnaissance", "vulnerability", "web", "network", "compliance"
+    complexity: str  # "basic", "intermediate", "advanced"
+    estimated_duration: str  # e.g. "5-10 min", "30-60 min"
+    plugin_id: str
+    preset: Optional[str] = None
+    inputs: Dict[str, Any] = {}
+    execution_context: Optional[Dict[str, Any]] = None
+    tags: List[str] = []
+    icon: str = "scan"  # material-symbols-outlined icon name
+
+# Curated templates
+TEMPLATES: List[ScanTemplate] = [
+    ScanTemplate(
+        id="quick-port-scan",
+        name="Quick Port Scan",
+        description="Scan top 1000 ports on a target to identify open services and entry points.",
+        category="network",
+        complexity="basic",
+        estimated_duration="2-5 min",
+        plugin_id="port_scanner",
+        preset="quick",
+        inputs={},
+        tags=["recon", "ports", "quick"],
+        icon="radar",
+    ),
+    ScanTemplate(
+        id="full-port-scan",
+        name="Full Port Enumeration",
+        description="Comprehensive port scan of all 65535 ports with service fingerprinting and OS detection.",
+        category="network",
+        complexity="intermediate",
+        estimated_duration="15-30 min",
+        plugin_id="port_scanner",
+        preset="full",
+        inputs={},
+        tags=["recon", "ports", "comprehensive"],
+        icon="grid_view",
+    ),
+    ScanTemplate(
+        id="web-vulnerability-scan",
+        name="Web Application Vulnerability Scan",
+        description="Automated web vulnerability assessment including XSS, SQLi, CSRF, and misconfigurations.",
+        category="web",
+        complexity="intermediate",
+        estimated_duration="10-30 min",
+        plugin_id="web_scanner",
+        preset="balanced",
+        inputs={},
+        tags=["web", "vulnerabilities", "owasp"],
+        icon="language",
+    ),
+    ScanTemplate(
+        id="full-web-audit",
+        name="Deep Web Application Audit",
+        description="Thorough web application security audit with aggressive crawling, all vulnerability checks, and evidence collection.",
+        category="web",
+        complexity="advanced",
+        estimated_duration="30-60 min",
+        plugin_id="web_scanner",
+        preset="aggressive",
+        inputs={},
+        tags=["web", "deep", "owasp", "comprehensive"],
+        icon="travel_explore",
+    ),
+    ScanTemplate(
+        id="recon-subdomain",
+        name="Subdomain Enumeration",
+        description="Discover subdomains and related targets through passive DNS, certificates, and search engines.",
+        category="reconnaissance",
+        complexity="basic",
+        estimated_duration="3-8 min",
+        plugin_id="recon_scanner",
+        preset="subdomain_enum",
+        inputs={},
+        tags=["recon", "subdomains", "passive"],
+        icon="dns",
+    ),
+    ScanTemplate(
+        id="recon-full",
+        name="Full Reconnaissance Suite",
+        description="Comprehensive recon including subdomains, technologies, WHOIS, DNS records, and OSINT data.",
+        category="reconnaissance",
+        complexity="advanced",
+        estimated_duration="20-45 min",
+        plugin_id="recon_scanner",
+        preset="full_recon",
+        inputs={},
+        tags=["recon", "osint", "comprehensive"],
+        icon="travel_explore",
+    ),
+    ScanTemplate(
+        id="api-security-scan",
+        name="API Security Assessment",
+        description="Test REST/GraphQL APIs for common vulnerabilities including auth bypasses, injection, and rate limiting issues.",
+        category="web",
+        complexity="intermediate",
+        estimated_duration="10-20 min",
+        plugin_id="api_scanner",
+        preset="default",
+        inputs={},
+        tags=["api", "rest", "graphql", "security"],
+        icon="api",
+    ),
+    ScanTemplate(
+        id="vulnerability-scan",
+        name="Network Vulnerability Assessment",
+        description="Scan network targets for known CVEs, misconfigurations, and common vulnerabilities.",
+        category="vulnerability",
+        complexity="intermediate",
+        estimated_duration="15-40 min",
+        plugin_id="network_scanner",
+        preset="balanced",
+        inputs={},
+        tags=["cve", "vulnerabilities", "network"],
+        icon="bug_report",
+    ),
+    ScanTemplate(
+        id="xss-validation",
+        name="XSS Validation & Exploit Testing",
+        description="Validate XSS findings with proof-of-concept generation and browser-based execution confirmation.",
+        category="vulnerability",
+        complexity="advanced",
+        estimated_duration="5-15 min",
+        plugin_id="xss_exploiter",
+        preset="default",
+        inputs={},
+        tags=["xss", "validation", "exploit"],
+        icon="javascript",
+    ),
+    ScanTemplate(
+        id="zap-scan",
+        name="OWASP ZAP Automated Scan",
+        description="Leverage OWASP ZAP for comprehensive web application security testing with both passive and active scanning.",
+        category="web",
+        complexity="intermediate",
+        estimated_duration="20-60 min",
+        plugin_id="zap_scanner",
+        preset="default",
+        inputs={},
+        tags=["zap", "owasp", "web", "automated"],
+        icon="security",
+    ),
+    ScanTemplate(
+        id="quick-external-audit",
+        name="Quick External Security Audit",
+        description="Rapid external-facing security check covering open ports, basic web checks, and common exposures.",
+        category="network",
+        complexity="basic",
+        estimated_duration="5-10 min",
+        plugin_id="port_scanner",
+        preset="quick",
+        inputs={},
+        tags=["external", "quick", "audit"],
+        icon="shield",
+    ),
+    ScanTemplate(
+        id="pci-recon-scan",
+        name="PCI DSS Reconnaissance Scan",
+        description="Discovery scan tailored for PCI DSS compliance, identifying all live services and entry points in scope.",
+        category="compliance",
+        complexity="intermediate",
+        estimated_duration="10-20 min",
+        plugin_id="recon_scanner",
+        preset="full_recon",
+        inputs={},
+        tags=["pci", "compliance", "recon"],
+        icon="verified",
+    ),
+]
+
+
+def get_templates() -> List[Dict[str, Any]]:
+    return [t.model_dump() for t in TEMPLATES]
+
+
+def get_template(template_id: str) -> Optional[Dict[str, Any]]:
+    for t in TEMPLATES:
+        if t.id == template_id:
+            return t.model_dump()
+    return None
+
+
+def get_templates_by_category(category: str) -> List[Dict[str, Any]]:
+    return [t.model_dump() for t in TEMPLATES if t.category == category]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Settings from './pages/Settings'
 import Scans from './pages/Scans'
 import TaskDetails from './pages/TaskDetails'
 import Workflows from './pages/Workflows'
+import ScanTemplates from './pages/ScanTemplates'
 import NotFound from './pages/NotFound'
 import SignIn from './pages/SignIn'
 import ErrorBoundary from './components/ErrorBoundary'
@@ -49,6 +50,7 @@ export function AppRoutes() {
           <Route path={routes.reports} element={<Reports />} />
           <Route path={routes.reportsCompare} element={<ReportCompare />} />
           <Route path={routes.workflows} element={<Workflows />} />
+          <Route path={routes.templates} element={<ScanTemplates />} />
           <Route path={routes.settings} element={<Settings />} />
           <Route path={routes.task} element={<TaskDetails />} />
           <Route path="*" element={<NotFound />} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -962,3 +962,23 @@ export function getAssetServices() {
 export function getKnowledgebaseStatus() {
   return request('/knowledgebase/status')
 }
+
+export interface ScanTemplate {
+  id: string
+  name: string
+  description: string
+  category: string
+  complexity: string
+  estimated_duration: string
+  plugin_id: string
+  preset?: string | null
+  inputs: Record<string, unknown>
+  execution_context?: Record<string, unknown> | null
+  tags: string[]
+  icon: string
+}
+
+export function getScanTemplates(category?: string) {
+  const params = category ? `?category=${encodeURIComponent(category)}` : ''
+  return request<{ templates: ScanTemplate[]; total: number }>(`/scan-templates${params}`)
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -160,6 +160,7 @@ export default function Sidebar() {
 
                 <NavItem to={routes.reports} icon="summarize" label="Reports" isExpanded={isExpanded} />
                 <NavItem to={routes.workflows} icon="account_tree" label="Workflows" isExpanded={isExpanded} />
+                <NavItem to={routes.templates} icon="auto_awesome" label="Templates" isExpanded={isExpanded} />
 
             </div>
 

--- a/frontend/src/pages/ScanTemplates.tsx
+++ b/frontend/src/pages/ScanTemplates.tsx
@@ -1,0 +1,242 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { motion, AnimatePresence, type Variants } from "framer-motion";
+import { getScanTemplates, type ScanTemplate } from "../api";
+
+const categories = [
+  { value: "", label: "ALL_TEMPLATES", icon: "dashboard" },
+  { value: "network", label: "NETWORK", icon: "lan" },
+  { value: "web", label: "WEB", icon: "language" },
+  { value: "reconnaissance", label: "RECONNAISSANCE", icon: "travel_explore" },
+  { value: "vulnerability", label: "VULNERABILITY", icon: "bug_report" },
+  { value: "compliance", label: "COMPLIANCE", icon: "verified" },
+];
+
+const complexityColors: Record<string, string> = {
+  basic: "bg-rag-green text-black",
+  intermediate: "bg-rag-amber text-black",
+  advanced: "bg-rag-red text-black",
+};
+
+const containerVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.06 },
+  },
+};
+
+const cardVariants: Variants = {
+  hidden: { opacity: 0, y: 24, scale: 0.95 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: { type: "spring", stiffness: 200, damping: 20 },
+  },
+};
+
+export default function ScanTemplates() {
+  const navigate = useNavigate();
+  const [templates, setTemplates] = useState<ScanTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [activeCategory, setActiveCategory] = useState("");
+
+  useEffect(() => {
+    loadTemplates();
+  }, [activeCategory]);
+
+  async function loadTemplates() {
+    setLoading(true);
+    try {
+      const data = await getScanTemplates(activeCategory || undefined);
+      setTemplates(data.templates || []);
+    } catch (err) {
+      console.error("Failed to load scan templates:", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleUseTemplate(template: ScanTemplate) {
+    navigate(`/toolkit?template=${template.id}`);
+  }
+
+  return (
+    <div className="min-h-screen bg-charcoal-dark text-silver p-6 md:p-12 space-y-12">
+      {/* Neo-Brutalist Header */}
+      <header className="relative flex flex-col md:flex-row justify-between items-start md:items-end gap-8 pb-12 border-b-4 border-silver-bright/10">
+        <div className="space-y-4">
+          <div className="bg-rag-blue text-black px-4 py-1 text-xs font-black uppercase tracking-widest inline-block shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+            Scan_Templates_v1.0
+          </div>
+          <h1 className="text-6xl md:text-8xl font-black text-silver-bright uppercase tracking-tighter leading-none italic">
+            Scan{" "}
+            <span
+              className="text-transparent stroke-white"
+              style={{ WebkitTextStroke: "1px var(--accent-silver-bright)" }}
+            >
+              Templates
+            </span>
+          </h1>
+          <p className="text-sm font-mono text-silver/40 uppercase tracking-widest italic flex items-center gap-4">
+            Total_Templates: {templates.length} //{" "}
+            {loading ? "LOADING..." : "READY"}
+            <span
+              className={`w-2 h-2 rounded-full ${loading ? "bg-rag-amber animate-pulse" : "bg-rag-green"}`}
+            ></span>
+          </p>
+        </div>
+      </header>
+
+      {/* Category Filter Chips */}
+      <section className="bg-charcoal border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+        <div className="flex flex-wrap items-center gap-4">
+          {categories.map((cat) => (
+            <button
+              key={cat.value}
+              onClick={() => setActiveCategory(cat.value)}
+              aria-pressed={activeCategory === cat.value}
+              className={`px-6 py-3 text-[10px] font-black uppercase tracking-widest transition-all border-2 flex items-center gap-2 ${
+                activeCategory === cat.value
+                  ? "bg-silver-bright text-black border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] -translate-x-0.5 -translate-y-0.5"
+                  : "bg-charcoal-dark text-silver/30 border-silver-bright/5 hover:border-silver-bright/20"
+              }`}
+            >
+              <span className="material-symbols-outlined text-sm">{cat.icon}</span>
+              {cat.label}
+              {activeCategory === cat.value && <span className="w-1 h-3 bg-black"></span>}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {/* Templates Grid */}
+      <section className="relative">
+        <AnimatePresence mode="wait">
+          {loading ? (
+            <motion.div
+              key="loading"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="py-40 flex items-center justify-center"
+            >
+              <div className="flex flex-col items-center gap-6">
+                <div className="w-12 h-12 border-4 border-rag-blue border-t-transparent rounded-full animate-spin"></div>
+                <p className="text-xs font-mono text-silver/40 uppercase tracking-widest italic">
+                  Loading templates...
+                </p>
+              </div>
+            </motion.div>
+          ) : templates.length === 0 ? (
+            <motion.div
+              key="empty"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="py-40 bg-charcoal/30 border-4 border-dashed border-silver-bright/5 text-center flex flex-col items-center gap-8"
+            >
+              <span className="material-symbols-outlined text-silver/5 text-9xl">scan_delete</span>
+              <div className="space-y-2">
+                <p className="text-xl font-black text-silver/20 uppercase tracking-[0.4em] italic">
+                  No templates found
+                </p>
+                <p className="text-xs font-mono text-silver/10 uppercase tracking-widest">
+                  No scan templates available for the selected category
+                </p>
+              </div>
+            </motion.div>
+          ) : (
+            <motion.div
+              key={activeCategory || "all"}
+              variants={containerVariants}
+              initial="hidden"
+              animate="visible"
+              className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8"
+            >
+              {templates.map((template) => (
+                <motion.div
+                  key={template.id}
+                  variants={cardVariants}
+                  layout
+                  className="bg-charcoal border-4 border-black p-8 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-[12px_12px_0px_0px_rgba(0,0,0,1)] transition-all flex flex-col group"
+                >
+                  {/* Icon */}
+                  <div className="w-14 h-14 bg-charcoal-dark border-4 border-black flex items-center justify-center shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] group-hover:shadow-none group-hover:translate-x-1 group-hover:translate-y-1 transition-all mb-6">
+                    <span className="material-symbols-outlined text-2xl text-rag-blue">
+                      {template.icon}
+                    </span>
+                  </div>
+
+                  {/* Name & Description */}
+                  <div className="flex-1 space-y-3 mb-6">
+                    <h3 className="text-2xl font-black text-silver-bright uppercase tracking-tighter italic leading-none group-hover:text-rag-blue transition-colors">
+                      {template.name}
+                    </h3>
+                    <p className="text-xs font-mono text-silver/50 leading-relaxed">
+                      {template.description}
+                    </p>
+                  </div>
+
+                  {/* Badges */}
+                  <div className="flex flex-wrap items-center gap-3 mb-6">
+                    <span className="px-3 py-1 text-[9px] font-black uppercase italic border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] bg-charcoal-dark text-silver/60">
+                      {template.category}
+                    </span>
+                    <span
+                      className={`px-3 py-1 text-[9px] font-black uppercase italic border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] ${
+                        complexityColors[template.complexity] || "bg-charcoal-dark text-silver/60"
+                      }`}
+                    >
+                      {template.complexity}
+                    </span>
+                    <span className="px-3 py-1 text-[9px] font-black uppercase italic border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] bg-charcoal-dark text-silver/60">
+                      {template.estimated_duration}
+                    </span>
+                  </div>
+
+                  {/* Tags */}
+                  {template.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mb-8">
+                      {template.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="text-[8px] font-mono text-silver/30 uppercase tracking-widest border border-silver-bright/10 px-2 py-1"
+                        >
+                          #{tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* CTA */}
+                  <button
+                    onClick={() => handleUseTemplate(template)}
+                    className="w-full bg-rag-blue text-black py-4 text-[10px] font-black uppercase tracking-widest shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-x-1 hover:translate-y-1 transition-all flex items-center justify-center gap-3 italic"
+                  >
+                    Use Template
+                    <span className="material-symbols-outlined text-sm">arrow_right_alt</span>
+                  </button>
+                </motion.div>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </section>
+
+      {/* Footer */}
+      <footer className="pt-24 opacity-20 pointer-events-none select-none flex flex-col md:flex-row justify-between items-center gap-8 text-[9px] font-black uppercase tracking-[0.5em] italic">
+        <div className="flex items-center gap-4">
+          <span className="w-8 h-8 border-4 border-silver/20 flex items-center justify-center font-serif text-lg">S</span>
+          SECUSCAN TEMPLATE CATALOG v1.0
+        </div>
+        <div className="flex gap-2">
+          {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((i) => (
+            <div key={i} className="w-1.5 h-3 bg-silver/20"></div>
+          ))}
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -10,6 +10,7 @@ export const routes = {
   settings: '/settings',
   task: '/task/:taskId',
   signIn: '/signin',
+  templates: '/templates',
 } as const
 
 export const routePath = {


### PR DESCRIPTION
Closes #34

- Creates backend/secuscan/templates.py with 12 scan template definitions
- Adds GET /scan-templates and GET /scan-templates/{id} endpoints
- Creates ScanTemplates.tsx page with grid display + category filter
- Adds route in App.tsx, nav link in Sidebar.tsx, API call in api.ts

## Description
<!-- Provide a clear description of the changes in this PR. -->

## Related Issues
<!-- Link any related issues using #issue-number. -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Provide instructions so we can reproduce. -->

## Checklist
- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
