### PR TITLE
docs: document raw scan output retention and cleanup

### DIFF
--- a/docs/SECURE_DEPLOYMENT.md
+++ b/docs/SECURE_DEPLOYMENT.md
@@ -367,6 +367,18 @@ network behavior of these variables.
 > assess.
 
 ---
+## Raw Scan Output Retention and Cleanup
+
+SecuScan stores runtime-generated scan artifacts in directories such as `data/raw/`, `backend/data/raw/`, `data/reports/`, and `backend/data/reports/`. These directories contain temporary scan outputs, reports, and other generated artifacts that are created during scan execution.
+
+Operators should retain runtime-generated artifacts only for operational needs such as validation, troubleshooting, or incident analysis. These artifacts are not intended to be committed to version control.
+
+Before cleaning up runtime-generated artifacts:
+
+* Ensure no active scan is using the files.
+* Preserve any reports or artifacts required for investigation or auditing.
+* Delete only runtime-generated files and retain repository placeholder files such as `.gitkeep`.
+* Verify that required scan results have been exported or archived before removal.
 
 # Hardening Checklist
 


### PR DESCRIPTION
## Description

- Added a new **Raw Scan Output Retention and Cleanup** section to docs/SECURE_DEPLOYMENT.md.
- Documented the runtime-generated artifact locations.
- Added guidance for retention and safe cleanup of runtime-generated scan artifacts.
- Clarified that runtime-generated artifacts should not be committed to version control.

## Related Issues

Fixes #2188

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?

- [x] Documentation reviewed for consistency with the existing deployment guide.
- [x] Verified the referenced runtime artifact locations against the repository.