### PR TITLE
Add retry support for notification delivery

### DIFF
--- a/backend/secuscan/notification_service.py
+++ b/backend/secuscan/notification_service.py
@@ -624,7 +624,7 @@ async def deliver_via_rule(
     channel = str(rule.get("channel_type", "")).lower()
     target = str(rule.get("target_url_or_email", ""))
 
-    
+
     config = get_delivery_configuration()
     max_retries = config["max_retries"]
     backoff = config["backoff_factor_seconds"]
@@ -976,7 +976,7 @@ async def process_slack_notification(db: Database, task_id: str) -> None:
         (task_id,),
     )
     total_findings = len(findings)
-    
+
     severity_counts: Dict[str, int] = {}
     for row in findings:
         sev = str(row.get("severity") or "info").lower()
@@ -992,7 +992,7 @@ async def process_slack_notification(db: Database, task_id: str) -> None:
 
     # Status-specific formatting
     status_icon = "✅" if status == "COMPLETED" else "❌" if status == "FAILED" else "ℹ️"
-    
+
     blocks = [
         {
             "type": "header",

--- a/backend/secuscan/notification_service.py
+++ b/backend/secuscan/notification_service.py
@@ -624,13 +624,31 @@ async def deliver_via_rule(
     channel = str(rule.get("channel_type", "")).lower()
     target = str(rule.get("target_url_or_email", ""))
 
-    if channel == NotificationChannelType.WEBHOOK.value:
-        ok, error = await send_webhook(target, payload)
-    elif channel == NotificationChannelType.EMAIL.value:
-        ok, error = await send_email(target, payload)
-    else:
-        ok, error = False, f"Unsupported channel type: {channel}"
+    
+    config = get_delivery_configuration()
+    max_retries = config["max_retries"]
+    backoff = config["backoff_factor_seconds"]
 
+    attempt = 0
+
+    while True:
+        if channel == NotificationChannelType.WEBHOOK.value:
+            ok, error = await send_webhook(target, payload)
+        elif channel == NotificationChannelType.EMAIL.value:
+            ok, error = await send_email(target, payload)
+        else:
+            ok, error = False, f"Unsupported channel type: {channel}"
+
+        if ok:
+            break
+
+        if attempt >= max_retries:
+            break
+
+        attempt += 1
+
+        if backoff > 0:
+            await asyncio.sleep(backoff * attempt)
     status = (
         NotificationDeliveryStatus.SUCCESS if ok else NotificationDeliveryStatus.FAILED
     )

--- a/testing/backend/unit/test_notification_service.py
+++ b/testing/backend/unit/test_notification_service.py
@@ -222,6 +222,42 @@ async def test_deliver_records_failure_on_webhook_error(test_db):
     assert row["status"] == NotificationDeliveryStatus.FAILED.value
     assert row["error_message"] == "connection refused"
 
+@pytest.mark.asyncio
+async def test_deliver_via_rule_retries_before_success(test_db):
+    _, finding_id = await _seed_finding(test_db)
+    rule_id = await _seed_rule(test_db)
+
+    finding = await test_db.fetchone(
+        "SELECT * FROM findings WHERE id = ?", (finding_id,)
+    )
+    rule = await test_db.fetchone(
+        "SELECT * FROM notification_rules WHERE id = ?", (rule_id,)
+    )
+
+    with (
+        patch(
+            "backend.secuscan.notification_service.get_delivery_configuration",
+            return_value={
+                "webhook_timeout_seconds": 10,
+                "webhook_connect_timeout_seconds": 3,
+                "max_retries": 2,
+                "backoff_factor_seconds": 0,
+            },
+        ),
+        patch(
+            "backend.secuscan.notification_service.send_webhook",
+            new=AsyncMock(
+                side_effect=[
+                    (False, "temporary error"),
+                    (True, None),
+                ]
+            ),
+        ) as mock_send,
+    ):
+        result = await deliver_via_rule(test_db, rule, finding)
+
+    assert result.status == NotificationDeliveryStatus.SUCCESS
+    assert mock_send.await_count == 2
 
 @pytest.mark.asyncio
 async def test_email_placeholder_records_success(test_db):


### PR DESCRIPTION
## 🔗 Related Issue

Closes #1830

---

## 📝 Summary of Changes

- Added configurable retry support for notification delivery.
- Uses the existing `max_retries` and `backoff_factor_seconds` from the delivery configuration.
- Retries failed webhook/email deliveries before recording the final delivery status.
- Added a unit test covering retry-before-success behavior.

---

## 🏷️ Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] 🎨 UI / Style change
- [ ] 🔧 Chore

---

## 🧪 Testing

**Steps to test:**

1. Run:

```bash
python -m pytest testing/backend/unit/test_notification_service.py -v
```

2. Verify all notification service tests pass.

3. Run:

```bash
python -m pytest testing/backend/unit/test_notification_delivery_config.py -v
```

**Results:**

- ✅ 36 notification service tests passed.
- ✅ 7 notification delivery configuration tests passed.

---

## ✅ Checklist

- [x] No merge conflicts
- [x] Changes follow the project guidelines
- [ ] Documentation updated (not applicable)
- [x] Related issue linked
- [x] Changes tested locally