### PR TITLE
fix(shortcuts): close popovers on Escape via a global broadcast

### DIFF
--- a/frontend/src/components/SavedViewsPanel.tsx
+++ b/frontend/src/components/SavedViewsPanel.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
+import { useEscapeToClose } from '../hooks/useEscapeToClose'
 import { AnimatePresence, motion } from 'framer-motion'
 import { FilterPreset, SavedView, UseSavedViewsReturn } from '../hooks/useSavedViews'
 
@@ -169,6 +170,9 @@ export default function SavedViewsPanel({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [successMsg, setSuccessMsg] = useState<string | null>(null)
+
+  const closePanel = useCallback(() => setOpen(false), [])
+  useEscapeToClose(open, closePanel)
 
   async function handleSave() {
     const trimmed = saveName.trim()

--- a/frontend/src/hooks/useEscapeToClose.ts
+++ b/frontend/src/hooks/useEscapeToClose.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+
+/**
+ * Global "user pressed Escape" event.
+ *
+ * `useShortcuts` owns the single window-level keydown listener and re-broadcasts
+ * Escape as this event. Popovers and dropdowns subscribe via `useEscapeToClose`
+ * rather than each registering their own keydown handler, so behaviour stays
+ * consistent and the listener count does not grow with the number of overlays
+ * on the page.
+ */
+export const ESCAPE_EVENT = 'secuscan:escape'
+
+/**
+ * Close an overlay when Escape is pressed.
+ *
+ * Only subscribes while `isOpen` is true, so a closed popover does nothing and
+ * Escape keeps reaching whatever else is listening.
+ *
+ * Note that `useShortcuts` blurs the focused field instead of broadcasting when
+ * the user is typing in an input, textarea, or contenteditable. Escape inside a
+ * panel's own text field therefore leaves the field first and closes the panel
+ * on a second press — deliberate, so a stray Escape while typing does not
+ * discard what the user was entering.
+ *
+ * @param isOpen   whether the overlay is currently open
+ * @param onClose  called when Escape is pressed while open
+ */
+export function useEscapeToClose(isOpen: boolean, onClose: () => void) {
+    useEffect(() => {
+        if (!isOpen) return
+
+        const handleEscape = () => onClose()
+        window.addEventListener(ESCAPE_EVENT, handleEscape)
+        return () => window.removeEventListener(ESCAPE_EVENT, handleEscape)
+    }, [isOpen, onClose])
+}

--- a/frontend/src/hooks/useShortcuts.ts
+++ b/frontend/src/hooks/useShortcuts.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { routes } from '../routes'
+import { ESCAPE_EVENT } from './useEscapeToClose'
 
 /**
  * Global keyboard shortcuts hook for SecuScan.
@@ -12,7 +13,8 @@ import { routes } from '../routes'
  * g + r : Reports
  * g + t : Settings (Tools)
  * g + b : Toggle Sidebar
- * Esc   : Close focus/modals
+ * Esc   : Blur the focused field, or broadcast ESCAPE_EVENT so open
+ *         popovers and dropdowns close (see useEscapeToClose).
  */
 export function useShortcuts(onToggleSidebar?: () => void) {
     const navigate = useNavigate()
@@ -31,7 +33,9 @@ export function useShortcuts(onToggleSidebar?: () => void) {
             }
 
             if (e.key === 'Escape') {
-                // Could emit global event to close modals
+                // Broadcast so open popovers/dropdowns can close themselves.
+                // See useEscapeToClose for the subscriber side.
+                window.dispatchEvent(new CustomEvent(ESCAPE_EVENT))
                 return
             }
 

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { getFindings, FindingsResponse } from '../api'
 import { formatLocaleDate, parseDateSafe, getCurrentTimeZone } from '../utils/date'
 import SavedViewsPanel from '../components/SavedViewsPanel'
 import { useSavedViews, FilterPreset } from '../hooks/useSavedViews'
+import { useEscapeToClose } from '../hooks/useEscapeToClose'
 import { exportFindingsAsCSV, exportFindingsAsJSON } from '../utils/exportUtils'
 
 type RiskFactor = {
@@ -176,6 +177,9 @@ export default function Findings() {
   // ── Multi-select export state & handlers ───────────────────────────────────
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [exportDropdownOpen, setExportDropdownOpen] = useState(false)
+
+  const closeExportDropdown = useCallback(() => setExportDropdownOpen(false), [])
+  useEscapeToClose(exportDropdownOpen, closeExportDropdown)
 
   const [columnVisibility, setColumnVisibility] = useState({
     category: true,

--- a/frontend/testing/unit/components/SavedViewsPanel.test.tsx
+++ b/frontend/testing/unit/components/SavedViewsPanel.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import SavedViewsPanel from '../../../src/components/SavedViewsPanel'
+import { ESCAPE_EVENT } from '../../../src/hooks/useEscapeToClose'
 
 /* ------------------------------------------------------------------ */
 /*  Mocks                                                             */
@@ -296,6 +297,40 @@ describe('SavedViewsPanel', () => {
       // The original rows should remain fully intact and not disappear or be replaced
       expect(screen.getByText('Critical Findings Only')).toBeInTheDocument()
       expect(screen.getByText('High Severity Filters')).toBeInTheDocument()
+    })
+  })
+  // ── Escape closes the panel (issue #1845) ────────────────────────────────
+  // Escape was a no-op outside inputs, so this panel stayed open.
+
+  describe('Closing with Escape', () => {
+    it('closes the open panel when Escape is broadcast', async () => {
+      const user = userEvent.setup()
+      renderSavedViewsPanel()
+
+      const toggleButton = screen.getByRole('button', { name: 'Saved filter views' })
+      await user.click(toggleButton)
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
+
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent(ESCAPE_EVENT))
+      })
+
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
+      expect(
+        screen.queryByRole('dialog', { name: 'Saved filter views panel' }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('ignores the escape broadcast while already closed', async () => {
+      renderSavedViewsPanel()
+
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent(ESCAPE_EVENT))
+      })
+
+      expect(
+        screen.getByRole('button', { name: 'Saved filter views' }),
+      ).toHaveAttribute('aria-expanded', 'false')
     })
   })
 })

--- a/frontend/testing/unit/hooks/useEscapeToClose.test.ts
+++ b/frontend/testing/unit/hooks/useEscapeToClose.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  ESCAPE_EVENT,
+  useEscapeToClose,
+} from '../../../src/hooks/useEscapeToClose'
+
+function pressEscape() {
+  window.dispatchEvent(new CustomEvent(ESCAPE_EVENT))
+}
+
+describe('useEscapeToClose', () => {
+  it('closes when escape is broadcast while open', () => {
+    const onClose = vi.fn()
+    renderHook(() => useEscapeToClose(true, onClose))
+
+    pressEscape()
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing while closed', () => {
+    const onClose = vi.fn()
+    renderHook(() => useEscapeToClose(false, onClose))
+
+    pressEscape()
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('stops listening once closed', () => {
+    const onClose = vi.fn()
+    const { rerender } = renderHook(
+      ({ isOpen }) => useEscapeToClose(isOpen, onClose),
+      { initialProps: { isOpen: true } },
+    )
+
+    rerender({ isOpen: false })
+    pressEscape()
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('removes its listener on unmount', () => {
+    const onClose = vi.fn()
+    const { unmount } = renderHook(() => useEscapeToClose(true, onClose))
+
+    unmount()
+    pressEscape()
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('closes on each subsequent escape while it stays open', () => {
+    const onClose = vi.fn()
+    renderHook(() => useEscapeToClose(true, onClose))
+
+    pressEscape()
+    pressEscape()
+
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+
+  it('only the open overlay reacts when several are mounted', () => {
+    const openClose = vi.fn()
+    const closedClose = vi.fn()
+    renderHook(() => useEscapeToClose(true, openClose))
+    renderHook(() => useEscapeToClose(false, closedClose))
+
+    pressEscape()
+
+    expect(openClose).toHaveBeenCalledTimes(1)
+    expect(closedClose).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/testing/unit/hooks/useShortcuts.test.tsx
+++ b/frontend/testing/unit/hooks/useShortcuts.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useShortcuts } from '../../../src/hooks/useShortcuts'
+import { ESCAPE_EVENT } from '../../../src/hooks/useEscapeToClose'
 import { routes } from '../../../src/routes'
 
 const mockNavigate = vi.fn()
@@ -89,5 +90,66 @@ describe('useShortcuts', () => {
     expect(document.activeElement).not.toBe(input)
 
     document.body.removeChild(input)
+  })
+
+  // ── Escape broadcast (issue #1845) ──────────────────────────────────────
+  // Escape used to be a no-op outside inputs, so custom popovers had nothing
+  // to listen for and stayed open.
+
+  it('broadcasts the escape event when Escape is pressed', () => {
+    const onEscape = vi.fn()
+    window.addEventListener(ESCAPE_EVENT, onEscape)
+    renderHook(() => useShortcuts())
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+
+    expect(onEscape).toHaveBeenCalledTimes(1)
+    window.removeEventListener(ESCAPE_EVENT, onEscape)
+  })
+
+  it('does not broadcast escape while typing in an input', () => {
+    const onEscape = vi.fn()
+    window.addEventListener(ESCAPE_EVENT, onEscape)
+    renderHook(() => useShortcuts())
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+    )
+
+    // The field is blurred instead, so a stray Escape mid-typing does not
+    // also tear down the surrounding panel.
+    expect(onEscape).not.toHaveBeenCalled()
+    expect(document.activeElement).not.toBe(input)
+
+    document.body.removeChild(input)
+    window.removeEventListener(ESCAPE_EVENT, onEscape)
+  })
+
+  it('does not broadcast escape for other keys', () => {
+    const onEscape = vi.fn()
+    window.addEventListener(ESCAPE_EVENT, onEscape)
+    renderHook(() => useShortcuts())
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }))
+
+    expect(onEscape).not.toHaveBeenCalled()
+    window.removeEventListener(ESCAPE_EVENT, onEscape)
+  })
+
+  it('stops broadcasting once unmounted', () => {
+    const onEscape = vi.fn()
+    window.addEventListener(ESCAPE_EVENT, onEscape)
+    const { unmount } = renderHook(() => useShortcuts())
+
+    unmount()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+
+    expect(onEscape).not.toHaveBeenCalled()
+    window.removeEventListener(ESCAPE_EVENT, onEscape)
   })
 })


### PR DESCRIPTION
Closes #1845

## Problem

`useShortcuts.ts` had a placeholder where the Escape handling should have been:

```ts
if (e.key === 'Escape') {
    // Could emit global event to close modals
    return
}
```

Nothing was ever emitted, so no popover had anything to listen for and Escape did nothing outside text fields.

## Changes

`useShortcuts` now broadcasts a `CustomEvent`, and a new `useEscapeToClose(isOpen, onClose)` hook is the subscriber side.

Keeping the single window-level `keydown` listener in `useShortcuts` and fanning out through one event means the listener count does not grow with the number of overlays on a page, and every overlay closes the same way.

`useEscapeToClose` only subscribes while its overlay is open, so a closed popover neither reacts nor keeps a listener alive.

### Two surfaces, not one

The Saved Views panel is the one the issue names. The bulk-export dropdown on the Findings page (`exportDropdownOpen`) had the identical problem, so it is fixed in the same change.

### Escape while typing

Existing behaviour is preserved deliberately: `useShortcuts` blurs the focused field and returns *without* broadcasting when the user is in an input, textarea, or contenteditable. A field inside a panel therefore takes two presses — one to leave the field, one to close the panel — so a stray Escape mid-typing cannot discard what someone was entering.

That is pinned by a test rather than left implicit. Happy to make a single press do both if you would rather.

## Verification

- `useEscapeToClose.test.ts` (new) + `useShortcuts.test.tsx` + `SavedViewsPanel.test.tsx` — **28 passed**
- Full `vitest run` — **65 files, 575 tests passed**
- `tsc --noEmit` — clean
- `quality-gate.cjs` — 13 passed, 0 failed. The single warning it reports (a 2000ms animation) is pre-existing; I confirmed it is identical on a clean `main` checkout.

**Mutation-checked:** removing the broadcast fails the `useShortcuts` test; removing the subscriber fails the `SavedViewsPanel` test.
