### PR TITLE
docs: Add GitHub Actions workflow status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@
   <a href="PLUGINS.md"><img src="https://img.shields.io/badge/plugins-60%20catalogued-brightgreen" alt="60 catalogued plugins"></a>
 </p>
 
+<p align="center">
+  <a href="https://github.com/AnzalKhan16/SecuScan/actions/workflows/ci.yml"><img src="https://github.com/AnzalKhan16/SecuScan/actions/workflows/ci.yml/badge.svg" alt="Continuous Integration"></a>
+  <a href="https://github.com/AnzalKhan16/SecuScan/actions/workflows/docker-validation.yml"><img src="https://github.com/AnzalKhan16/SecuScan/actions/workflows/docker-validation.yml/badge.svg" alt="Docker Build Validation"></a>
+  <a href="https://github.com/AnzalKhan16/SecuScan/actions/workflows/codeql-analysis.yml"><img src="https://github.com/AnzalKhan16/SecuScan/actions/workflows/codeql-analysis.yml/badge.svg" alt="CodeQL Analysis"></a>
+  <a href="https://github.com/AnzalKhan16/SecuScan/actions/workflows/security-scan.yml"><img src="https://github.com/AnzalKhan16/SecuScan/actions/workflows/security-scan.yml/badge.svg" alt="Security Scanning"></a>
+  <a href="https://github.com/AnzalKhan16/SecuScan/actions/workflows/docker-publish.yml"><img src="https://github.com/AnzalKhan16/SecuScan/actions/workflows/docker-publish.yml/badge.svg" alt="Release Workflow"></a>
+</p>
+
 > **Authorized use only:** Run SecuScan only against systems you own, systems you are explicitly permitted to assess, or deliberately vulnerable lab environments.
 
 ## Overview


### PR DESCRIPTION
## Description
This PR updates the repository's `README.md` to include live GitHub Actions workflow status badges for all primary CI pipelines. 

Previously, users and contributors had to manually navigate to the Actions tab to verify if builds or security checks were passing. By adding status badges for Continuous Integration, Docker Build Validation, CodeQL Analysis, Security Scanning, and the Release Workflow directly to the README, this PR improves repository transparency and allows anyone to assess the project's health and automation status at a single glance.

## Related Issues
#2387 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
This change has been tested by verifying the markdown rendering. The URLs and badge SVGs follow the standard GitHub Actions badge format (`https://github.com/<owner>/<repo>/actions/workflows/<workflow_file>/badge.svg`) and point precisely to the `AnzalKhan16/SecuScan` repository. Each badge serves as a direct hyperlinked image that automatically updates as the workflow statuses change.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
