### PR TITLE
ci: Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  # Maintain dependencies for npm (frontend)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 10
+    groups:
+      frontend-dependencies:
+        patterns:
+          - "*"
+
+  # Maintain dependencies for Python (backend)
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 10
+    groups:
+      backend-dependencies:
+        patterns:
+          - "*"
+
+  # Maintain dependencies for Python (root pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 10
+    groups:
+      root-dependencies:
+        patterns:
+          - "*"
+
+  # Maintain GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description
This PR introduces GitHub Dependabot configuration (`.github/dependabot.yml`) to automatically monitor and update the project's third-party dependencies. 

The configuration ensures that Node.js packages in the `frontend` directory, Python packages in the `backend` and root directories, and all GitHub Actions used across workflows are continuously monitored. Checks are scheduled to run on a weekly basis, targeting the `main` branch. To keep the pull request volume manageable, open PRs are limited to 10 per ecosystem, and updates are grouped together where appropriate to simplify the review and merge process.

## Related Issues
#2389 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
This was tested by verifying the `.github/dependabot.yml` syntax according to the official GitHub documentation. The configuration specifically targets the correct directories where our dependency lockfiles/manifests reside (`/frontend` for npm, `/backend` and `/` for pip). Dependency update grouping has been appropriately defined using wildcard patterns for all package ecosystems. 

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
