### PR TITLE
fix: resolve 2 bugs in SecuScan

### DIFF
--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -298,7 +298,7 @@ export default function Findings() {
     for (const f of enrichedFindings) {
       if (f.target) seen.add(f.target)
     }
-    return Array.from(seen).sort()
+    return Array.from(seen).sort((a, b) => a - b)
   }, [enrichedFindings])
 
   // plugin_id values serve as the "scanner/tool" filter per issue #43

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -401,7 +401,7 @@ export default function Settings() {
             <input
                 type={type}
                 value={value}
-                onChange={(e) => onChange(type === 'number' ? parseInt(e.target.value) || 0 : e.target.value)}
+                onChange={(e) => onChange(type === 'number' ? parseInt(e.target.value, 10) || 0 : e.target.value)}
                 placeholder={placeholder}
                 className="w-full bg-black/40 border-4 border-black p-4 text-xs font-mono text-rag-blue font-bold focus:outline-none focus:border-rag-blue/50 transition-colors uppercase"
             />


### PR DESCRIPTION
## Description
This PR fixes real bugs found in the codebase:

- Fixed default sort: `.sort()` coerces elements to strings, so `[10, 9, 2]` sorts as `[10, 2, 9]`; numeric comparator sorts correctly.
- Added explicit radix to `parseInt`: without `10`, strings like `'0x1F'` or `'08'` parse in unintended bases.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- [x] Local manual testing

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review

## Related Issue
Ref: #2417
