### PR TITLE
test : added unit tests for _build_triage_prompt in triage_engine

### DIFF
--- a/testing/backend/unit/test_triage_engine.py
+++ b/testing/backend/unit/test_triage_engine.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from backend.secuscan.triage_engine import (
+    _build_triage_prompt,
     extract_code_context,
     is_eligible_for_triage,
     triage_finding,
@@ -201,3 +202,116 @@ class TestFindingIntelligenceIntegration:
 
         assert settings.triage_engine_enabled is False
         assert settings.triage_engine_api_key == ""
+
+
+class TestBuildTriagePrompt:
+    """Unit tests for _build_triage_prompt."""
+
+    def _make_finding(self, **overrides):
+        finding = {
+            "title": "SQL Injection",
+            "category": "code security",
+            "severity": "high",
+            "description": "User input concatenated into query",
+            "proof": "query = f\"SELECT * FROM users WHERE id={user_id}\"",
+        }
+        finding.update(overrides)
+        return finding
+
+    def _make_context(self, **overrides):
+        context = {
+            "snippet": 'query = f"SELECT * FROM users WHERE id={user_id}"',
+            "variables": ["user_id"],
+            "file": "app/db.py",
+            "line": "42",
+        }
+        context.update(overrides)
+        return context
+
+    def test_includes_title(self):
+        finding = self._make_finding(title="Hardcoded Password")
+        prompt = _build_triage_prompt(finding, {})
+        assert "Hardcoded Password" in prompt
+
+    def test_includes_category(self):
+        finding = self._make_finding(category="authentication")
+        prompt = _build_triage_prompt(finding, {})
+        assert "authentication" in prompt
+
+    def test_includes_severity(self):
+        finding = self._make_finding(severity="critical")
+        prompt = _build_triage_prompt(finding, {})
+        assert "critical" in prompt
+
+    def test_includes_description(self):
+        finding = self._make_finding(description="Stack buffer overflow detected")
+        prompt = _build_triage_prompt(finding, {})
+        assert "Stack buffer overflow detected" in prompt
+
+    def test_includes_code_snippet(self):
+        finding = self._make_finding()
+        context = self._make_context(snippet='x = eval(user_input)')
+        prompt = _build_triage_prompt(finding, context)
+        assert 'x = eval(user_input)' in prompt
+
+    def test_includes_variable_hints(self):
+        finding = self._make_finding()
+        context = self._make_context(variables=["user_input", "password"])
+        prompt = _build_triage_prompt(finding, context)
+        assert "user_input" in prompt
+        assert "password" in prompt
+
+    def test_missing_title_defaults_to_untitled(self):
+        finding = self._make_finding(title="")
+        prompt = _build_triage_prompt(finding, {})
+        assert "Untitled finding" in prompt
+
+    def test_missing_category_defaults_to_unknown(self):
+        finding = self._make_finding(category="")
+        prompt = _build_triage_prompt(finding, {})
+        assert "unknown" in prompt
+
+    def test_missing_severity_defaults_to_unknown(self):
+        finding = self._make_finding(severity="")
+        prompt = _build_triage_prompt(finding, {})
+        assert "unknown" in prompt
+
+    def test_missing_description_shows_none_provided(self):
+        finding = self._make_finding(description="")
+        prompt = _build_triage_prompt(finding, {})
+        assert "(none provided)" in prompt
+
+    def test_missing_snippet_shows_fallback(self):
+        finding = self._make_finding()
+        context = self._make_context(snippet="")
+        prompt = _build_triage_prompt(finding, context)
+        assert "(no source snippet available)" in prompt
+
+    def test_missing_variables_shows_none_identified(self):
+        finding = self._make_finding()
+        context = self._make_context(variables=[])
+        prompt = _build_triage_prompt(finding, context)
+        assert "(none identified)" in prompt
+
+    def test_includes_file_and_line(self):
+        finding = self._make_finding()
+        context = self._make_context(file="src/app.py", line="10")
+        prompt = _build_triage_prompt(finding, context)
+        assert "src/app.py" in prompt
+        assert "line" in prompt
+
+    def test_includes_response_format_instructions(self):
+        finding = self._make_finding()
+        prompt = _build_triage_prompt(finding, {})
+        assert "JSON object" in prompt
+        assert "verdict" in prompt
+        assert "confidence" in prompt
+        assert "reasoning" in prompt
+        assert "remediation" in prompt
+
+    def test_is_deterministic(self):
+        finding = self._make_finding()
+        context = self._make_context()
+        prompt1 = _build_triage_prompt(finding, context)
+        prompt2 = _build_triage_prompt(finding, context)
+        assert prompt1 == prompt2


### PR DESCRIPTION
Closes #2420.

Summary of What Has Been Done:
Added 15 unit tests for the `_build_triage_prompt()` private helper function in `backend/secuscan/triage_engine.py`. The tests are in a new `TestBuildTriagePrompt` class added to `testing/backend/unit/test_triage_engine.py`.

The function was previously only exercised indirectly through the `triage_finding` integration tests, which mocked the LLM response and asserted on the parsed verdict — but never validated the prompt content itself.

Changes Made:
- Import `_build_triage_prompt` from `backend.secuscan.triage_engine`
- Added `TestBuildTriagePrompt` class with 15 tests covering:
  - Field inclusion: title, category, severity, description, code snippet, variable hints, file and line references
  - Default fallbacks: "Untitled finding", "unknown", "(none provided)", "(no source snippet available)", "(none identified)"
  - Response format instructions: JSON object with verdict/confidence/reasoning/remediation keys
  - Determinism: same inputs produce same output

Impact it Made:
- Directly validates the prompt construction logic without needing a mock LLM
- Ensures the LLM receives well-formed prompts with all required fields and graceful fallbacks
- Catches regressions if the prompt template changes

Note: This task is being handled by tmdeveloper007 — please assign to that account when picking it up.