### PR TITLE
test: add unit tests for _validate_lengths field length guard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4536,9 +4536,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/testing/backend/unit/test_routes_validate_lengths.py
+++ b/testing/backend/unit/test_routes_validate_lengths.py
@@ -1,0 +1,61 @@
+import pytest
+from fastapi import HTTPException
+
+from backend.secuscan.routes import _validate_lengths
+
+
+def test_valid_name_under_255_chars_passes():
+    # Should not raise
+    _validate_lengths(name="a" * 100)
+
+
+def test_valid_description_and_notes_under_2000_chars_passes():
+    # Should not raise
+    _validate_lengths(description="d" * 500, notes="n" * 500)
+
+
+def test_name_exactly_255_chars_passes():
+    # Should not raise — boundary is inclusive
+    _validate_lengths(name="a" * 255)
+
+
+def test_name_over_255_chars_raises_with_detail_message():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_lengths(name="a" * 256)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Resource name exceeds maximum length of 255 characters"
+
+
+def test_description_exactly_2000_chars_passes():
+    # Should not raise — boundary is inclusive
+    _validate_lengths(description="d" * 2000)
+
+
+def test_description_over_2000_chars_raises_http_exception():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_lengths(description="d" * 2001)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Resource description exceeds maximum length of 2000 characters"
+
+
+def test_notes_over_2000_chars_raises_http_exception():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_lengths(notes="n" * 2001)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Resource notes exceeds maximum length of 2000 characters"
+
+
+def test_custom_resource_type_reflected_in_error_message():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_lengths(name="a" * 256, resource_type="Target policy")
+
+    assert exc_info.value.detail == "Target policy name exceeds maximum length of 255 characters"
+
+
+def test_none_values_for_optional_fields_pass():
+    # All fields default to None — should not raise
+    _validate_lengths()
+    _validate_lengths(name=None, description=None, notes=None)


### PR DESCRIPTION
## Description
Adds unit tests for the `_validate_lengths` helper in `backend/secuscan/routes.py`, which enforces maximum field lengths (255 chars for `name`, 2000 chars for `description`/`notes`) before data reaches the database. Covers valid/boundary/over-limit cases for name, description, and notes fields, plus custom `resource_type` substitution and `None` handling for optional fields.

## Related Issues
Closes #2307

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Ran `python -m pytest testing/backend/unit/test_routes_validate_lengths.py -v` locally — all 9 tests pass. Coverage includes:
- Valid name/description/notes under their respective limits
- Exact-boundary values (255 chars for name, 2000 for description/notes) — confirmed to pass
- Over-limit values for name, description, and notes — confirmed to raise `HTTPException` with status 400 and the correct detail message
- Custom `resource_type` correctly substituted into the error message
- `None` values for all optional fields — confirmed to pass without raising

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.