### PR TITLE
test: add unit tests for _escape_like SQL injection guard

### DIFF
--- a/testing/backend/unit/test_routes_escape_like.py
+++ b/testing/backend/unit/test_routes_escape_like.py
@@ -1,0 +1,37 @@
+from backend.secuscan.routes import _escape_like
+
+
+def test_normal_string_passes_through_unchanged():
+    assert _escape_like("hello world") == "hello world"
+    assert _escape_like("example.com") == "example.com"
+
+
+def test_backslash_is_escaped_to_double_backslash():
+    assert _escape_like("\\") == "\\\\"
+    assert _escape_like("C:\\path\\to\\file") == "C:\\\\path\\\\to\\\\file"
+
+
+def test_percent_sign_is_escaped():
+    assert _escape_like("%") == "\\%"
+    assert _escape_like("100% done") == "100\\% done"
+
+
+def test_underscore_is_escaped():
+    assert _escape_like("_") == "\\_"
+    assert _escape_like("my_variable") == "my\\_variable"
+
+
+def test_multiple_wildcards_are_all_escaped():
+    assert _escape_like("%%__") == "\\%\\%\\_\\_"
+    assert _escape_like("a%b_c%d_e") == "a\\%b\\_c\\%d\\_e"
+
+
+def test_empty_string_returns_empty_string():
+    assert _escape_like("") == ""
+
+
+def test_mixed_content_with_all_wildcard_types():
+    # Backslash must be escaped first so it doesn't double-escape the
+    # backslashes introduced when escaping % and _.
+    assert _escape_like("100%_off\\sale") == "100\\%\\_off\\\\sale"
+    assert _escape_like("a\\b%c_d") == "a\\\\b\\%c\\_d"


### PR DESCRIPTION
## Description
Adds unit tests for the `_escape_like` helper in `backend/secuscan/routes.py`, which escapes SQLite LIKE wildcards (`%` and `_`) in user search input to prevent pattern injection.

## Related Issues
Closes #2306

## Type of Change
- [x] New feature (non-breaking change which adds functionality) — adds test coverage only, no production code changes

## How Has This Been Tested?
Ran `python -m pytest testing/backend/unit/test_routes_escape_like.py -v` — all 7 tests pass, covering: normal strings unchanged, backslash escaping (escaped first, before % and _), percent sign escaping, underscore escaping, multiple wildcards in one string, empty string, and mixed content combining all wildcard types.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.