### PR TITLE
test: add unit tests for _sandbox_argv helper

### DIFF
--- a/testing/backend/unit/test_parser_sandbox_argv.py
+++ b/testing/backend/unit/test_parser_sandbox_argv.py
@@ -1,0 +1,47 @@
+from backend.secuscan import parser_sandbox
+from backend.secuscan.parser_sandbox import _sandbox_argv
+
+
+def test_returns_unshare_prefixed_argv_when_unshare_net_supported(monkeypatch):
+    monkeypatch.setattr(parser_sandbox, "_unshare_net_supported", lambda: True)
+
+    result = _sandbox_argv("/usr/bin/python3", "print('hello')")
+
+    assert result == [
+        "unshare",
+        "--user",
+        "--net",
+        "--",
+        "/usr/bin/python3",
+        "-c",
+        "print('hello')",
+    ]
+
+
+def test_returns_argv_without_unshare_when_unshare_net_not_supported(monkeypatch):
+    monkeypatch.setattr(parser_sandbox, "_unshare_net_supported", lambda: False)
+
+    result = _sandbox_argv("/usr/bin/python3", "print('hello')")
+
+    assert result == ["/usr/bin/python3", "-c", "print('hello')"]
+    assert "unshare" not in result
+
+
+def test_with_different_python_executables(monkeypatch):
+    monkeypatch.setattr(parser_sandbox, "_unshare_net_supported", lambda: True)
+
+    result_a = _sandbox_argv("/usr/bin/python3.11", "code")
+    result_b = _sandbox_argv("C:\\Python314\\python.exe", "code")
+
+    assert result_a[4] == "/usr/bin/python3.11"
+    assert result_b[4] == "C:\\Python314\\python.exe"
+
+
+def test_with_different_bootstrap_code(monkeypatch):
+    monkeypatch.setattr(parser_sandbox, "_unshare_net_supported", lambda: False)
+
+    result_a = _sandbox_argv("python3", "import sys; sys.exit(0)")
+    result_b = _sandbox_argv("python3", "")
+
+    assert result_a == ["python3", "-c", "import sys; sys.exit(0)"]
+    assert result_b == ["python3", "-c", ""]


### PR DESCRIPTION
## Description
Adds unit tests for the `_sandbox_argv` helper in `backend/secuscan/parser_sandbox.py`, which builds the argv list for the parser subprocess and prefixes it with `unshare --user --net --` for network isolation when the host supports it.

## Related Issues
Closes #2305

## Type of Change
- [x] New feature (non-breaking change which adds functionality) — adds test coverage only, no production code changes

## How Has This Been Tested?
Ran `python -m pytest testing/backend/unit/test_parser_sandbox_argv.py -v` — all 4 tests pass. Uses `monkeypatch` to control the return value of `_unshare_net_supported` (avoiding reliance on the actual host's `unshare` support), covering: argv with the `unshare` prefix when supported, plain argv without it when unsupported, different `python_executable` values, and different `bootstrap_code` values (including empty string).

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.