### PR TITLE
test: add unit tests for _extract_variable_hints helper

### DIFF
--- a/testing/backend/unit/test_triage_engine_variable_hints.py
+++ b/testing/backend/unit/test_triage_engine_variable_hints.py
@@ -1,0 +1,45 @@
+from backend.secuscan.triage_engine import _extract_variable_hints
+
+
+def test_finding_with_proof_containing_variable_names():
+    finding = {"proof": "user_input = request.GET.get('name')"}
+    assert _extract_variable_hints(finding) == ["user_input"]
+
+
+def test_finding_with_description_containing_variable_names():
+    finding = {"description": "The password = input() call reads unsanitized data."}
+    assert _extract_variable_hints(finding) == ["password"]
+
+
+def test_finding_with_title_containing_variable_names():
+    finding = {"title": "Hardcoded secret: token = 'abc123'"}
+    assert _extract_variable_hints(finding) == ["token"]
+
+
+def test_deduplication_of_variable_names_while_preserving_order():
+    finding = {
+        "proof": "a = 1",
+        "description": "b = 2 a = 3",
+        "title": "c = 4 b = 5",
+    }
+    # Fields are concatenated in proof, description, title order:
+    # "a = 1 b = 2 a = 3 c = 4 b = 5" -> matches a, b, a, c, b
+    # -> deduped preserving first-seen order: a, b, c
+    assert _extract_variable_hints(finding) == ["a", "b", "c"]
+
+
+def test_cap_at_10_results():
+    assignments = " ".join(f"v{i} = {i}" for i in range(15))
+    finding = {"proof": assignments}
+    result = _extract_variable_hints(finding)
+    assert len(result) == 10
+    assert result == [f"v{i}" for i in range(10)]
+
+
+def test_empty_finding_dict():
+    assert _extract_variable_hints({}) == []
+
+
+def test_finding_with_no_relevant_fields():
+    finding = {"category": "xss", "severity": "high"}
+    assert _extract_variable_hints(finding) == []


### PR DESCRIPTION
## Description
Adds unit tests for the `_extract_variable_hints` helper in `backend/secuscan/triage_engine.py`, a pure function that extracts variable names from SAST finding text (`proof`, `description`, `title`) using a regex pattern, for use in triage prompt context.

## Related Issues
Closes #2304

## Type of Change
- [x] New feature (non-breaking change which adds functionality) — adds test coverage only, no production code changes

## How Has This Been Tested?
Ran `python -m pytest testing/backend/unit/test_triage_engine_variable_hints.py -v` — all 7 tests pass. Coverage includes: variable extraction from each of the three source fields individually, deduplication with first-seen order preserved across concatenated fields (proof → description → title), capping results at 10 when more unique names are present, an empty finding dict, and a finding with no relevant text fields present.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.