### PR TITLE
test: add unit tests for _row_value helper

### DIFF
--- a/testing/backend/unit/test_executor_row_value.py
+++ b/testing/backend/unit/test_executor_row_value.py
@@ -1,0 +1,49 @@
+from backend.secuscan.executor import _row_value
+
+
+class FakeSqliteRow:
+    """Duck-typed stand-in for sqlite3.Row: supports __getitem__ by key,
+    but is not a dict, so it exercises the try/except branch of _row_value."""
+
+    def __init__(self, data):
+        self._data = data
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+
+def test_dict_with_existing_key_returns_value():
+    assert _row_value({"status": "completed"}, "status", "unknown") == "completed"
+
+
+def test_dict_with_missing_key_returns_default():
+    assert _row_value({"status": "completed"}, "duration", 0) == 0
+
+
+def test_none_row_returns_default():
+    assert _row_value(None, "status", "unknown") == "unknown"
+
+
+def test_sqlite_row_like_object_with_existing_key():
+    row = FakeSqliteRow({"status": "completed", "duration": 42})
+    assert _row_value(row, "status", "unknown") == "completed"
+    assert _row_value(row, "duration", 0) == 42
+
+
+def test_sqlite_row_like_object_with_missing_key_raises_keyerror_caught_returns_default():
+    row = FakeSqliteRow({"status": "completed"})
+    # Accessing a missing key raises KeyError internally (dict lookup),
+    # which _row_value must catch and fall back to the default.
+    assert _row_value(row, "nonexistent_field", "fallback") == "fallback"
+
+
+def test_various_default_values_used_correctly():
+    assert _row_value({}, "missing", None) is None
+    assert _row_value({}, "missing", 0) == 0
+    assert _row_value({}, "missing", "") == ""
+    assert _row_value({}, "missing", []) == []
+    assert _row_value({}, "missing", "{}") == "{}"
+
+    row = FakeSqliteRow({})
+    assert _row_value(row, "missing", None) is None
+    assert _row_value(row, "missing", "{}") == "{}"


### PR DESCRIPTION
## Description
Adds unit tests for the `_row_value` helper in `backend/secuscan/executor.py`, which reads a value from a dict or sqlite-row-like object by key with a default fallback, used for backward-compatible mocks in tests and safe row access in production code.

## Related Issues
Closes #2296

## Type of Change
- [x] New feature (non-breaking change which adds functionality) — adds test coverage only, no production code changes

## How Has This Been Tested?
Ran `python -m pytest testing/backend/unit/test_executor_row_value.py -v` — all 6 tests pass. Coverage includes: dict with an existing key, dict with a missing key, a `None` row, a duck-typed `sqlite.Row`-like object (via a small fake class supporting `__getitem__`) with an existing key, the same fake object with a missing key (verifying the internal `KeyError` is caught and the default returned), and multiple default value types (`None`, `0`, `""`, `[]`, a JSON string) across both dict and row-like inputs.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.