### PR TITLE
fix(ci): bump undici to 7.29.0 to unblock the npm audit gate

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4536,9 +4536,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Problem

`frontend-run-checks` fails on both Node matrix legs at the *Check npm audit results* step, on `main` and therefore on every PR that runs the frontend job:

```
ERROR:__main__:[FAIL] GHSA-4cwx-7wf7-3272 (high): undici (CVSS 7.4)
ERROR:__main__:[FAIL] 1 npm vulnerabilities block deployment
```

`package-lock.json` pins `undici@7.28.0`. The advisory range is `7.0.0 - 7.28.0`, so the pinned version is the last vulnerable one — `npm ci` installs it and the gate rejects it. `.audit-config.yaml` sets `min_severity_to_block: high`, so this single advisory blocks while the react-router moderates stay warnings.

`undici` is test-only: it arrives transitively via `jsdom`, a vitest devDependency, and is not in the production bundle.

## Change

`npm update undici --package-lock-only` → `7.28.0` → `7.29.0`.

`jsdom@29.1.1` already declares `undici: ^7.25.0`, so `7.29.0` is in range. **`package.json` is untouched** and no `jsdom` upgrade is needed — `jsdom@30` would move to `undici: ^8.9.0`, which is a larger change than this problem warrants.

The whole diff is three lines:

```diff
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
```

This removes the vulnerable code rather than muting the alarm, so I did not add an `.audit-config.yaml` exception. If you would rather hold the dependency and record an exception instead, the existing `GHSA-gv7w-rqvm-qjhr` / esbuild entry is the pattern and I am happy to switch to it.

It clears all five `undici` advisories, not only the blocking one.

## Verification

Before — the repo's own gate, on a clean `main`:

```
$ python scripts/check_npm_audit.py --report frontend/npm-audit-report.json --config .audit-config.yaml
ERROR:__main__:[FAIL] GHSA-4cwx-7wf7-3272 (high): undici (CVSS 7.4)
ERROR:__main__:[FAIL] 1 npm vulnerabilities block deployment
# exit 1
```

After:

```
WARNING:__main__:[WARN] GHSA-wrjc-x8rr-h8h6 (moderate): react-router
WARNING:__main__:[WARN] GHSA-337j-9hxr-rhxg (moderate): react-router
WARNING:__main__:[WARN] GHSA-jjmj-jmhj-qwj2 (moderate): react-router-dom
WARNING:__main__:[WARN] 3 low-severity vulnerabilities detected.
INFO:__main__:[OK] npm audit passed!
# exit 0
```

`jsdom` is what vitest runs the DOM on, so the tests are the real check that the bump is safe. Run after a clean `npm ci` from the updated lockfile:

- `npm ci` → resolves `jsdom@29.1.1 → undici@7.29.0`
- full `vitest run` → **65 files, 575 tests passed**
- `tsc --noEmit` → clean
- `quality-gate.cjs` → 13 passed, 0 failed (its 1 warning is a pre-existing 2000ms animation)

The react-router moderates are untouched and still reported as warnings; they are a separate question and do not block the gate.
